### PR TITLE
Force Cabal to be in the plan

### DIFF
--- a/nix/builder.nix
+++ b/nix/builder.nix
@@ -37,6 +37,10 @@ let
           secure: True
 
         extra-packages: ${package-id}
+        if impl(ghc <9.9)
+          extra-packages: Cabal <3.11
+        else
+          extra-packages: Cabal
       '';
 
       modules = [{


### PR DESCRIPTION
This tries to reduce the divergences between Haskell.nix and
cabal-install, as they can cause issues (e.g. Haskell.nix reinstall ghc
by default, assuming that Cabal is in the plan, which it might not be).