### PR TITLE
Added Win32-network-0.2.0.0

### DIFF
--- a/_sources/Win32-network/0.2.0.0/meta.toml
+++ b/_sources/Win32-network/0.2.0.0/meta.toml
@@ -1,0 +1,2 @@
+timestamp = 2024-06-04T16:16:15Z
+github = { repo = "IntersectMBO/Win32-network", rev = "cd5ab6ae6e24e059bd01a3aacc7601ab1f01b72c" }


### PR DESCRIPTION
From https://github.com/IntersectMBO/Win32-network at cd5ab6ae6e24e059bd01a3aacc7601ab1f01b72c

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
