### PR TITLE
Revisions for bumping `io-classes` to `1.6` in `fs-api-0.2.0.1` and `fs-sim-0.2.1.1`

### DIFF
--- a/_sources/fs-api/0.2.0.1/meta.toml
+++ b/_sources/fs-api/0.2.0.1/meta.toml
@@ -5,3 +5,7 @@ subdir = 'fs-api'
 [[revisions]]
 number = 1
 timestamp = 2024-02-23T10:34:09Z
+
+[[revisions]]
+number = 2
+timestamp = 2024-06-06T15:27:49Z

--- a/_sources/fs-api/0.2.0.1/revisions/2.cabal
+++ b/_sources/fs-api/0.2.0.1/revisions/2.cabal
@@ -1,0 +1,68 @@
+cabal-version:   3.0
+name:            fs-api
+version:         0.2.0.1
+synopsis:        API for file systems
+description:     API for file systems.
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+copyright:       2019-2023 Input Output Global Inc (IOG)
+author:          IOG Engineering Team
+maintainer:      operations@iohk.io
+category:        System
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+tested-with:     GHC ==8.10 || ==9.2 || ==9.4 || ==9.6
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/fs-sim
+  subdir:   fs-api
+
+library
+  hs-source-dirs:   src
+
+  if os(windows)
+    hs-source-dirs: src-win32
+
+  else
+    hs-source-dirs: src-unix
+
+  exposed-modules:
+    System.FS.API
+    System.FS.API.Lazy
+    System.FS.API.Strict
+    System.FS.API.Types
+    System.FS.CRC
+    System.FS.IO
+    System.FS.IO.Internal
+    System.FS.IO.Internal.Handle
+    Util.CallStack
+    Util.Condense
+
+  default-language: Haskell2010
+  build-depends:
+    , base        >=4.14 && <4.20
+    , bytestring  >=0.10 && <0.13
+    , containers  >=0.5  && <0.7
+    , deepseq
+    , digest
+    , directory   >=1.3  && <1.4
+    , filepath    >=1.4  && <1.5
+    , io-classes  >=0.3  && <1.6
+    , text        >=1.2  && <2.2
+
+  if os(windows)
+    build-depends: Win32 >=2.6.1.0
+
+  else
+    build-depends:
+      , unix
+      , unix-bytestring  >=0.4.0
+
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages

--- a/_sources/fs-sim/0.2.1.1/meta.toml
+++ b/_sources/fs-sim/0.2.1.1/meta.toml
@@ -5,3 +5,7 @@ subdir = 'fs-sim'
 [[revisions]]
 number = 1
 timestamp = 2024-02-23T09:48:23Z
+
+[[revisions]]
+number = 2
+timestamp = 2024-06-06T15:28:08Z

--- a/_sources/fs-sim/0.2.1.1/revisions/2.cabal
+++ b/_sources/fs-sim/0.2.1.1/revisions/2.cabal
@@ -1,0 +1,85 @@
+cabal-version:   3.0
+name:            fs-sim
+version:         0.2.1.1
+synopsis:        Simulated file systems
+description:     Simulated file systems.
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+copyright:       2019-2023 Input Output Global Inc (IOG)
+author:          IOG Engineering Team
+maintainer:      operations@iohk.io
+category:        Testing
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+tested-with:     GHC ==8.10 || ==9.2 || ==9.4 || ==9.6 || ==9.8
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/fs-sim
+  subdir:   fs-sim
+
+library
+  hs-source-dirs:   src
+  exposed-modules:
+    System.FS.Sim.Error
+    System.FS.Sim.FsTree
+    System.FS.Sim.MockFS
+    System.FS.Sim.Pure
+    System.FS.Sim.STM
+    System.FS.Sim.Stream
+
+  default-language: Haskell2010
+  build-depends:
+    , base               >=4.14 && <4.20
+    , base16-bytestring
+    , bytestring         >=0.10 && <0.13
+    , containers         >=0.5  && <0.7
+    , fs-api             ^>=0.2
+    , io-classes         >=0.3  && <1.6
+    , mtl
+    , QuickCheck
+    , strict-stm         >=0.3  && <1.6
+    , text               >=1.2  && <2.2
+
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+
+test-suite fs-sim-test
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test
+  main-is:          Main.hs
+  other-modules:
+    Test.System.FS.Sim.FsTree
+    Test.System.FS.StateMachine
+    Test.Util.RefEnv
+
+  default-language: Haskell2010
+  build-depends:
+    , base
+    , bifunctors
+    , bytestring
+    , containers
+    , fs-api
+    , fs-sim
+    , generics-sop
+    , pretty-show
+    , QuickCheck
+    , quickcheck-state-machine  >=0.7.2 && <0.8
+    , random
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , temporary
+    , text
+    , tree-diff
+
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wpartial-fields -Widentities
+    -Wredundant-constraints -Wmissing-export-lists -Wunused-packages
+    -fno-ignore-asserts


### PR DESCRIPTION
<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
