### PR TITLE
network/release 2024 01 22

### DIFF
--- a/_sources/cardano-client/0.3.1.0/meta.toml
+++ b/_sources/cardano-client/0.3.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-01-22T13:37:50Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "c5f71777939160c54d5097622291bb5928e6094c" }
+subdir = 'cardano-client'

--- a/_sources/cardano-ping/0.2.0.11/meta.toml
+++ b/_sources/cardano-ping/0.2.0.11/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-01-22T13:37:51Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "c5f71777939160c54d5097622291bb5928e6094c" }
+subdir = 'cardano-ping'

--- a/_sources/monoidal-synchronisation/0.1.0.5/meta.toml
+++ b/_sources/monoidal-synchronisation/0.1.0.5/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-01-22T13:37:52Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "c5f71777939160c54d5097622291bb5928e6094c" }
+subdir = 'monoidal-synchronisation'

--- a/_sources/ntp-client/0.0.1.4/meta.toml
+++ b/_sources/ntp-client/0.0.1.4/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-01-22T13:37:53Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "c5f71777939160c54d5097622291bb5928e6094c" }
+subdir = 'ntp-client'

--- a/_sources/ouroboros-network-api/0.6.3.0/meta.toml
+++ b/_sources/ouroboros-network-api/0.6.3.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-01-22T13:37:54Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "c5f71777939160c54d5097622291bb5928e6094c" }
+subdir = 'ouroboros-network-api'

--- a/_sources/ouroboros-network-framework/0.11.0.0/meta.toml
+++ b/_sources/ouroboros-network-framework/0.11.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-01-22T13:37:55Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "c5f71777939160c54d5097622291bb5928e6094c" }
+subdir = 'ouroboros-network-framework'

--- a/_sources/ouroboros-network-mock/0.1.1.1/meta.toml
+++ b/_sources/ouroboros-network-mock/0.1.1.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-01-22T13:37:56Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "c5f71777939160c54d5097622291bb5928e6094c" }
+subdir = 'ouroboros-network-mock'

--- a/_sources/ouroboros-network-protocols/0.7.0.0/meta.toml
+++ b/_sources/ouroboros-network-protocols/0.7.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-01-22T13:37:57Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "c5f71777939160c54d5097622291bb5928e6094c" }
+subdir = 'ouroboros-network-protocols'

--- a/_sources/ouroboros-network/0.11.0.0/meta.toml
+++ b/_sources/ouroboros-network/0.11.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-01-22T13:37:54Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "c5f71777939160c54d5097622291bb5928e6094c" }
+subdir = 'ouroboros-network'

--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,36 @@
         cardano-prelude = {
           ghc98.enabled = v : true;
         };
+        ntp-client = {
+          ghc98.enabled = v : true;
+        };
+        network-mux = {
+          ghc98.enabled = v : true;
+        };
+        monoidal-synchronisation = {
+          ghc98.enabled = v : true;
+        };
+        ouroboros-network-api = {
+          ghc98.enabled = v : true;
+        };
+        ouroboros-network-mock = {
+          ghc98.enabled = v : true;
+        };
+        ouroboros-network-framework = {
+          ghc98.enabled = v : true;
+        };
+        ouroboros-network-protocols = {
+          ghc98.enabled = v : true;
+        };
+        ouroboros-network = {
+          ghc98.enabled = v : true;
+        };
+        cardano-ping = {
+          ghc98.enabled = v : true;
+        };
+        cardano-client = {
+          ghc98.enabled = v : true;
+        };
         cardano-node-emulator = {
           ghc810.enabled = v : false;
         };


### PR DESCRIPTION
- Added cardano-client-0.3.1.0
- Added cardano-ping-0.2.0.11
- Added monoidal-synchronisation-0.1.0.5
- Added ntp-client-0.0.1.4
- Added ouroboros-network-0.11.0.0
- Added ouroboros-network-api-0.6.3.0
- Added ouroboros-network-framework-0.11.0.0
- Added ouroboros-network-mock-0.1.1.1
- Added ouroboros-network-protocols-0.7.0.0
- Enabled ghc-9.8 for network packages
