### PR TITLE
Revise set-algebra 1.1.0.2

### DIFF
--- a/_sources/set-algebra/1.1.0.2/meta.toml
+++ b/_sources/set-algebra/1.1.0.2/meta.toml
@@ -1,3 +1,8 @@
 timestamp = 2024-01-26T10:34:07Z
 github = { repo = "IntersectMBO/cardano-ledger", rev = "6e2d37cc0f47bd02e89b4ce9f78b59c35c958e96" }
 subdir = 'libs/set-algebra'
+
+[[revisions]]
+number = 1
+timestamp = 2024-05-29T10:00:00Z
+

--- a/_sources/set-algebra/1.1.0.2/revisions/1.cabal
+++ b/_sources/set-algebra/1.1.0.2/revisions/1.cabal
@@ -1,0 +1,60 @@
+cabal-version:      3.0
+name:               set-algebra
+version:            1.1.0.2
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+homepage:           https://github.com/intersectmbo/cardano-ledger
+synopsis:           Set Algebra
+category:           Control
+build-type:         Simple
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/set-algebra
+
+library
+    exposed-modules:
+        Control.Iterate.BaseTypes
+        Control.Iterate.Collect
+        Control.Iterate.Exp
+        Control.Iterate.SetAlgebra
+        Control.SetAlgebra
+
+    hs-source-dirs:   src
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        ansi-wl-pprint,
+        cardano-data >=1.1,
+        containers
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Control.Iterate.SetAlgebra
+        Test.Control.Iterate.RelationReference
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded
+
+    build-depends:
+        base,
+        containers,
+        set-algebra,
+        tasty,
+        tasty-hunit,
+        tasty-quickcheck,
+        cardano-data
+


### PR DESCRIPTION
Removes the upper bound on `ansi-wl-pprint`. This allows to use the latest versions which are shims to  `prettyprinter`.

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
