### PR TITLE
Rework the CI

### DIFF
--- a/.github/actions/build-repo/action.yml
+++ b/.github/actions/build-repo/action.yml
@@ -1,0 +1,33 @@
+name: Build repository
+inputs:
+  ref:
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Checkout ${{ inputs.ref }}
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
+
+    - name: Unpack keys
+      env:
+        KEYS: ${{ secrets.KEYS }}
+      run: |
+        if [[ -z "$KEYS" ]]; then
+          echo "Could not access repository secret keys (PR is coming from a fork?)"
+          echo "Generating fresh keys for this run"
+          nix develop -c foliage create-keys
+        else
+          mkdir _keys
+          echo "$KEYS" | base64 -d | tar xvz -C _keys
+        fi
+
+    - name: Build repository
+      run: nix develop --command foliage build -j 0  --write-metadata
+
+    - name: Copy static web assets
+      run: |
+        cp static/index.html _repo
+        cp README.md _repo
+

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
   check:
     runs-on: nixos
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # the check script below needs the whole history
 
@@ -90,6 +90,8 @@ jobs:
       - build-repo-base
       - build-repo-head
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download built repository (base)
         uses: actions/download-artifact@v3
         with:
@@ -204,11 +206,11 @@ jobs:
     needs:
       - build-repo-head
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: src
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: repo
           ref: repo

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -130,7 +130,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - id: set-matrix
-        run: nix eval --json github:${{ github.repository }}/${{ github.ref }}#ghaMatrix >> "$GITHUB_OUTPUT"
+        run: echo "matrix=$(nix eval --json github:${{ github.repository }}/${{ github.ref }}#ghaMatrix)" >> "$GITHUB_OUTPUT"
 
   build-packages:
     name: build-package ${{ matrix.name }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,7 +87,8 @@ jobs:
     if: github.event_name == 'pull'
     runs-on: nixos
     needs:
-      - build-repos
+      - build-repo-base
+      - build-repo-head
     steps:
       - name: Download built repository (base)
         uses: actions/download-artifact@v3
@@ -131,7 +132,8 @@ jobs:
     name: build-package ${{ matrix.name }}
     runs-on: nixos
     needs:
-      - build-repos
+      - build-repo-base
+      - build-repo-head
       - generate-smoke-tests
     strategy:
       fail-fast: false
@@ -200,7 +202,7 @@ jobs:
     runs-on: nixos
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs:
-      - build-repos
+      - build-repo-head
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -238,7 +238,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs:
       - check
-      - build-repos
+      - build-repo-head
       - deploy-check
 
     concurrency:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,16 +14,8 @@ env:
   NIX_CONFIG: accept-flake-config = true
 
 jobs:
-  shellcheck:
-    runs-on: nixos
-    steps:
-      - uses: actions/checkout@v3
-      - name: Run shellcheck on scripts/*.sh
-        run: nix-shell -I nixpkgs=https://github.com/nixos/nixpkgs/archive/release-23.05.tar.gz -p shellcheck --run 'shellcheck scripts/*.sh'
-        
   check:
     runs-on: nixos
-
     steps:
       - uses: actions/checkout@v3
         with:
@@ -32,165 +24,186 @@ jobs:
       - name: Run checks
         run: nix develop -c ./scripts/check.sh
 
-  build-repo:
+  # If this is a pull request, we have a base ref to compare against
+  build-repo-base:
+    if: github.event_name == 'pull'
     runs-on: nixos
-
     steps:
-      - name: Checkout main 
-        uses: actions/checkout@v3
+      # We don't need to build the repos more than once, we can deal with
+      # transient issues by wiping the broken cache (e.g. `gh cache delete`)
+      - name: Fetch cache
+        id: cache
+        uses: actions/cache@v3
         with:
-          ref: main
+          path: _repo
+          key: built-repo-${{ github.event.pull_request.base.sha }}
 
-      - uses: actions/cache@v3
+      - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        name: Build repository
+        uses: ./.github/actions/build-repo
         with:
-          path: _cache
-          key: 1 # bump to refresh
-
-      - name: Unpack keys
-        env:
-          KEYS: ${{ secrets.KEYS }}
-        run: |
-          if [[ -z "$KEYS" ]]; then
-            echo "Could not access repository secret keys (PR is coming from a fork?)"
-            echo "Generating fresh keys for this run"
-            nix develop -c foliage create-keys
-          else 
-            mkdir _keys
-            echo "$KEYS" | base64 -d | tar xvz -C _keys
-          fi
-
-      - name: Build repository (main)
-        run: |
-          nix develop -c foliage build -j 0  --write-metadata
-          mv _repo _repo-main
-          cp _repo-main/foliage/packages.json packages-old.json
-
-      - name: Checkout tip commit
-        uses: actions/checkout@v3
-        with:
-          clean: false
-
-      - name: Build repository (tip)
-        run: |
-          nix develop -c foliage build -j 0 --write-metadata
-          cp _repo/foliage/packages.json packages-new.json
-
-      - name: Copy static web assets
-        run: |
-          cp static/index.html _repo
-          cp README.md _repo
+          ref: ${{ github.event.pull_request.base.ref }}
 
       # See https://github.com/actions/upload-artifact/issues/36
       - name: Pack repository in a tar archive
         run: tar cf _repo.tar -C _repo .
 
-      # Do this before the check, useful to have the artifact in case the 
-      # check fails!
       - name: Upload built repository
         uses: actions/upload-artifact@v3
         with:
-          name: built-repo
+          name: built-repo-base
           path: _repo.tar
 
-      - name: Upload package metadata
+  build-repo-head:
+    runs-on: nixos
+    steps:
+      # We don't need to build the repos more than once, we can deal with
+      # transient issues by wiping the broken cache (e.g. `gh cache delete`)
+      - name: Fetch cache
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: _repo
+          key: built-repo-${{ github.sha }}
+
+      - if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        name: Build repository
+        uses: ./.github/actions/build-repo
+        with:
+          ref: ${{ github.ref }}
+
+      # See https://github.com/actions/upload-artifact/issues/36
+      - name: Pack repository in a tar archive
+        run: tar cf _repo.tar -C _repo .
+
+      - name: Upload built repository
         uses: actions/upload-artifact@v3
         with:
-          name: package-metadata
-          path: |
-            packages-old.json
-            packages-new.json
+          name: built-repo-head
+          path: _repo.tar
 
-      # Note: we use the check script from the tip so we pick up changes 
-      # to the script from the PR itself.
+  # If this is a pull request, we have a base ref to compare against
+  check-append-only:
+    if: github.event_name == 'pull'
+    runs-on: nixos
+    needs:
+      - build-repos
+    steps:
+      - name: Download built repository (base)
+        uses: actions/download-artifact@v3
+        with:
+          name: built-repo-base
+          path: built-repo-base
+
+      - name: Unpack built repository (base)
+        run: |
+          mkdir _repo-base
+          tar xf built-repo-base/_repo.tar -C _repo-base
+
+      - name: Download built repository (head)
+        uses: actions/download-artifact@v3
+        with:
+          name: built-repo-head
+          path: built-repo-head
+
+      - name: Unpack built repository (head)
+        run: |
+          mkdir _repo-head
+          tar xf built-repo-head/_repo.tar -C _repo-head
+
       - name: Check new index is an extension of the old index
         run: |
           echo "If this check failed because 'some entries only exist in the old index'"
           echo "then you may need to update your branch.\n"
           echo "If it failed because 'the last old entry is newer than the first new entry'"
           echo "then you may need to update the timestamps in your new packages to be newer than those in main."
-          ./scripts/check-archive-extension.sh _repo-main/01-index.tar _repo/01-index.tar
+          ./scripts/check-archive-extension.sh _repo-base/01-index.tar _repo-head/01-index.tar
+
+  generate-smoke-tests:
+    runs-on: nixos
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: nix eval --json github:${{ github.repository }}/${{ github.ref }}#ghaMatrix >> "$GITHUB_OUTPUT"
 
   build-packages:
+    name: build-package ${{ matrix.name }}
     runs-on: nixos
     needs:
-      - build-repo
-
+      - build-repos
+      - generate-smoke-tests
+    strategy:
+      fail-fast: false
+      # The step generate-smoke-tests produces a list of derivations to build
+      # include:
+      #  - name: ghc96/cardano-node/8.5.0
+      #  ...
+      matrix: ${{ fromJSON(needs.generate-smoke-tests.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Download built repository
+      - name: Download built repository (base)
+        if: github.event_name == 'pull'
         uses: actions/download-artifact@v3
         with:
-          name: built-repo
+          name: built-repo-base
+          path: built-repo-base
 
-      - name: Unpack built repository
+      - name: Unpack built repository (base)
+        if: github.event_name == 'pull'
         run: |
-          mkdir _repo
-          tar xf _repo.tar -C _repo
+          mkdir _repo-base
+          tar xf built-repo-base/_repo.tar -C _repo-base
 
-      - name: Build smoke test packages
-        # The > is the "YAML folded string" marker, which replaces 
-        # newlines with spaces, since the usual bash idiom of \ 
-        # doesn't work for some reason
+      - name: Download built repository (head)
+        uses: actions/download-artifact@v3
+        with:
+          name: built-repo-head
+          path: built-repo-head
+
+      - name: Unpack built repository (head)
+        run: |
+          mkdir _repo-head
+          tar xf built-repo-head/_repo.tar -C _repo-head
+
+      - name: Old install plan
+        if: github.event_name == 'pull'
+        id: build
         run: >
-          nix build .#allSmokeTestPackages
-          -L 
-          --override-input CHaP path:_repo
-          --show-trace
+          nix build
+          'github:${{ github.repository }}/${{ github.ref }}#"${{ matrix.name }}".passthru.project.plan-nix.json'
+          --out-link plan-base
+          --override-input CHaP path:_repo-base
 
-  build-new-packages:
-    runs-on: nixos
-
-    needs:
-      - build-repo
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Download built repository
-        uses: actions/download-artifact@v3
-        with:
-          name: built-repo
-
-      - name: Unpack built repository
-        run: |
-          mkdir _repo
-          tar xf _repo.tar -C _repo
-
-      - name: Download package metadata
-        uses: actions/download-artifact@v3
-        with:
-          name: package-metadata
-          path: .
-
-      # This is a bit of a hack: to build the newly added packages, we:
-      # 1. compute the packages.json that just contains the new pacakge-versions
-      # 2. overwrite the built repository's packages.json with the computed one
-      # 3. build "all the packages" which now means "the new packages"
-      #
-      # This avoids us having to do other complicated tricks to make the flake
-      # take the set of packages to build as an argument.
-      - name: Adjust repository metadata
-        run: |
-          scripts/compare-package-metadata.sh packages-old.json packages-new.json > packages-diff.json
-          echo "Newly added packages:"
-          cat packages-diff.json
-          mv -f packages-diff.json _repo/foliage/packages.json
-
-      - name: Build all newly added packages
+      - name: New install plan
+        id: build
         run: >
-          nix build .#allPackages
-          -L
-          --override-input CHaP path:_repo
+          nix build
+          'github:${{ github.repository }}/${{ github.ref }}#"${{ matrix.name }}".passthru.project.plan-nix.json'
+          --out-link plan-head
+          --override-input CHaP path:_repo-head
+
+      - name: Compute difference between install plans
+        if: github.event_name == 'pull'
+        run: >
+          nix develop --command
+          cabal-plan diff --plan-json plan-base-json --plan-json plan-head-json
+
+      - name: Build package
+        # The > is the "YAML folded string" marker, which replaces newlines
+        # with spaces, since the usual bash idiom of \ doesn't work for some
+        # reason
+        id: build
+        run: >
+          nix build 'github:${{ github.repository }}/${{ github.ref }}#"${{ matrix.name }}"'
+          --print-build-logs
+          --override-input CHaP path:_repo-head
           --show-trace
 
   deploy-check:
     runs-on: nixos
-
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: 
-      - build-repo
-
+    needs:
+      - build-repos
     steps:
       - uses: actions/checkout@v3
         with:
@@ -201,15 +214,16 @@ jobs:
           path: repo
           ref: repo
 
-      - name: Download built repository
+      - name: Download built repository (head)
         uses: actions/download-artifact@v3
         with:
-          name: built-repo
+          name: built-repo-head
+          path: built-repo-head
 
-      - name: Unpack built repository
+      - name: Unpack built repository (head)
         run: |
-          mkdir built-repo
-          tar xf _repo.tar -C built-repo
+          mkdir _repo-head
+          tar xf built-repo-head/_repo.tar -C _repo-head
 
       # This is meaningfully different to the check in 'build': that checks the repository
       # built from main and from the PR tip, but that's not _actually_ the repository
@@ -217,15 +231,15 @@ jobs:
       # against the thing that's actually deployed before we deploy.
       - name: Check new index is an extension of the old index
         run: |
-          ./src/scripts/check-archive-extension.sh repo/01-index.tar built-repo/01-index.tar
+          ./src/scripts/check-archive-extension.sh repo/01-index.tar _repo-head/01-index.tar
 
   deploy:
     # This job is fine to run on GitHub provided (free) runners.
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: 
+    needs:
       - check
-      - build-repo
+      - build-repos
       - deploy-check
 
     concurrency:
@@ -244,12 +258,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - uses: actions/checkout@v3
-
       - name: Download built repository
         uses: actions/download-artifact@v3
         with:
-          name: built-repo
+          name: built-repo-head
 
       - name: Unpack built repository
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,6 +29,8 @@ jobs:
     if: github.event_name == 'pull'
     runs-on: nixos
     steps:
+      - uses: actions/checkout@v4
+
       # We don't need to build the repos more than once, we can deal with
       # transient issues by wiping the broken cache (e.g. `gh cache delete`)
       - name: Fetch cache
@@ -57,6 +59,8 @@ jobs:
   build-repo-head:
     runs-on: nixos
     steps:
+      - uses: actions/checkout@v4
+
       # We don't need to build the repos more than once, we can deal with
       # transient issues by wiping the broken cache (e.g. `gh cache delete`)
       - name: Fetch cache
@@ -90,8 +94,6 @@ jobs:
       - build-repo-base
       - build-repo-head
     steps:
-      - uses: actions/checkout@v4
-
       - name: Download built repository (base)
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -167,7 +167,6 @@ jobs:
 
       - name: Old install plan
         if: github.event_name == 'pull'
-        id: build
         run: >
           nix build
           'github:${{ github.repository }}/${{ github.ref }}#"${{ matrix.name }}".passthru.project.plan-nix.json'
@@ -175,7 +174,6 @@ jobs:
           --override-input CHaP path:_repo-base
 
       - name: New install plan
-        id: build
         run: >
           nix build
           'github:${{ github.repository }}/${{ github.ref }}#"${{ matrix.name }}".passthru.project.plan-nix.json'
@@ -192,7 +190,6 @@ jobs:
         # The > is the "YAML folded string" marker, which replaces newlines
         # with spaces, since the usual bash idiom of \ doesn't work for some
         # reason
-        id: build
         run: >
           nix build 'github:${{ github.repository }}/${{ github.ref }}#"${{ matrix.name }}"'
           --print-build-logs

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,22 @@
+name: shellcheck
+
+on:
+  # Following https://github.com/orgs/community/discussions/26276
+  # to get builds on PRs and pushes to main but not double
+  # builds on PRs.
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+env:
+  NIX_CONFIG: accept-flake-config = true
+
+jobs:
+  shellcheck:
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run shellcheck on scripts/*.sh
+        run: nix-shell -I nixpkgs=https://github.com/nixos/nixpkgs/archive/release-23.05.tar.gz -p shellcheck --run 'shellcheck scripts/*.sh'

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1698441381,
-        "narHash": "sha256-zFDjPseeYbCQQmsnCdDzRdMiRCrjwO+2oHmrFZoE4Vg=",
+        "lastModified": 1698645491,
+        "narHash": "sha256-P+cNk+SltCS+gqlG8KdE5KjJmpOYfPfZLg1/Q7kdWQ0=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "f6076612f80e9e215f86b587e5f83087e980d3db",
+        "rev": "f83ad7ac03011b4d409b2eb00a9eba960a698d9c",
         "type": "github"
       },
       "original": {
@@ -139,11 +139,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -198,14 +198,51 @@
         "type": "github"
       }
     },
+    "ghc98X": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696643148,
+        "narHash": "sha256-E02DfgISH7EvvNAu0BHiPvl1E5FGMDi0pWdNZtIBC9I=",
+        "ref": "ghc-9.8",
+        "rev": "443e870d977b1ab6fc05f47a9a17bc49296adbd6",
+        "revCount": 61642,
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.8",
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      }
+    },
+    "ghc99": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1697054644,
+        "narHash": "sha256-kKarOuXUaAH3QWv7ASx+gGFMHaHKe0pK5Zu37ky2AL4=",
+        "ref": "refs/heads/master",
+        "rev": "f383a242c76f90bcca8a4d7ee001dcb49c172a9a",
+        "revCount": 62040,
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      },
+      "original": {
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      }
+    },
     "hackage-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1696638186,
-        "narHash": "sha256-h5wT7jZ3bM07ZvdTSm2j2CdX5EP0LXsk3+9x3QHEE8I=",
+        "lastModified": 1698625513,
+        "narHash": "sha256-wxhTWDj1BxoH2Tw1YR2MhCx16dl1AxnZgDkionCGUyo=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "aa653b3c276f617aa0f61095ecbc16860c98480a",
+        "rev": "ce5ebe664ba192ce3b03f837ed9c5723a9dfefd7",
         "type": "github"
       },
       "original": {
@@ -222,14 +259,17 @@
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
+        "ghc98X": "ghc98X",
+        "ghc99": "ghc99",
         "hackage": [
           "hackage-nix"
         ],
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
         "hls-2.2": "hls-2.2",
+        "hls-2.3": "hls-2.3",
+        "hls-2.4": "hls-2.4",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -248,11 +288,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1693795950,
-        "narHash": "sha256-tvTquqMdRQqBbefNO7f+198hq3VuVlY0rjiN5hmzGFw=",
+        "lastModified": 1698637946,
+        "narHash": "sha256-B1zw4+qlOvYGGzwHZBr1qAylN91+JQNMxeZ1RQyT8Co=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "e166d754a739f5e41d389c537498ccdc6150be0b",
+        "rev": "97ef9986e985b4e625b25281287b0b05b40e3316",
         "type": "github"
       },
       "original": {
@@ -312,6 +352,40 @@
         "type": "github"
       }
     },
+    "hls-2.3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696939266,
+        "narHash": "sha256-VOMf5+kyOeOmfXTHlv4LNFJuDGa7G3pDnOxtzYR40IU=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "362fdd1293efb4b82410b676ab1273479f6d17ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hpc-coveralls": {
       "flake": false,
       "locked": {
@@ -361,11 +435,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1684223806,
-        "narHash": "sha256-IyLoP+zhuyygLtr83XXsrvKyqqLQ8FHXTiySFf4FJOI=",
+        "lastModified": 1696471795,
+        "narHash": "sha256-aNNvjUtCGXaXSp5M/HSj1SOeLjqLyTRWYbIHqAEeUp0=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "86421fdd89b3af43fa716ccd07638f96c6ecd1e4",
+        "rev": "91f16fa8acb58b312f94977715c630d8bf77e33e",
         "type": "github"
       },
       "original": {
@@ -377,11 +451,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1688517130,
-        "narHash": "sha256-hUqfxSlo+ffqVdkSZ1EDoB7/ILCL25eYkcCXW9/P3Wc=",
+        "lastModified": 1691634696,
+        "narHash": "sha256-MZH2NznKC/gbgBu8NgIibtSUZeJ00HTLJ0PlWKCBHb0=",
         "ref": "hkm/remote-iserv",
-        "rev": "9151db2a9a61d7f5fe52ff8836f18bbd0fd8933c",
-        "revCount": 13,
+        "rev": "43a979272d9addc29fbffc2e8542c5d96e993d73",
+        "revCount": 14,
         "type": "git",
         "url": "https://gitlab.haskell.org/hamishmack/iserv-proxy.git"
       },
@@ -526,11 +600,11 @@
     },
     "nixpkgs-2305": {
       "locked": {
-        "lastModified": 1690680713,
-        "narHash": "sha256-NXCWA8N+GfSQyoN7ZNiOgq/nDJKOp5/BHEpiZP8sUZw=",
+        "lastModified": 1695416179,
+        "narHash": "sha256-610o1+pwbSu+QuF3GE0NU5xQdTHM3t9wyYhB9l94Cd8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "rev": "715d72e967ec1dd5ecc71290ee072bcaf5181ed6",
         "type": "github"
       },
       "original": {
@@ -558,11 +632,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1690720142,
-        "narHash": "sha256-GywuiZjBKfFkntQwpNQfL+Ksa2iGjPprBGL0/psgRZM=",
+        "lastModified": 1695318763,
+        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3acb5c4264c490e7714d503c7166a3fde0c51324",
+        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
         "type": "github"
       },
       "original": {
@@ -592,10 +666,7 @@
     "root": {
       "inputs": {
         "CHaP": "CHaP",
-        "flake-utils": [
-          "haskell-nix",
-          "flake-utils"
-        ],
+        "flake-utils": "flake-utils",
         "foliage": "foliage",
         "hackage-nix": "hackage-nix",
         "haskell-nix": "haskell-nix",
@@ -643,11 +714,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1693786159,
-        "narHash": "sha256-IzpBwbwD90CIdhOKfdzS98+o3AtoADNsSz5QBr281Gg=",
+        "lastModified": 1698624588,
+        "narHash": "sha256-693LLLpMatQACFiCWI5ICXjmgrd46FqSF7wGqQVKyNg=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "69d620fde80c1dfbe78b081db1b5725e9c0ce9e2",
+        "rev": "6f04f7ab1228b19119f1e67ade0fe5de957f0a16",
         "type": "github"
       },
       "original": {

--- a/nix/chap-meta.nix
+++ b/nix/chap-meta.nix
@@ -6,30 +6,30 @@ let
   # type ChapMeta = [ ChapPkgMeta ]
   # type PkgVersions = Map PkgName [PkgVersion]
 
-  # chap-package-meta :: ChapPkgMeta
+  # chapPackageMeta :: ChapPkgMeta
   # [ { name = "foo"; version = "X.Y.Z"; } { name = "foo"; version = "P.Q.R"; } ]
-  chap-package-meta =
+  chapPackageMeta =
     builtins.map (p: { name = p.pkg-name; version = p.pkg-version; })
       (builtins.fromJSON (builtins.readFile "${CHaP}/foliage/packages.json"));
 
-  # chap-package-versions :: PkgVersions
+  # chapPackageVersions :: PkgVersions
   # { foo = [ "X.Y.Z" "P.Q.R" ]; ... }
-  chap-package-versions =
+  chapPackageVersions =
     let
       # { foo = [{ name = "foo"; version = "X.Y.Z"; } { name = "foo"; version = "P.Q.R"; } ...]; ... }
-      grouped = lib.groupBy (m: m.name) chap-package-meta;
+      grouped = lib.groupBy (m: m.name) chapPackageMeta;
     in
     lib.mapAttrs (_name: lib.catAttrs "version") grouped;
 
-  # chap-package-latest-versions :: PkgVersions
-  # { foo = [ "X.Y.Z" ]; ... }
-  chap-package-latest-versions =
+  # chapPackageLatestVersion :: PkgVersions
+  # { foo = "X.Y.Z"; ... }
+  chapPackageLatestVersion =
     let latest = versions: lib.last (lib.naturalSort versions);
-    in lib.mapAttrs (name: versions: [ (latest versions) ]) chap-package-versions;
+    in lib.mapAttrs (name: versions: latest versions) chapPackageVersions;
 
   # mkPackageTreeWith
   # :: (PkgName -> PkgVersion -> a)
-  # -> PkgVersions
+  # -> Either PkgVersion [PkgVersion]
   # -> Map PkgName (Map PkgVersion a)
   #
   # Collect package names and versions in a hierarchical structure, calling
@@ -38,14 +38,14 @@ let
   # mkPackageTree f == { Win32-network = { "0.1.0.0" = f "Win32-network" "0.1.0.0"; ... }; ... }
   #
   mkPackageTreeWith = f:
-    builtins.mapAttrs (name: versions: lib.genAttrs versions (f name));
+    builtins.mapAttrs (name: versions: lib.genAttrs (lib.toList versions) (f name));
 
 in
 {
   inherit
-    chap-package-meta
-    chap-package-versions
-    chap-package-latest-versions
+    chapPackageMeta
+    chapPackageVersions
+    chapPackageLatestVersion
     mkPackageTreeWith
     ;
 }


### PR DESCRIPTION
This reworks the CI to give more control to GitHub Actions.

- The flake exposes the list of smoke-test derivations that GHA load and execute.
- The repositories for base (available only for PRs) and head are built concurrently
- Built repositories are cached by their commit hash, we should not need to build them more than once. We can always delete the specific cache in case of issues.

Minor changes:
- haskellPackages -> chapPackages
- Consistent camelCase
- chapPackagesLatestVersion maps to a single version rather than a list with a single element

Opening as draft to see if it works.