### PR TITLE
Include `constraints: ghc source` when planning

### DIFF
--- a/nix/builder.nix
+++ b/nix/builder.nix
@@ -37,7 +37,10 @@ let
           secure: True
 
         extra-packages: ${package-id}
+        constraints: ghc source
+        allow-newer: ghc:Cabal
       '';
+      configureArgs = "--allow-boot-library-installs";
 
       modules = [{
         postHaddock = ''


### PR DESCRIPTION
This tries to reduce the divergences between Haskell.nix and
cabal-install, as they can cause issues (e.g. Haskell.nix reinstall ghc
by default, assuming that Cabal is in the plan, which it might not be).