### PR TITLE
Add quick script for listing latest versions and revs

### DIFF
--- a/scripts/list-latest-package-revs.sh
+++ b/scripts/list-latest-package-revs.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+declare -A repos
+
+is_version_more_recent() {
+  local version1=$1
+  local version2=$2
+
+  # Split version numbers into arrays
+  IFS='.' read -ra v1_parts <<< "$version1"
+  IFS='.' read -ra v2_parts <<< "$version2"
+
+  # Compare version parts
+  local i=0
+  while [[ $i -lt ${#v1_parts[@]} || $i -lt ${#v2_parts[@]} ]]; do
+    local part1="${v1_parts[$i]}"
+    local part2="${v2_parts[$i]}"
+
+    # If one part is missing in one of the versions, consider it as zero
+    part1=${part1:-0}
+    part2=${part2:-0}
+
+    if (( part1 > part2 )); then
+      return 0
+    elif (( part1 < part2 )); then
+      return 1
+    fi
+
+    ((i++))
+  done
+
+  # If we reached here, versions are equal
+  return 1
+}
+
+# Find all meta.toml files
+while IFS= read -r toml; do
+  # Extract information from each meta.toml (we use grep for efficiency)
+  repo=$(grep -oP '(?<=repo = ")[^"]+' "$toml")
+  rev=$(grep -oP '(?<=rev = ")[^"]+' "$toml")
+  subdir=$(grep -oP "(?<=subdir = ')[^']+" "$toml")
+  version=$(basename "$(dirname "$toml")")
+
+  # Remove trailing "/" from repo and subdir if it exists
+  repo="${repo%/}"
+  subdir="${subdir%/}"
+
+  # Sanitise repo and subdir names and convert to lowercase
+  repo_sanitized=$(echo "$repo" | tr '/' '_' | tr '[:upper:]' '[:lower:]')
+  subdir_sanitized=$(echo "$subdir" | tr '/' '_' | tr '[:upper:]' '[:lower:]')
+
+  # Store information in an associative array
+  key="${repo_sanitized}_${subdir_sanitized}"
+
+  # Use associative array to keep track of latest version
+  if [[ ! -v "repos[$key]" ]];
+  then
+    repos[$key]="$repo $version $rev $subdir"
+  else
+    latestVersion=$(echo "${repos[$key]}" | awk '{print $2}')
+    if is_version_more_recent "$version" "$latestVersion";
+    then
+      repos[$key]="$repo $version $rev $subdir"
+    fi
+  fi
+done < <(find _sources -name "meta.toml")
+
+for key in "${!repos[@]}"; do
+  echo "${repos[$key]}"
+done
+
+


### PR DESCRIPTION
This PR adds a standalone bash script `list-latest-package-revs.sh` for listing the latest versions for packages, their repos, their subdir, and their commit, separated by space.

Unlike `list-latest-package-versions.sh`, this script doesn't require to build the whole `folliage` database, and only relies on the `_sources` directory.

The reason I think this is useful is for manually querying without having to wait and without requiring lots of disk space. And the motivation was that I was considering generating a dependency graph of projects, so this would serve as a first step in that direction.

This is the beginning of the current output:

```bash
$ scripts/list-latest-package-revs.sh | sort
erikd/vector-algorithms 0.9.0.1.0.0.0.0.1 e3fc242ac75d928ca613be9702ff2946011ef7d4 
haskell-servant/servant 0.19.2.0.0.0.0.1 58aa0d1c0c19f7b1c26ffc52bfd65c70934704c9 servant-server
haskell-streaming/streaming 0.2.3.1.0.0.0.0.1 0c815bf9043d0f0cbda92b80ef791892e2b7fb43 
hedgehogqa/haskell-hedgehog 1.2.0.0.0.0.1 70cf9fd0719e2d0ace1093cbe75673d7b9b4cf65 hedgehog
input-output-hk/anti-diffs 0.1.0.0 f3dcc3beedc55b6bae45e1faff91321c16e4ef86 simple-semigroupoids
input-output-hk/anti-diffs 1.0.0.2 18d0b7d8a690b56aba417b8bee5408ca2987b264 fingertree-rm
input-output-hk/anti-diffs 1.2.0.0 353e0cc86e1aeeffa95821253158376065ac653a diff-containers
input-output-hk/bech32 1.1.4.1 c938472efd2b72ecbbb1e323993142b6d360566a bech32
input-output-hk/cardano-api 8.2.0.0 9183a6751acd1506cf86ec2898306837bda80b2d cardano-api-gen
input-output-hk/cardano-api 8.43.0.0 3999f41ce79a0904b9fbd78afca74bbd36f8c811 cardano-api
input-output-hk/cardano-base 0.1.0.0 0f3a867493059e650cda69e20a5cbf1ace289a57 strict-containers
input-output-hk/cardano-base 0.1.0.2 56a71b150b7ff7fb6d6bf588f3e9d88822c9048c base-deriving-via
input-output-hk/cardano-base 0.1.0.2 56a71b150b7ff7fb6d6bf588f3e9d88822c9048c heapwords
input-output-hk/cardano-base 0.1.0.2 56a71b150b7ff7fb6d6bf588f3e9d88822c9048c measures
input-output-hk/cardano-base 0.1.0.2 56a71b150b7ff7fb6d6bf588f3e9d88822c9048c orphans-deriving-via
input-output-hk/cardano-base 0.1.0.2 b5f2941d003398b77f9b3d1b43a9cebb8a4515fd slotting
input-output-hk/cardano-base 0.1.2.0 ca78a7ca7f91ed0f14dab244426432aae90c698b cardano-slotting
...
```