### PR TITLE
Release ouroboros-consensus-diffusion-0.14.0.0

### DIFF
--- a/_sources/ouroboros-consensus-cardano/0.14.2.0/meta.toml
+++ b/_sources/ouroboros-consensus-cardano/0.14.2.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'ouroboros-consensus-cardano'
 [[revisions]]
 number = 1
 timestamp = 2024-03-28T23:05:39Z
+
+[[revisions]]
+number = 2
+timestamp = 2024-04-08T09:22:59Z

--- a/_sources/ouroboros-consensus-cardano/0.14.2.0/revisions/2.cabal
+++ b/_sources/ouroboros-consensus-cardano/0.14.2.0/revisions/2.cabal
@@ -1,0 +1,631 @@
+cabal-version:   3.0
+name:            ouroboros-consensus-cardano
+version:         0.14.2.0
+synopsis:
+  The instantation of the Ouroboros consensus layer used by Cardano
+
+description:
+  The instantation of the Ouroboros consensus layer used by Cardano.
+
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+copyright:
+  2019-2023 Input Output Global Inc (IOG), INTERSECT 2023-2024.
+
+author:          IOG Engineering Team
+maintainer:      operations@iohk.io
+category:        Network
+build-type:      Simple
+extra-doc-files:
+  CHANGELOG.md
+  README.md
+
+source-repository head
+  type:     git
+  location: https://github.com/IntersectMBO/ouroboros-consensus
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+common common-lib
+  default-language: Haskell2010
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -Wno-unticked-promoted-constructors
+
+  if flag(asserts)
+    ghc-options: -fno-ignore-asserts
+
+common common-test
+  import:      common-lib
+  ghc-options: -threaded -rtsopts
+
+common common-exe
+  import:      common-lib
+  ghc-options: -threaded -rtsopts "-with-rtsopts=-N -I0 -A16m"
+
+library
+  import:          common-lib
+  hs-source-dirs:  src/ouroboros-consensus-cardano src/byron src/shelley
+  exposed-modules:
+    Ouroboros.Consensus.Byron.Crypto.DSIGN
+    Ouroboros.Consensus.Byron.EBBs
+    Ouroboros.Consensus.Byron.Ledger
+    Ouroboros.Consensus.Byron.Ledger.Block
+    Ouroboros.Consensus.Byron.Ledger.Config
+    Ouroboros.Consensus.Byron.Ledger.Conversions
+    Ouroboros.Consensus.Byron.Ledger.Forge
+    Ouroboros.Consensus.Byron.Ledger.HeaderValidation
+    Ouroboros.Consensus.Byron.Ledger.Inspect
+    Ouroboros.Consensus.Byron.Ledger.Integrity
+    Ouroboros.Consensus.Byron.Ledger.Ledger
+    Ouroboros.Consensus.Byron.Ledger.Mempool
+    Ouroboros.Consensus.Byron.Ledger.NetworkProtocolVersion
+    Ouroboros.Consensus.Byron.Ledger.Orphans
+    Ouroboros.Consensus.Byron.Ledger.PBFT
+    Ouroboros.Consensus.Byron.Ledger.Serialisation
+    Ouroboros.Consensus.Byron.Node
+    Ouroboros.Consensus.Byron.Node.Serialisation
+    Ouroboros.Consensus.Byron.Protocol
+    Ouroboros.Consensus.Cardano
+    Ouroboros.Consensus.Cardano.Block
+    Ouroboros.Consensus.Cardano.ByronHFC
+    Ouroboros.Consensus.Cardano.CanHardFork
+    Ouroboros.Consensus.Cardano.Condense
+    Ouroboros.Consensus.Cardano.Node
+    Ouroboros.Consensus.Shelley.Crypto
+    Ouroboros.Consensus.Shelley.Eras
+    Ouroboros.Consensus.Shelley.HFEras
+    Ouroboros.Consensus.Shelley.Ledger
+    Ouroboros.Consensus.Shelley.Ledger.Block
+    Ouroboros.Consensus.Shelley.Ledger.Config
+    Ouroboros.Consensus.Shelley.Ledger.Forge
+    Ouroboros.Consensus.Shelley.Ledger.Inspect
+    Ouroboros.Consensus.Shelley.Ledger.Integrity
+    Ouroboros.Consensus.Shelley.Ledger.Ledger
+    Ouroboros.Consensus.Shelley.Ledger.Mempool
+    Ouroboros.Consensus.Shelley.Ledger.NetworkProtocolVersion
+    Ouroboros.Consensus.Shelley.Ledger.PeerSelection
+    Ouroboros.Consensus.Shelley.Ledger.Protocol
+    Ouroboros.Consensus.Shelley.Ledger.Query
+    Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol
+    Ouroboros.Consensus.Shelley.Node
+    Ouroboros.Consensus.Shelley.Node.Common
+    Ouroboros.Consensus.Shelley.Node.Praos
+    Ouroboros.Consensus.Shelley.Node.Serialisation
+    Ouroboros.Consensus.Shelley.Node.TPraos
+    Ouroboros.Consensus.Shelley.Protocol.Abstract
+    Ouroboros.Consensus.Shelley.Protocol.Praos
+    Ouroboros.Consensus.Shelley.Protocol.TPraos
+    Ouroboros.Consensus.Shelley.ShelleyHFC
+
+  other-modules:
+    Ouroboros.Consensus.Shelley.Ledger.Query.PParamsLegacyEncoder
+
+  build-depends:
+    , base                          >=4.14   && <4.20
+    , base-deriving-via
+    , bytestring                    >=0.10   && <0.13
+    , cardano-binary
+    , cardano-crypto
+    , cardano-crypto-class
+    , cardano-crypto-wrapper
+    , cardano-ledger-allegra        ^>=1.3
+    , cardano-ledger-alonzo         ^>=1.6
+    , cardano-ledger-api            ^>=1.8
+    , cardano-ledger-babbage        ^>=1.6
+    , cardano-ledger-binary         ^>=1.3
+    , cardano-ledger-byron          ^>=1.0
+    , cardano-ledger-conway         ^>=1.12
+    , cardano-ledger-core           ^>=1.10
+    , cardano-ledger-mary           ^>=1.5
+    , cardano-ledger-shelley        ^>=1.9
+    , cardano-prelude
+    , cardano-protocol-tpraos       ^>=1.1
+    , cardano-slotting
+    , cardano-strict-containers
+    , cborg                         ^>=0.2.2
+    , containers                    >=0.5    && <0.7
+    , cryptonite                    >=0.25   && <0.31
+    , deepseq
+    , formatting                    >=6.3    && <7.3
+    , measures
+    , microlens
+    , mtl
+    , nothunks
+    , ouroboros-consensus           ^>=0.16
+    , ouroboros-consensus-protocol  ^>=0.7
+    , ouroboros-network-api         ^>=0.7.1
+    , serialise                     ^>=0.2
+    , small-steps
+    , sop-core                      ^>=0.5
+    , sop-extras                    ^>=0.1
+    , strict-sop-core               ^>=0.1
+    , text
+    , these                         ^>=1.2
+    , vector-map
+
+  -- GHC 8.10.7 on aarch64-darwin cannot use text-2
+  build-depends:   text >=1.2.5.0 && <2.2
+
+library unstable-byronspec
+  import:          common-lib
+  visibility:      public
+  hs-source-dirs:  src/unstable-byronspec
+  exposed-modules:
+    Ouroboros.Consensus.ByronSpec.Ledger
+    Ouroboros.Consensus.ByronSpec.Ledger.Accessors
+    Ouroboros.Consensus.ByronSpec.Ledger.Block
+    Ouroboros.Consensus.ByronSpec.Ledger.Conversions
+    Ouroboros.Consensus.ByronSpec.Ledger.Forge
+    Ouroboros.Consensus.ByronSpec.Ledger.Genesis
+    Ouroboros.Consensus.ByronSpec.Ledger.GenTx
+    Ouroboros.Consensus.ByronSpec.Ledger.Ledger
+    Ouroboros.Consensus.ByronSpec.Ledger.Mempool
+    Ouroboros.Consensus.ByronSpec.Ledger.Orphans
+    Ouroboros.Consensus.ByronSpec.Ledger.Rules
+
+  build-depends:
+    , base                       >=4.14  && <4.20
+    , bimap                      >=0.4   && <0.6
+    , byron-spec-chain
+    , byron-spec-ledger
+    , cardano-ledger-binary
+    , cardano-ledger-byron-test
+    , cborg                      >=0.2.2 && <0.3
+    , containers                 >=0.5   && <0.7
+    , mtl
+    , nothunks
+    , ouroboros-consensus        ^>=0.16
+    , serialise                  ^>=0.2
+    , small-steps
+    , transformers
+
+library unstable-byron-testlib
+  import:          common-lib
+  visibility:      public
+  hs-source-dirs:  src/unstable-byron-testlib
+  exposed-modules:
+    Ouroboros.Consensus.ByronDual.Ledger
+    Ouroboros.Consensus.ByronDual.Node
+    Ouroboros.Consensus.ByronDual.Node.Serialisation
+    Test.Consensus.Byron.Examples
+    Test.Consensus.Byron.Generators
+    Test.ThreadNet.Infra.Byron
+    Test.ThreadNet.Infra.Byron.Genesis
+    Test.ThreadNet.Infra.Byron.ProtocolInfo
+    Test.ThreadNet.Infra.Byron.TrackUpdates
+    Test.ThreadNet.TxGen.Byron
+
+  build-depends:
+    , base
+    , byron-spec-ledger
+    , bytestring
+    , cardano-crypto-class
+    , cardano-crypto-test
+    , cardano-crypto-wrapper
+    , cardano-ledger-binary:{cardano-ledger-binary, testlib}
+    , cardano-ledger-byron
+    , cardano-ledger-byron-test
+    , containers
+    , hedgehog-quickcheck
+    , mtl
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion:unstable-diffusion-testlib
+    , ouroboros-consensus:{ouroboros-consensus, unstable-consensus-testlib}
+    , ouroboros-network-api
+    , QuickCheck
+    , serialise
+    , unstable-byronspec
+
+test-suite byron-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/byron-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Consensus.Byron.Golden
+    Test.Consensus.Byron.Serialisation
+    Test.ThreadNet.Byron
+    Test.ThreadNet.DualByron
+
+  build-depends:
+    , base
+    , binary-search
+    , byron-spec-chain
+    , byron-spec-ledger
+    , bytestring
+    , cardano-crypto-class
+    , cardano-crypto-wrapper
+    , cardano-ledger-binary
+    , cardano-ledger-byron
+    , cardano-ledger-byron-test
+    , cborg
+    , constraints
+    , containers
+    , filepath
+    , hedgehog-quickcheck
+    , mtl
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion:unstable-diffusion-testlib
+    , ouroboros-consensus:{ouroboros-consensus, unstable-consensus-testlib}
+    , ouroboros-network-mock
+    , QuickCheck
+    , small-steps                                                            <1.1
+    , small-steps-test
+    , tasty
+    , tasty-quickcheck
+    , unstable-byron-testlib
+    , unstable-byronspec
+
+library unstable-shelley-testlib
+  import:          common-lib
+  visibility:      public
+  hs-source-dirs:  src/unstable-shelley-testlib
+  exposed-modules:
+    Test.Consensus.Shelley.Examples
+    Test.Consensus.Shelley.Generators
+    Test.Consensus.Shelley.MockCrypto
+    Test.ThreadNet.Infra.Shelley
+    Test.ThreadNet.TxGen.Shelley
+
+  build-depends:
+    , base
+    , bytestring
+    , cardano-crypto-class
+    , cardano-data
+    , cardano-ledger-allegra
+    , cardano-ledger-alonzo
+    , cardano-ledger-alonzo-test
+    , cardano-ledger-babbage-test
+    , cardano-ledger-conway-test                                                              >=1.2.1
+    , cardano-ledger-core:{cardano-ledger-core, testlib}
+    , cardano-ledger-mary
+    , cardano-ledger-shelley-ma-test
+    , cardano-ledger-shelley-test
+    , cardano-ledger-shelley:{cardano-ledger-shelley, testlib}
+    , cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib}
+    , cardano-strict-containers
+    , containers
+    , generic-random
+    , microlens
+    , mtl
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion:unstable-diffusion-testlib
+    , ouroboros-consensus-protocol:{ouroboros-consensus-protocol, unstable-protocol-testlib}
+    , ouroboros-consensus:{ouroboros-consensus, unstable-consensus-testlib}
+    , ouroboros-network-api
+    , QuickCheck
+    , quiet                                                                                   ^>=0.2
+    , small-steps
+
+test-suite shelley-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/shelley-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Consensus.Shelley.Coherence
+    Test.Consensus.Shelley.Golden
+    Test.Consensus.Shelley.Serialisation
+    Test.Consensus.Shelley.SupportedNetworkProtocolVersion
+    Test.ThreadNet.Shelley
+
+  build-depends:
+    , base
+    , bytestring
+    , cardano-crypto-class
+    , cardano-ledger-alonzo
+    , cardano-ledger-alonzo-test
+    , cardano-ledger-core
+    , cardano-ledger-shelley
+    , cardano-protocol-tpraos
+    , cardano-slotting
+    , cborg
+    , constraints
+    , containers
+    , filepath
+    , microlens
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion:unstable-diffusion-testlib
+    , ouroboros-consensus-protocol
+    , ouroboros-consensus:{ouroboros-consensus, unstable-consensus-testlib}
+    , QuickCheck
+    , sop-core
+    , strict-sop-core
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , unstable-shelley-testlib
+
+library unstable-cardano-testlib
+  import:          common-lib
+  visibility:      public
+  hs-source-dirs:  src/unstable-cardano-testlib
+  exposed-modules:
+    Test.Consensus.Cardano.Examples
+    Test.Consensus.Cardano.Generators
+    Test.Consensus.Cardano.MockCrypto
+    Test.Consensus.Cardano.ProtocolInfo
+    Test.ThreadNet.Infra.ShelleyBasedHardFork
+    Test.ThreadNet.Infra.TwoEras
+    Test.ThreadNet.TxGen.Allegra
+    Test.ThreadNet.TxGen.Alonzo
+    Test.ThreadNet.TxGen.Babbage
+    Test.ThreadNet.TxGen.Cardano
+    Test.ThreadNet.TxGen.Mary
+
+  build-depends:
+    , base
+    , cardano-crypto-class
+    , cardano-crypto-wrapper
+    , cardano-ledger-alonzo-test
+    , cardano-ledger-api
+    , cardano-ledger-byron
+    , cardano-ledger-conway-test                                                                 ^>=1.2.1
+    , cardano-ledger-conway:testlib
+    , cardano-ledger-core:{cardano-ledger-core, testlib}
+    , cardano-ledger-shelley
+    , cardano-protocol-tpraos
+    , cardano-slotting
+    , cardano-strict-containers
+    , containers
+    , microlens
+    , mtl
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion:{ouroboros-consensus-diffusion, unstable-diffusion-testlib}
+    , ouroboros-consensus-protocol:{ouroboros-consensus-protocol, unstable-protocol-testlib}
+    , ouroboros-consensus:{ouroboros-consensus, unstable-consensus-testlib}
+    , ouroboros-network-api
+    , QuickCheck
+    , sop-core
+    , sop-extras
+    , strict-sop-core
+    , unstable-byron-testlib
+    , unstable-shelley-testlib
+
+test-suite cardano-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/cardano-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Consensus.Cardano.ByronCompatibility
+    Test.Consensus.Cardano.Golden
+    Test.Consensus.Cardano.MiniProtocol.LocalTxSubmission.ByteStringTxParser
+    Test.Consensus.Cardano.MiniProtocol.LocalTxSubmission.Server
+    Test.Consensus.Cardano.Serialisation
+    Test.Consensus.Cardano.SupportedNetworkProtocolVersion
+    Test.ThreadNet.AllegraMary
+    Test.ThreadNet.Cardano
+    Test.ThreadNet.MaryAlonzo
+    Test.ThreadNet.ShelleyAllegra
+
+  build-depends:
+    , base
+    , base16-bytestring
+    , bytestring
+    , cardano-crypto-class
+    , cardano-ledger-alonzo
+    , cardano-ledger-alonzo-test
+    , cardano-ledger-api
+    , cardano-ledger-byron
+    , cardano-ledger-core
+    , cardano-ledger-shelley
+    , cardano-protocol-tpraos
+    , cardano-slotting
+    , cborg
+    , constraints
+    , containers
+    , contra-tracer
+    , filepath
+    , microlens
+    , ouroboros-consensus-cardano:{ouroboros-consensus-cardano, unstable-cardano-testlib}
+    , ouroboros-consensus-diffusion:unstable-diffusion-testlib
+    , ouroboros-consensus-protocol
+    , ouroboros-consensus:{ouroboros-consensus, unstable-consensus-testlib, unstable-mempool-test-utils}
+    , ouroboros-network-api
+    , ouroboros-network-protocols:{ouroboros-network-protocols, testlib}
+    , pretty-simple
+    , QuickCheck
+    , sop-core
+    , sop-extras
+    , strict-sop-core
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , typed-protocols                                                                                     ^>=0.1.1
+    , unstable-byron-testlib
+    , unstable-cardano-testlib
+    , unstable-shelley-testlib
+
+library unstable-cardano-tools
+  import:          common-lib
+  visibility:      public
+  hs-source-dirs:  src/unstable-cardano-tools
+  exposed-modules:
+    Cardano.Api.Any
+    Cardano.Api.Protocol.Types
+    Cardano.Node.Protocol
+    Cardano.Node.Protocol.Types
+    Cardano.Node.Types
+    Cardano.Tools.DBAnalyser.Analysis
+    Cardano.Tools.DBAnalyser.Analysis.BenchmarkLedgerOps.FileWriting
+    Cardano.Tools.DBAnalyser.Analysis.BenchmarkLedgerOps.Metadata
+    Cardano.Tools.DBAnalyser.Analysis.BenchmarkLedgerOps.SlotDataPoint
+    Cardano.Tools.DBAnalyser.Block.Byron
+    Cardano.Tools.DBAnalyser.Block.Cardano
+    Cardano.Tools.DBAnalyser.Block.Shelley
+    Cardano.Tools.DBAnalyser.HasAnalysis
+    Cardano.Tools.DBAnalyser.Run
+    Cardano.Tools.DBAnalyser.Types
+    Cardano.Tools.DBSynthesizer.Forging
+    Cardano.Tools.DBSynthesizer.Orphans
+    Cardano.Tools.DBSynthesizer.Run
+    Cardano.Tools.DBSynthesizer.Types
+    Cardano.Tools.DBTruncater.Run
+    Cardano.Tools.DBTruncater.Types
+    Cardano.Tools.GitRev
+    Cardano.Tools.ImmDBServer.Diffusion
+    Cardano.Tools.ImmDBServer.MiniProtocols
+
+  other-modules:
+    Cardano.Api.Key
+    Cardano.Api.KeysByron
+    Cardano.Api.KeysPraos
+    Cardano.Api.KeysShelley
+    Cardano.Api.OperationalCertificate
+    Cardano.Api.SerialiseTextEnvelope
+    Cardano.Api.SerialiseUsing
+    Cardano.Node.Protocol.Alonzo
+    Cardano.Node.Protocol.Byron
+    Cardano.Node.Protocol.Cardano
+    Cardano.Node.Protocol.Conway
+    Cardano.Node.Protocol.Shelley
+
+  build-depends:
+    , aeson
+    , base                           >=4.14   && <4.20
+    , base16-bytestring              >=1.0
+    , bytestring                     >=0.10   && <0.13
+    , cardano-crypto
+    , cardano-crypto-class
+    , cardano-crypto-wrapper
+    , cardano-git-rev                ^>=0.2.1
+    , cardano-ledger-allegra
+    , cardano-ledger-alonzo
+    , cardano-ledger-api
+    , cardano-ledger-babbage
+    , cardano-ledger-binary
+    , cardano-ledger-byron
+    , cardano-ledger-conway
+    , cardano-ledger-core
+    , cardano-ledger-mary
+    , cardano-ledger-shelley
+    , cardano-prelude
+    , cardano-protocol-tpraos        ^>=1.1
+    , cardano-slotting
+    , cardano-strict-containers
+    , cborg                          ^>=0.2.2
+    , containers                     >=0.5    && <0.7
+    , contra-tracer
+    , directory
+    , filepath
+    , fs-api                         ^>=0.2
+    , githash
+    , microlens
+    , mtl
+    , network
+    , nothunks
+    , ouroboros-consensus            ^>=0.16
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion  ^>=0.12 || ^>=0.14
+    , ouroboros-consensus-protocol   ^>=0.7
+    , ouroboros-network
+    , ouroboros-network-api
+    , ouroboros-network-framework
+    , ouroboros-network-protocols
+    , serialise                      ^>=0.2
+    , sop-core
+    , sop-extras
+    , strict-sop-core
+    , text
+    , text-builder
+    , transformers
+    , transformers-except
+
+executable db-analyser
+  import:         common-lib
+  hs-source-dirs: app
+  main-is:        db-analyser.hs
+  build-depends:
+    , base
+    , cardano-crypto-class
+    , cardano-crypto-wrapper
+    , optparse-applicative
+    , ouroboros-consensus
+    , ouroboros-consensus-cardano:{ouroboros-consensus-cardano, unstable-cardano-tools}
+    , text
+    , with-utf8
+
+  -- NOTE: these options should match the ones in the cardano-node.
+  --
+  -- 'db-analyser' is often used as a benchmarking tool. Thus, by using
+  -- the same GHC flags as the node, we are more likely to get
+  -- performance observations that correspond to those we get from a
+  -- running node.
+  ghc-options:    -threaded -rtsopts
+
+  if arch(arm)
+    ghc-options:
+      "-with-rtsopts=-T -I0 -A16m -N1 --disable-delayed-os-memory-return"
+
+  else
+    ghc-options:
+      "-with-rtsopts=-T -I0 -A16m -N2 --disable-delayed-os-memory-return"
+
+  other-modules:  DBAnalyser.Parsers
+
+executable db-synthesizer
+  import:         common-exe
+  hs-source-dirs: app
+  main-is:        db-synthesizer.hs
+  build-depends:
+    , base
+    , cardano-crypto-class
+    , optparse-applicative
+    , ouroboros-consensus
+    , unstable-cardano-tools
+    , with-utf8
+
+  other-modules:  DBSynthesizer.Parsers
+
+executable db-truncater
+  import:         common-exe
+  hs-source-dirs: app
+  main-is:        db-truncater.hs
+  build-depends:
+    , base
+    , cardano-crypto-class
+    , cardano-crypto-wrapper
+    , optparse-applicative
+    , ouroboros-consensus
+    , ouroboros-consensus-cardano:{ouroboros-consensus-cardano, unstable-cardano-tools}
+    , with-utf8
+
+  other-modules:
+    DBAnalyser.Parsers
+    DBTruncater.Parsers
+
+executable immdb-server
+  import:         common-exe
+  hs-source-dirs: app
+  main-is:        immdb-server.hs
+  build-depends:
+    , base
+    , cardano-crypto-class
+    , network
+    , optparse-applicative
+    , ouroboros-consensus
+    , ouroboros-consensus-cardano:unstable-cardano-tools
+    , with-utf8
+
+test-suite tools-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/tools-test
+  main-is:        Main.hs
+  build-depends:
+    , base
+    , ouroboros-consensus-cardano
+    , ouroboros-consensus:unstable-consensus-testlib
+    , tasty
+    , tasty-hunit
+    , unstable-cardano-tools

--- a/_sources/ouroboros-consensus-diffusion/0.14.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-diffusion/0.14.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-04-08T09:20:21Z
+github = { repo = "input-output-hk/ouroboros-consensus", rev = "ed22dd3bd4c3871387862f87dc94c3677d98f3f4" }
+subdir = 'ouroboros-consensus-diffusion'

--- a/_sources/ouroboros-consensus/0.16.0.0/meta.toml
+++ b/_sources/ouroboros-consensus/0.16.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-02-23T19:12:56Z
 github = { repo = "input-output-hk/ouroboros-consensus", rev = "a2cb6e5bff880a8e54cbe1abb654839522b55b34" }
 subdir = 'ouroboros-consensus'
+
+[[revisions]]
+number = 1
+timestamp = 2024-04-08T10:25:46Z

--- a/_sources/ouroboros-consensus/0.16.0.0/revisions/1.cabal
+++ b/_sources/ouroboros-consensus/0.16.0.0/revisions/1.cabal
@@ -1,0 +1,695 @@
+cabal-version:   3.0
+name:            ouroboros-consensus
+version:         0.16.0.0
+synopsis:        Consensus layer for the Ouroboros blockchain protocol
+description:     Consensus layer for the Ouroboros blockchain protocol.
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+copyright:
+  2019-2023 Input Output Global Inc (IOG), INTERSECT 2023-2024.
+
+author:          IOG Engineering Team
+maintainer:      operations@iohk.io
+category:        Network
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+
+source-repository head
+  type:     git
+  location: https://github.com/IntersectMBO/ouroboros-consensus
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+common common-lib
+  default-language: Haskell2010
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -Wno-unticked-promoted-constructors
+
+  if flag(asserts)
+    ghc-options: -fno-ignore-asserts
+    cpp-options: -DENABLE_ASSERTIONS
+
+common common-test
+  import:      common-lib
+  ghc-options: -threaded -rtsopts
+
+common common-bench
+  import:      common-test
+  ghc-options: -threaded -rtsopts
+
+  -- We use this option to avoid skewed results due to changes in cache-line
+  -- alignment. See
+  -- https://github.com/Bodigrim/tasty-bench#comparison-against-baseline
+  if impl(ghc >=8.6)
+    ghc-options: -fproc-alignment=64
+
+library
+  import:          common-lib
+  hs-source-dirs:  src/ouroboros-consensus
+  exposed-modules:
+    Ouroboros.Consensus.Block
+    Ouroboros.Consensus.Block.Abstract
+    Ouroboros.Consensus.Block.EBB
+    Ouroboros.Consensus.Block.Forging
+    Ouroboros.Consensus.Block.NestedContent
+    Ouroboros.Consensus.Block.RealPoint
+    Ouroboros.Consensus.Block.SupportsMetrics
+    Ouroboros.Consensus.Block.SupportsProtocol
+    Ouroboros.Consensus.BlockchainTime
+    Ouroboros.Consensus.BlockchainTime.API
+    Ouroboros.Consensus.BlockchainTime.WallClock.Default
+    Ouroboros.Consensus.BlockchainTime.WallClock.HardFork
+    Ouroboros.Consensus.BlockchainTime.WallClock.Simple
+    Ouroboros.Consensus.BlockchainTime.WallClock.Types
+    Ouroboros.Consensus.BlockchainTime.WallClock.Util
+    Ouroboros.Consensus.Config
+    Ouroboros.Consensus.Config.SecurityParam
+    Ouroboros.Consensus.Config.SupportsNode
+    Ouroboros.Consensus.Forecast
+    Ouroboros.Consensus.Fragment.Diff
+    Ouroboros.Consensus.Fragment.InFuture
+    Ouroboros.Consensus.Fragment.Validated
+    Ouroboros.Consensus.Fragment.ValidatedDiff
+    Ouroboros.Consensus.HardFork.Abstract
+    Ouroboros.Consensus.HardFork.Combinator
+    Ouroboros.Consensus.HardFork.Combinator.Abstract
+    Ouroboros.Consensus.HardFork.Combinator.Abstract.CanHardFork
+    Ouroboros.Consensus.HardFork.Combinator.Abstract.NoHardForks
+    Ouroboros.Consensus.HardFork.Combinator.Abstract.SingleEraBlock
+    Ouroboros.Consensus.HardFork.Combinator.AcrossEras
+    Ouroboros.Consensus.HardFork.Combinator.Basics
+    Ouroboros.Consensus.HardFork.Combinator.Block
+    Ouroboros.Consensus.HardFork.Combinator.Compat
+    Ouroboros.Consensus.HardFork.Combinator.Condense
+    Ouroboros.Consensus.HardFork.Combinator.Degenerate
+    Ouroboros.Consensus.HardFork.Combinator.Embed.Binary
+    Ouroboros.Consensus.HardFork.Combinator.Embed.Nary
+    Ouroboros.Consensus.HardFork.Combinator.Embed.Unary
+    Ouroboros.Consensus.HardFork.Combinator.Forging
+    Ouroboros.Consensus.HardFork.Combinator.Info
+    Ouroboros.Consensus.HardFork.Combinator.InjectTxs
+    Ouroboros.Consensus.HardFork.Combinator.Ledger
+    Ouroboros.Consensus.HardFork.Combinator.Ledger.CommonProtocolParams
+    Ouroboros.Consensus.HardFork.Combinator.Ledger.PeerSelection
+    Ouroboros.Consensus.HardFork.Combinator.Ledger.Query
+    Ouroboros.Consensus.HardFork.Combinator.Lifting
+    Ouroboros.Consensus.HardFork.Combinator.Mempool
+    Ouroboros.Consensus.HardFork.Combinator.Node
+    Ouroboros.Consensus.HardFork.Combinator.Node.InitStorage
+    Ouroboros.Consensus.HardFork.Combinator.Node.Metrics
+    Ouroboros.Consensus.HardFork.Combinator.PartialConfig
+    Ouroboros.Consensus.HardFork.Combinator.Protocol
+    Ouroboros.Consensus.HardFork.Combinator.Protocol.ChainSel
+    Ouroboros.Consensus.HardFork.Combinator.Protocol.LedgerView
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseDisk
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToClient
+    Ouroboros.Consensus.HardFork.Combinator.Serialisation.SerialiseNodeToNode
+    Ouroboros.Consensus.HardFork.Combinator.State
+    Ouroboros.Consensus.HardFork.Combinator.State.Infra
+    Ouroboros.Consensus.HardFork.Combinator.State.Instances
+    Ouroboros.Consensus.HardFork.Combinator.State.Lift
+    Ouroboros.Consensus.HardFork.Combinator.State.Types
+    Ouroboros.Consensus.HardFork.Combinator.Translation
+    Ouroboros.Consensus.HardFork.History
+    Ouroboros.Consensus.HardFork.History.Caching
+    Ouroboros.Consensus.HardFork.History.EpochInfo
+    Ouroboros.Consensus.HardFork.History.EraParams
+    Ouroboros.Consensus.HardFork.History.Qry
+    Ouroboros.Consensus.HardFork.History.Summary
+    Ouroboros.Consensus.HardFork.History.Util
+    Ouroboros.Consensus.HardFork.Simple
+    Ouroboros.Consensus.HeaderStateHistory
+    Ouroboros.Consensus.HeaderValidation
+    Ouroboros.Consensus.Ledger.Abstract
+    Ouroboros.Consensus.Ledger.Basics
+    Ouroboros.Consensus.Ledger.CommonProtocolParams
+    Ouroboros.Consensus.Ledger.Dual
+    Ouroboros.Consensus.Ledger.Extended
+    Ouroboros.Consensus.Ledger.Inspect
+    Ouroboros.Consensus.Ledger.Query
+    Ouroboros.Consensus.Ledger.Query.Version
+    Ouroboros.Consensus.Ledger.SupportsMempool
+    Ouroboros.Consensus.Ledger.SupportsPeerSelection
+    Ouroboros.Consensus.Ledger.SupportsProtocol
+    Ouroboros.Consensus.Mempool
+    Ouroboros.Consensus.Mempool.API
+    Ouroboros.Consensus.Mempool.Capacity
+    Ouroboros.Consensus.Mempool.Impl.Common
+    Ouroboros.Consensus.Mempool.Init
+    Ouroboros.Consensus.Mempool.Query
+    Ouroboros.Consensus.Mempool.TxSeq
+    Ouroboros.Consensus.Mempool.Update
+    Ouroboros.Consensus.MiniProtocol.BlockFetch.ClientInterface
+    Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
+    Ouroboros.Consensus.MiniProtocol.ChainSync.Client
+    Ouroboros.Consensus.MiniProtocol.ChainSync.Client.InFutureCheck
+    Ouroboros.Consensus.MiniProtocol.ChainSync.Server
+    Ouroboros.Consensus.MiniProtocol.LocalStateQuery.Server
+    Ouroboros.Consensus.MiniProtocol.LocalTxMonitor.Server
+    Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
+    Ouroboros.Consensus.Node.InitStorage
+    Ouroboros.Consensus.Node.NetworkProtocolVersion
+    Ouroboros.Consensus.Node.ProtocolInfo
+    Ouroboros.Consensus.Node.Run
+    Ouroboros.Consensus.Node.Serialisation
+    Ouroboros.Consensus.NodeId
+    Ouroboros.Consensus.Protocol.Abstract
+    Ouroboros.Consensus.Protocol.BFT
+    Ouroboros.Consensus.Protocol.LeaderSchedule
+    Ouroboros.Consensus.Protocol.MockChainSel
+    Ouroboros.Consensus.Protocol.ModChainSel
+    Ouroboros.Consensus.Protocol.PBFT
+    Ouroboros.Consensus.Protocol.PBFT.Crypto
+    Ouroboros.Consensus.Protocol.PBFT.State
+    Ouroboros.Consensus.Protocol.Signed
+    Ouroboros.Consensus.Storage.ChainDB
+    Ouroboros.Consensus.Storage.ChainDB.API
+    Ouroboros.Consensus.Storage.ChainDB.API.Types.InvalidBlockPunishment
+    Ouroboros.Consensus.Storage.ChainDB.Impl
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Args
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Background
+    Ouroboros.Consensus.Storage.ChainDB.Impl.BlockCache
+    Ouroboros.Consensus.Storage.ChainDB.Impl.ChainSel
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Follower
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Iterator
+    Ouroboros.Consensus.Storage.ChainDB.Impl.LgrDB
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Paths
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Query
+    Ouroboros.Consensus.Storage.ChainDB.Impl.Types
+    Ouroboros.Consensus.Storage.ChainDB.Init
+    Ouroboros.Consensus.Storage.Common
+    Ouroboros.Consensus.Storage.ImmutableDB
+    Ouroboros.Consensus.Storage.ImmutableDB.API
+    Ouroboros.Consensus.Storage.ImmutableDB.Chunks
+    Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Internal
+    Ouroboros.Consensus.Storage.ImmutableDB.Chunks.Layout
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Cache
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Primary
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Index.Secondary
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Iterator
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Parser
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.State
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Util
+    Ouroboros.Consensus.Storage.ImmutableDB.Impl.Validation
+    Ouroboros.Consensus.Storage.LedgerDB
+    Ouroboros.Consensus.Storage.LedgerDB.DiskPolicy
+    Ouroboros.Consensus.Storage.LedgerDB.Init
+    Ouroboros.Consensus.Storage.LedgerDB.LedgerDB
+    Ouroboros.Consensus.Storage.LedgerDB.Query
+    Ouroboros.Consensus.Storage.LedgerDB.Snapshots
+    Ouroboros.Consensus.Storage.LedgerDB.Stream
+    Ouroboros.Consensus.Storage.LedgerDB.Update
+    Ouroboros.Consensus.Storage.Serialisation
+    Ouroboros.Consensus.Storage.VolatileDB
+    Ouroboros.Consensus.Storage.VolatileDB.API
+    Ouroboros.Consensus.Storage.VolatileDB.Impl
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.FileInfo
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.Index
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.Parser
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.State
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.Types
+    Ouroboros.Consensus.Storage.VolatileDB.Impl.Util
+    Ouroboros.Consensus.Ticked
+    Ouroboros.Consensus.TypeFamilyWrappers
+    Ouroboros.Consensus.Util
+    Ouroboros.Consensus.Util.AnchoredFragment
+    Ouroboros.Consensus.Util.Args
+    Ouroboros.Consensus.Util.Assert
+    Ouroboros.Consensus.Util.CallStack
+    Ouroboros.Consensus.Util.CBOR
+    Ouroboros.Consensus.Util.Condense
+    Ouroboros.Consensus.Util.DepPair
+    Ouroboros.Consensus.Util.EarlyExit
+    Ouroboros.Consensus.Util.Enclose
+    Ouroboros.Consensus.Util.FileLock
+    Ouroboros.Consensus.Util.HList
+    Ouroboros.Consensus.Util.IOLike
+    Ouroboros.Consensus.Util.MonadSTM.NormalForm
+    Ouroboros.Consensus.Util.MonadSTM.RAWLock
+    Ouroboros.Consensus.Util.MonadSTM.StrictSVar
+    Ouroboros.Consensus.Util.NormalForm.StrictMVar
+    Ouroboros.Consensus.Util.NormalForm.StrictTVar
+    Ouroboros.Consensus.Util.Orphans
+    Ouroboros.Consensus.Util.RedundantConstraints
+    Ouroboros.Consensus.Util.ResourceRegistry
+    Ouroboros.Consensus.Util.STM
+    Ouroboros.Consensus.Util.TentativeState
+    Ouroboros.Consensus.Util.Time
+    Ouroboros.Consensus.Util.TraceSize
+    Ouroboros.Consensus.Util.Versioned
+
+  build-depends:
+    , base                         >=4.14   && <4.20
+    , base16-bytestring
+    , bimap                        >=0.4    && <0.6
+    , binary                       >=0.8    && <0.11
+    , bytestring                   >=0.10   && <0.13
+    , cardano-binary
+    , cardano-crypto-class
+    , cardano-prelude
+    , cardano-slotting             ^>=0.1
+    , cardano-strict-containers
+    , cborg                        ^>=0.2.2
+    , containers                   >=0.5    && <0.7
+    , contra-tracer
+    , deepseq
+    , filelock
+    , fs-api                       ^>=0.2
+    , hashable
+    , io-classes                   ^>=1.4.1
+    , measures
+    , mtl
+    , nothunks                     ^>=0.1.5
+    , ouroboros-network-api        ^>=0.7
+    , ouroboros-network-mock       ^>=0.1
+    , ouroboros-network-protocols  ^>=0.8
+    , primitive
+    , psqueues                     ^>=0.2.3
+    , quiet                        ^>=0.2
+    , semialign                    >=1.1
+    , serialise                    ^>=0.2
+    , si-timers                    ^>=1.4
+    , sop-core                     ^>=0.5
+    , sop-extras                   ^>=0.1
+    , streaming
+    , strict-checked-vars          ^>=0.2
+    , strict-sop-core              ^>=0.1
+    , strict-stm                   ^>=1.4
+    , text
+    , these                        ^>=1.2
+    , time
+    , transformers
+    , typed-protocols              ^>=0.1.1
+    , vector                       ^>=0.13
+
+  -- GHC 8.10.7 on aarch64-darwin cannot use text-2
+  build-depends:   text >=1.2.5.0 && <2.2
+
+library unstable-consensus-testlib
+  import:          common-lib
+  visibility:      public
+  hs-source-dirs:  src/unstable-consensus-testlib
+  exposed-modules:
+    Test.Ouroboros.Consensus.ChainGenerator.Adversarial
+    Test.Ouroboros.Consensus.ChainGenerator.BitVector
+    Test.Ouroboros.Consensus.ChainGenerator.Counting
+    Test.Ouroboros.Consensus.ChainGenerator.Honest
+    Test.Ouroboros.Consensus.ChainGenerator.Params
+    Test.Ouroboros.Consensus.ChainGenerator.RaceIterator
+    Test.Ouroboros.Consensus.ChainGenerator.Slot
+    Test.Ouroboros.Consensus.ChainGenerator.Some
+    Test.QuickCheck.Extras
+    Test.Util.BoolProps
+    Test.Util.ChainDB
+    Test.Util.ChainUpdates
+    Test.Util.ChunkInfo
+    Test.Util.Corruption
+    Test.Util.FileLock
+    Test.Util.HardFork.Future
+    Test.Util.HardFork.OracularClock
+    Test.Util.InvertedMap
+    Test.Util.LogicalClock
+    Test.Util.MockChain
+    Test.Util.Orphans.Arbitrary
+    Test.Util.Orphans.IOLike
+    Test.Util.Orphans.NoThunks
+    Test.Util.Orphans.Serialise
+    Test.Util.Orphans.SignableRepresentation
+    Test.Util.Orphans.ToExpr
+    Test.Util.Paths
+    Test.Util.QSM
+    Test.Util.QuickCheck
+    Test.Util.Range
+    Test.Util.RefEnv
+    Test.Util.Schedule
+    Test.Util.Serialisation.Examples
+    Test.Util.Serialisation.Golden
+    Test.Util.Serialisation.Roundtrip
+    Test.Util.Serialisation.SomeResult
+    Test.Util.Shrink
+    Test.Util.Slots
+    Test.Util.SOP
+    Test.Util.Split
+    Test.Util.Stream
+    Test.Util.SupportedNetworkProtocolVersion
+    Test.Util.TestBlock
+    Test.Util.TestEnv
+    Test.Util.Time
+    Test.Util.ToExpr
+    Test.Util.Tracer
+    Test.Util.WithEq
+
+  build-depends:
+    , base
+    , base16-bytestring
+    , binary
+    , bytestring
+    , cardano-binary:testlib
+    , cardano-crypto-class
+    , cardano-prelude
+    , cardano-slotting:testlib
+    , cardano-strict-containers
+    , cborg
+    , constraints
+    , containers
+    , contra-tracer
+    , deepseq
+    , directory
+    , file-embed
+    , filepath
+    , fs-api                                         ^>=0.2
+    , fs-sim                                         ^>=0.2
+    , generics-sop
+    , io-classes
+    , io-sim
+    , mtl
+    , nothunks
+    , optparse-applicative
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , ouroboros-network-mock
+    , pretty-simple
+    , QuickCheck
+    , quickcheck-instances
+    , quickcheck-state-machine:no-vendored-treediff  ^>=0.9
+    , quiet
+    , random
+    , serialise
+    , sop-core
+    , sop-extras
+    , strict-checked-vars
+    , strict-sop-core
+    , tasty
+    , tasty-expected-failure
+    , tasty-golden
+    , tasty-hunit
+    , tasty-quickcheck
+    , template-haskell
+    , text
+    , time
+    , tree-diff
+    , utf8-string
+    , vector
+    , with-utf8
+
+library unstable-mock-block
+  import:          common-lib
+  visibility:      public
+  hs-source-dirs:  src/unstable-mock-block
+  exposed-modules:
+    Ouroboros.Consensus.Mock.Ledger
+    Ouroboros.Consensus.Mock.Ledger.Address
+    Ouroboros.Consensus.Mock.Ledger.Block
+    Ouroboros.Consensus.Mock.Ledger.Block.BFT
+    Ouroboros.Consensus.Mock.Ledger.Block.PBFT
+    Ouroboros.Consensus.Mock.Ledger.Block.Praos
+    Ouroboros.Consensus.Mock.Ledger.Block.PraosRule
+    Ouroboros.Consensus.Mock.Ledger.Forge
+    Ouroboros.Consensus.Mock.Ledger.Stake
+    Ouroboros.Consensus.Mock.Ledger.State
+    Ouroboros.Consensus.Mock.Ledger.UTxO
+    Ouroboros.Consensus.Mock.Node
+    Ouroboros.Consensus.Mock.Node.Abstract
+    Ouroboros.Consensus.Mock.Node.BFT
+    Ouroboros.Consensus.Mock.Node.PBFT
+    Ouroboros.Consensus.Mock.Node.Praos
+    Ouroboros.Consensus.Mock.Node.PraosRule
+    Ouroboros.Consensus.Mock.Node.Serialisation
+    Ouroboros.Consensus.Mock.Protocol.LeaderSchedule
+    Ouroboros.Consensus.Mock.Protocol.Praos
+
+  build-depends:
+    , base
+    , bimap
+    , bytestring
+    , cardano-binary
+    , cardano-crypto-class
+    , cardano-slotting
+    , cborg
+    , containers
+    , deepseq
+    , hashable
+    , mtl
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , ouroboros-network-mock
+    , serialise
+    , time
+    , unstable-consensus-testlib
+
+library unstable-mempool-test-utils
+  import:          common-lib
+  visibility:      public
+  hs-source-dirs:  src/unstable-mempool-test-utils
+  exposed-modules: Test.Consensus.Mempool.Mocked
+  build-depends:
+    , base
+    , contra-tracer
+    , deepseq
+    , ouroboros-consensus
+    , strict-stm
+
+library unstable-tutorials
+  import:         common-lib
+  visibility:     public
+  hs-source-dirs: src/unstable-tutorials
+  other-modules:
+    Ouroboros.Consensus.Tutorial.Simple
+    Ouroboros.Consensus.Tutorial.WithEpoch
+
+  build-depends:
+    , base
+    , containers
+    , hashable
+    , mtl
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , serialise
+
+test-suite consensus-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/consensus-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Consensus.BlockchainTime.Simple
+    Test.Consensus.HardFork.Forecast
+    Test.Consensus.HardFork.History
+    Test.Consensus.HardFork.Infra
+    Test.Consensus.HardFork.Summary
+    Test.Consensus.Mempool
+    Test.Consensus.Mempool.Fairness
+    Test.Consensus.Mempool.Fairness.TestBlock
+    Test.Consensus.MiniProtocol.BlockFetch.Client
+    Test.Consensus.MiniProtocol.ChainSync.Client
+    Test.Consensus.MiniProtocol.LocalStateQuery.Server
+    Test.Consensus.ResourceRegistry
+    Test.Consensus.Util.MonadSTM.NormalForm
+    Test.Consensus.Util.MonadSTM.RAWLock
+    Test.Consensus.Util.Versioned
+
+  build-depends:
+    , async
+    , base
+    , base-deriving-via
+    , cardano-binary
+    , cardano-crypto-class
+    , cardano-slotting
+    , cborg
+    , containers
+    , contra-tracer
+    , deepseq
+    , fs-api                                                              ^>=0.2
+    , generics-sop
+    , hashable
+    , io-classes
+    , io-sim
+    , mtl
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-network
+    , ouroboros-network-api
+    , ouroboros-network-mock
+    , ouroboros-network-protocols:{ouroboros-network-protocols, testlib}
+    , QuickCheck
+    , quickcheck-state-machine:no-vendored-treediff
+    , quiet
+    , random
+    , serialise
+    , si-timers
+    , sop-core
+    , sop-extras
+    , strict-sop-core
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , time
+    , tree-diff
+    , typed-protocols                                                     ^>=0.1.1
+    , typed-protocols-examples
+    , unstable-consensus-testlib
+    , unstable-mock-block
+
+test-suite infra-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/infra-test
+  main-is:        Main.hs
+  other-modules:
+    Ouroboros.Consensus.Util.Tests
+    Test.Ouroboros.Consensus.ChainGenerator.Tests
+    Test.Ouroboros.Consensus.ChainGenerator.Tests.Adversarial
+    Test.Ouroboros.Consensus.ChainGenerator.Tests.BitVector
+    Test.Ouroboros.Consensus.ChainGenerator.Tests.Counting
+    Test.Ouroboros.Consensus.ChainGenerator.Tests.Honest
+    Test.Util.ChainUpdates.Tests
+    Test.Util.Schedule.Tests
+    Test.Util.Split.Tests
+
+  build-depends:
+    , base
+    , mtl
+    , ouroboros-consensus:{ouroboros-consensus, unstable-consensus-testlib}
+    , QuickCheck
+    , random
+    , tasty
+    , tasty-quickcheck
+    , unstable-consensus-testlib
+    , vector
+
+test-suite storage-test
+  import:         common-test
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: test/storage-test
+  main-is:        Main.hs
+  other-modules:
+    Test.Ouroboros.Storage
+    Test.Ouroboros.Storage.ChainDB
+    Test.Ouroboros.Storage.ChainDB.FollowerPromptness
+    Test.Ouroboros.Storage.ChainDB.GcSchedule
+    Test.Ouroboros.Storage.ChainDB.Iterator
+    Test.Ouroboros.Storage.ChainDB.Model
+    Test.Ouroboros.Storage.ChainDB.Model.Test
+    Test.Ouroboros.Storage.ChainDB.Paths
+    Test.Ouroboros.Storage.ChainDB.StateMachine
+    Test.Ouroboros.Storage.ChainDB.StateMachine.Utils.RunOnRepl
+    Test.Ouroboros.Storage.ChainDB.Unit
+    Test.Ouroboros.Storage.ImmutableDB
+    Test.Ouroboros.Storage.ImmutableDB.Mock
+    Test.Ouroboros.Storage.ImmutableDB.Model
+    Test.Ouroboros.Storage.ImmutableDB.Primary
+    Test.Ouroboros.Storage.ImmutableDB.StateMachine
+    Test.Ouroboros.Storage.LedgerDB
+    Test.Ouroboros.Storage.LedgerDB.DiskPolicy
+    Test.Ouroboros.Storage.LedgerDB.InMemory
+    Test.Ouroboros.Storage.LedgerDB.OnDisk
+    Test.Ouroboros.Storage.LedgerDB.OrphanArbitrary
+    Test.Ouroboros.Storage.Orphans
+    Test.Ouroboros.Storage.TestBlock
+    Test.Ouroboros.Storage.VolatileDB
+    Test.Ouroboros.Storage.VolatileDB.Mock
+    Test.Ouroboros.Storage.VolatileDB.Model
+    Test.Ouroboros.Storage.VolatileDB.StateMachine
+
+  build-depends:
+    , base
+    , bifunctors
+    , binary
+    , bytestring
+    , cardano-crypto-class
+    , cardano-slotting
+    , cborg
+    , containers
+    , contra-tracer
+    , fs-api                                         ^>=0.2
+    , fs-sim                                         ^>=0.2
+    , generics-sop
+    , hashable
+    , io-classes
+    , io-sim
+    , mtl
+    , nothunks
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , ouroboros-network-mock
+    , pretty-show
+    , QuickCheck
+    , quickcheck-state-machine:no-vendored-treediff  ^>=0.9
+    , random
+    , serialise
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , text
+    , time
+    , transformers
+    , tree-diff
+    , unstable-consensus-testlib
+    , vector
+
+benchmark mempool-bench
+  import:         common-bench
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: bench/mempool-bench
+  main-is:        Main.hs
+  other-modules:
+    Bench.Consensus.Mempool
+    Bench.Consensus.Mempool.TestBlock
+
+  build-depends:
+    , aeson
+    , base
+    , bytestring
+    , cardano-slotting
+    , cassava
+    , containers
+    , contra-tracer
+    , deepseq
+    , nothunks
+    , ouroboros-consensus
+    , serialise
+    , tasty
+    , tasty-bench
+    , tasty-hunit
+    , text
+    , transformers
+    , tree-diff
+    , unstable-consensus-testlib
+    , unstable-mempool-test-utils
+    , with-utf8
+
+benchmark ChainSync-client-bench
+  import:         common-bench
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: bench/ChainSync-client-bench
+  main-is:        Main.hs
+  other-modules:  Bench.Consensus.ChainSyncClient.Driver
+  build-depends:
+    , array
+    , base
+    , cardano-crypto-class
+    , containers
+    , contra-tracer
+    , ouroboros-consensus
+    , ouroboros-network-api
+    , ouroboros-network-protocols
+    , time
+    , typed-protocols-examples
+    , unstable-consensus-testlib
+    , with-utf8


### PR DESCRIPTION
Note that this is a **backport release**, see https://github.com/IntersectMBO/ouroboros-consensus/pull/1042, 0.13.0.0 is still the latest and greatest. (We might change our versioning scheme in the future to make that more clear.)