### PR TITLE
Add script to reproduce GitHub Actions runs locally

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -155,6 +155,7 @@
               coreutils
               curlMinimal.bin
               gitMinimal
+              gh                  # GitHub CLI tool
               gnutar
               foliage.packages.${system}.default
             ];

--- a/scripts/reproduce-github-actions-run.sh
+++ b/scripts/reproduce-github-actions-run.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+usage() {
+	echo "Usage: $0 [GHA RUN ID] [(DERIVATION=allPackages)]"
+}
+
+REPO="input-output-hk/cardano-haskell-packages"
+
+ghaRunId="$1"
+derivation="${2:-allPackages}"
+
+if ! shift; then
+	usage
+	exit 0
+fi
+
+ARTIFACT_TEMP_DIR="$(mktemp -d)"
+trap '{ echo "Cleaning up $ARTIFACT_TEMP_DIR"; rm -rf -- "$ARTIFACT_TEMP_DIR"; }' EXIT
+
+echo "Downloading artifacts for run $ghaRunId in $ARTIFACT_TEMP_DIR"
+gh run download --repo "$REPO" "$ghaRunId" --dir "$ARTIFACT_TEMP_DIR"
+
+echo "Unpacking built-repo in $ARTIFACT_TEMP_DIR/_repo"
+mkdir "$ARTIFACT_TEMP_DIR/_repo"
+tar xf "$ARTIFACT_TEMP_DIR/built-repo/_repo.tar" -C "$ARTIFACT_TEMP_DIR/_repo"
+
+echo -n "Obtaining commit hash ..."
+headSha=$(gh run view --repo "$REPO" "$ghaRunId" --json headSha --jq .headSha)
+echo " $headSha"
+
+nix build \
+	"github:$REPO/${headSha}#${derivation}" \
+	--override-input CHaP "path:$ARTIFACT_TEMP_DIR/_repo" \
+	--accept-flake-config true \
+	--print-build-logs --show-trace


### PR DESCRIPTION
This scripts should help troubleshooting CI failures when adding new packages.

Given a run id, the script does the following:
1. It downloads the built-repo artifact from the CI
2. It unpacks it in a temporary folder
3. It obtains the commit hash that triggered the run
4. It runs the same nix build; i.e.

```
nix build \
        "github:$REPO/${headSha}#allPackages" \
        --override-input CHaP "path:$ARTIFACT_TEMP_DIR/_repo" \
        --accept-flake-config true \
        --print-build-logs --show-trace
```

It is also possible to specify which derivation to build.

The scripts uses the GitHub CLI utility `gh` because one needs to authenticate to download artifacts. I added `gh` to the dev shell.
