### PR TITLE
Added latex-svg-image-0.2.0.0.0.1

### DIFF
--- a/_sources/latex-svg-image/0.2.0.0.0.1/meta.toml
+++ b/_sources/latex-svg-image/0.2.0.0.0.1/meta.toml
@@ -1,0 +1,4 @@
+timestamp = 2024-04-05T13:36:27Z
+github = { repo = "jasagredo/latex-svg", rev = "c52c9905cb043ddb430c93b41ce431a7506a300d" }
+subdir = 'latex-svg-image'
+force-version = true


### PR DESCRIPTION
From https://github.com/jasagredo/latex-svg at c52c9905cb043ddb430c93b41ce431a7506a300d

Until this gets merged and released https://github.com/phadej/latex-svg/pull/9
<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
