### PR TITLE
Ledger release 8.12

### DIFF
--- a/_sources/cardano-ledger-allegra/1.5.0.0/meta.toml
+++ b/_sources/cardano-ledger-allegra/1.5.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-18T12:42:43Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "923e75bf3e16da01f26ed1ab53d9aac7184fc699" }
+subdir = 'eras/allegra/impl'

--- a/_sources/cardano-ledger-alonzo-test/1.2.1.2/meta.toml
+++ b/_sources/cardano-ledger-alonzo-test/1.2.1.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-18T12:42:43Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "923e75bf3e16da01f26ed1ab53d9aac7184fc699" }
+subdir = 'eras/alonzo/test-suite'

--- a/_sources/cardano-ledger-alonzo/1.9.0.0/meta.toml
+++ b/_sources/cardano-ledger-alonzo/1.9.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-18T12:42:43Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "923e75bf3e16da01f26ed1ab53d9aac7184fc699" }
+subdir = 'eras/alonzo/impl'

--- a/_sources/cardano-ledger-api/1.9.2.0/meta.toml
+++ b/_sources/cardano-ledger-api/1.9.2.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-18T12:42:43Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "923e75bf3e16da01f26ed1ab53d9aac7184fc699" }
+subdir = 'libs/cardano-ledger-api'

--- a/_sources/cardano-ledger-babbage-test/1.2.0.3/meta.toml
+++ b/_sources/cardano-ledger-babbage-test/1.2.0.3/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-18T12:42:43Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "923e75bf3e16da01f26ed1ab53d9aac7184fc699" }
+subdir = 'eras/babbage/test-suite'

--- a/_sources/cardano-ledger-babbage/1.8.1.0/meta.toml
+++ b/_sources/cardano-ledger-babbage/1.8.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-18T12:42:43Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "923e75bf3e16da01f26ed1ab53d9aac7184fc699" }
+subdir = 'eras/babbage/impl'

--- a/_sources/cardano-ledger-binary/1.3.3.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.3.3.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-18T12:42:43Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "923e75bf3e16da01f26ed1ab53d9aac7184fc699" }
+subdir = 'libs/cardano-ledger-binary'

--- a/_sources/cardano-ledger-byron-test/1.5.1.1/meta.toml
+++ b/_sources/cardano-ledger-byron-test/1.5.1.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-18T12:42:43Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "923e75bf3e16da01f26ed1ab53d9aac7184fc699" }
+subdir = 'eras/byron/ledger/impl/test'

--- a/_sources/cardano-ledger-conway-test/1.2.1.6/meta.toml
+++ b/_sources/cardano-ledger-conway-test/1.2.1.6/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-18T12:42:43Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "923e75bf3e16da01f26ed1ab53d9aac7184fc699" }
+subdir = 'eras/conway/test-suite'

--- a/_sources/cardano-ledger-conway/1.15.0.0/meta.toml
+++ b/_sources/cardano-ledger-conway/1.15.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-18T12:42:43Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "923e75bf3e16da01f26ed1ab53d9aac7184fc699" }
+subdir = 'eras/conway/impl'

--- a/_sources/cardano-ledger-core/1.13.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.13.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-18T12:42:43Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "923e75bf3e16da01f26ed1ab53d9aac7184fc699" }
+subdir = 'libs/cardano-ledger-core'

--- a/_sources/cardano-ledger-mary/1.6.1.0/meta.toml
+++ b/_sources/cardano-ledger-mary/1.6.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-18T12:42:43Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "923e75bf3e16da01f26ed1ab53d9aac7184fc699" }
+subdir = 'eras/mary/impl'

--- a/_sources/cardano-ledger-shelley-ma-test/1.2.2.2/meta.toml
+++ b/_sources/cardano-ledger-shelley-ma-test/1.2.2.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-18T12:42:43Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "923e75bf3e16da01f26ed1ab53d9aac7184fc699" }
+subdir = 'eras/shelley-ma/test-suite'

--- a/_sources/cardano-ledger-shelley-test/1.4.0.2/meta.toml
+++ b/_sources/cardano-ledger-shelley-test/1.4.0.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-18T12:42:43Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "923e75bf3e16da01f26ed1ab53d9aac7184fc699" }
+subdir = 'eras/shelley/test-suite'

--- a/_sources/cardano-ledger-shelley/1.12.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley/1.12.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-18T12:42:43Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "923e75bf3e16da01f26ed1ab53d9aac7184fc699" }
+subdir = 'eras/shelley/impl'

--- a/_sources/cardano-protocol-tpraos/1.2.0.1/meta.toml
+++ b/_sources/cardano-protocol-tpraos/1.2.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-18T12:42:43Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "923e75bf3e16da01f26ed1ab53d9aac7184fc699" }
+subdir = 'libs/cardano-protocol-tpraos'

--- a/_sources/set-algebra/1.1.0.3/meta.toml
+++ b/_sources/set-algebra/1.1.0.3/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-18T12:42:43Z
+github = { repo = "input-output-hk/cardano-ledger", rev = "923e75bf3e16da01f26ed1ab53d9aac7184fc699" }
+subdir = 'libs/set-algebra'

--- a/flake.nix
+++ b/flake.nix
@@ -248,6 +248,7 @@
                 cardano-ledger-alonzo.doHaddock = false;
                 cardano-ledger-api.doHaddock = false;
                 cardano-ledger-conway.doHaddock = false;
+                cardano-ledger-core.doHaddock = false;
                 cardano-ledger-babbage.doHaddock = false;
                 cardano-ledger-shelley.doHaddock = false;
                 cardano-protocol-tpraos.doHaddock = false;


### PR DESCRIPTION
~Ledger containing CIP-0069 changes, but NOT the plutus update. I opened the PR in order to see and fix any problems.
So we should not merge until the latter is in as well.~

CIP-0069 and plutus update to 1.30. 
Can be merged after this is merged into ledger: https://github.com/IntersectMBO/cardano-ledger/pull/4409
<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
