### PR TITLE
Add --allow-boot-library-installs to CI

### DIFF
--- a/nix/builder.nix
+++ b/nix/builder.nix
@@ -37,6 +37,7 @@ let
           secure: True
 
         extra-packages: ${package-id}
+        allow-boot-library-installs: True
       '';
 
       modules = [{


### PR DESCRIPTION
This tries to reduce the divergences between Haskell.nix and
cabal-install, as they can cause issues (e.g. Haskell.nix reinstall ghc
by default, assuming that Cabal is in the plan, which it might not be).
