### PR TITLE
Release Consensus packages for Node 8.12

### DIFF
--- a/_sources/ouroboros-consensus-cardano/0.17.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-cardano/0.17.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-19T09:05:06Z
+github = { repo = "input-output-hk/ouroboros-consensus", rev = "f4c0208fcc5dda5ff190ab33744a1739b5d3575c" }
+subdir = 'ouroboros-consensus-cardano'

--- a/_sources/ouroboros-consensus-diffusion/0.17.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-diffusion/0.17.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-19T09:05:06Z
+github = { repo = "input-output-hk/ouroboros-consensus", rev = "f4c0208fcc5dda5ff190ab33744a1739b5d3575c" }
+subdir = 'ouroboros-consensus-diffusion'

--- a/_sources/ouroboros-consensus-protocol/0.9.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-protocol/0.9.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-19T09:05:06Z
+github = { repo = "input-output-hk/ouroboros-consensus", rev = "f4c0208fcc5dda5ff190ab33744a1739b5d3575c" }
+subdir = 'ouroboros-consensus-protocol'

--- a/_sources/ouroboros-consensus/0.19.0.0/meta.toml
+++ b/_sources/ouroboros-consensus/0.19.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-19T09:05:06Z
+github = { repo = "input-output-hk/ouroboros-consensus", rev = "f4c0208fcc5dda5ff190ab33744a1739b5d3575c" }
+subdir = 'ouroboros-consensus'

--- a/flake.nix
+++ b/flake.nix
@@ -253,6 +253,7 @@
                 cardano-ledger-shelley.doHaddock = false;
                 cardano-protocol-tpraos.doHaddock = false;
                 ouroboros-network.doHaddock = false;
+                ouroboros-consensus.doHaddock = false;
                 ouroboros-consensus-cardano.doHaddock = false;
               };
             }


### PR DESCRIPTION
Depends on https://github.com/IntersectMBO/ouroboros-consensus/pull/1151

| Package | Old version | New version |
| --- | :-: | :-: |
| `ouroboros-consensus` | `0.18.0.0` | `0.19.0.0` |
| `ouroboros-consensus-diffusion` | `0.16.0.0` | `0.17.0.0`|
| `ouroboros-consensus-protocol` | `0.9.0.0` | `0.9.0.1` |
| `ouroboros-consensus-cardano` | `0.16.0.0` | `0.17.0.0` |