### PR TITLE
Backport ledger release for node 8.9.4

### DIFF
--- a/_sources/cardano-ledger-babbage/1.6.1.0/meta.toml
+++ b/_sources/cardano-ledger-babbage/1.6.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-27T00:48:39Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "0e648203ad14faee7e6b0e7c64849872b942a900" }
+subdir = 'eras/babbage/impl'

--- a/_sources/cardano-ledger-conway/1.12.1.0/meta.toml
+++ b/_sources/cardano-ledger-conway/1.12.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-27T00:48:39Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "0e648203ad14faee7e6b0e7c64849872b942a900" }
+subdir = 'eras/conway/impl'

--- a/_sources/small-steps-test/0.1.0.0/meta.toml
+++ b/_sources/small-steps-test/0.1.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-10-17T00:00:00Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "c7c63dabdb215ebdaed8b63274965966f2bf408f" }
 subdir = 'libs/small-steps-test'
+
+[[revisions]]
+number = 1
+timestamp = 2024-06-27T01:45:40Z

--- a/_sources/small-steps-test/0.1.0.0/revisions/1.cabal
+++ b/_sources/small-steps-test/0.1.0.0/revisions/1.cabal
@@ -1,0 +1,81 @@
+cabal-version: 2.2
+
+name:                small-steps-test
+version:             0.1.0.0
+synopsis:            Small step semantics testing library
+homepage:            https://github.com/input-output-hk/cardano-legder-specs
+license:             Apache-2.0
+author:              IOHK Formal Methods Team
+maintainer:          formal.methods@iohk.io
+category:            Control
+build-type:          Simple
+extra-source-files:
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/cardano-ledger
+  subdir:   libs/small-steps-test
+
+common base
+  build-depends:      base >= 4.12 && < 4.15
+
+common project-config
+  default-language:   Haskell2010
+
+  ghc-options:        -Wall
+                      -Wcompat
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wredundant-constraints
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+
+  exposed-modules:     Control.State.Transition.Invalid.Trace
+                     , Control.State.Transition.Generator
+                     , Control.State.Transition.Trace
+                     , Control.State.Transition.Trace.Generator.QuickCheck
+                     , Hedgehog.Extra.Manual
+  build-depends:       goblins
+                     , deepseq
+                     , hedgehog >= 1.0.4
+                     , tasty-hunit
+                     , microlens
+                     , microlens-th
+                     , mtl
+                     , nothunks
+                     , transformers >= 0.5
+                     , QuickCheck
+                     -- IOHK deps
+                     , small-steps ^>= 0.1
+                     , strict-containers
+  hs-source-dirs:      src
+
+test-suite examples
+  import:             base, project-config
+
+  hs-source-dirs:      test
+  main-is:             examples/Main.hs
+  other-modules:       Control.State.Transition.Examples.Sum
+  other-modules:       Control.State.Transition.Examples.GlobalSum
+                     , Control.State.Transition.Examples.CommitReveal
+  type:                exitcode-stdio-1.0
+  default-language:    Haskell2010
+  build-depends:       containers
+                     , hedgehog >= 1.0.4
+                     , mtl
+                     , tasty
+                     , tasty-hedgehog
+                     , tasty-expected-failure
+                     , QuickCheck
+                     , tasty-quickcheck
+                     , tasty-hunit
+                     , Unique
+                     -- IOHK deps
+                     , cardano-crypto-class
+                     , cardano-binary
+                     -- Local deps
+                     , small-steps
+                     , small-steps-test
+  ghc-options:        -threaded

--- a/_sources/small-steps-test/0.1.1.1/meta.toml
+++ b/_sources/small-steps-test/0.1.1.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-11-11T00:24:50Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "2fac95ef338ff9622543d08fe16d0fa6716d0019" }
 subdir = 'libs/small-steps-test'
+
+[[revisions]]
+number = 1
+timestamp = 2024-06-27T01:45:35Z

--- a/_sources/small-steps-test/0.1.1.1/revisions/1.cabal
+++ b/_sources/small-steps-test/0.1.1.1/revisions/1.cabal
@@ -1,0 +1,81 @@
+cabal-version: 2.2
+
+name:                small-steps-test
+version:             0.1.1.1
+synopsis:            Small step semantics testing library
+homepage:            https://github.com/input-output-hk/cardano-legder-specs
+license:             Apache-2.0
+author:              IOHK Formal Methods Team
+maintainer:          formal.methods@iohk.io
+category:            Control
+build-type:          Simple
+extra-source-files:
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/cardano-ledger
+  subdir:   libs/small-steps-test
+
+common base
+  build-depends:      base >= 4.12 && < 4.15
+
+common project-config
+  default-language:   Haskell2010
+
+  ghc-options:        -Wall
+                      -Wcompat
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wredundant-constraints
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+
+  exposed-modules:     Control.State.Transition.Invalid.Trace
+                     , Control.State.Transition.Generator
+                     , Control.State.Transition.Trace
+                     , Control.State.Transition.Trace.Generator.QuickCheck
+                     , Hedgehog.Extra.Manual
+  build-depends:       goblins
+                     , deepseq
+                     , hedgehog >= 1.0.4
+                     , tasty-hunit
+                     , microlens
+                     , microlens-th
+                     , mtl
+                     , nothunks
+                     , transformers >= 0.5
+                     , QuickCheck
+                     -- IOHK deps
+                     , small-steps ^>= 0.1
+                     , cardano-strict-containers
+  hs-source-dirs:      src
+
+test-suite examples
+  import:             base, project-config
+
+  hs-source-dirs:      test
+  main-is:             examples/Main.hs
+  other-modules:       Control.State.Transition.Examples.Sum
+  other-modules:       Control.State.Transition.Examples.GlobalSum
+                     , Control.State.Transition.Examples.CommitReveal
+  type:                exitcode-stdio-1.0
+  default-language:    Haskell2010
+  build-depends:       containers
+                     , hedgehog >= 1.0.4
+                     , mtl
+                     , tasty
+                     , tasty-hedgehog
+                     , tasty-expected-failure
+                     , QuickCheck
+                     , tasty-quickcheck
+                     , tasty-hunit
+                     , Unique
+                     -- IOHK deps
+                     , cardano-crypto-class
+                     , cardano-binary
+                     -- Local deps
+                     , small-steps
+                     , small-steps-test
+  ghc-options:        -threaded

--- a/_sources/small-steps-test/0.1.1.2/meta.toml
+++ b/_sources/small-steps-test/0.1.1.2/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-11-14T13:25:11Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "760a73e89ef040d3ad91b4b0386b3bbace9431a9" }
 subdir = 'libs/small-steps-test'
+
+[[revisions]]
+number = 1
+timestamp = 2024-06-27T01:45:32Z

--- a/_sources/small-steps-test/0.1.1.2/revisions/1.cabal
+++ b/_sources/small-steps-test/0.1.1.2/revisions/1.cabal
@@ -1,0 +1,81 @@
+cabal-version: 2.2
+
+name:                small-steps-test
+version:             0.1.1.2
+synopsis:            Small step semantics testing library
+homepage:            https://github.com/input-output-hk/cardano-legder-specs
+license:             Apache-2.0
+author:              IOHK Formal Methods Team
+maintainer:          formal.methods@iohk.io
+category:            Control
+build-type:          Simple
+extra-source-files:
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/cardano-ledger
+  subdir:   libs/small-steps-test
+
+common base
+  build-depends:      base >= 4.12 && < 4.17
+
+common project-config
+  default-language:   Haskell2010
+
+  ghc-options:        -Wall
+                      -Wcompat
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wredundant-constraints
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+
+  exposed-modules:     Control.State.Transition.Invalid.Trace
+                     , Control.State.Transition.Generator
+                     , Control.State.Transition.Trace
+                     , Control.State.Transition.Trace.Generator.QuickCheck
+                     , Hedgehog.Extra.Manual
+  build-depends:       goblins
+                     , deepseq
+                     , hedgehog >= 1.0.4
+                     , tasty-hunit
+                     , microlens
+                     , microlens-th
+                     , mtl
+                     , nothunks
+                     , transformers >= 0.5
+                     , QuickCheck
+                     -- IOHK deps
+                     , small-steps ^>= 0.1
+                     , cardano-strict-containers
+  hs-source-dirs:      src
+
+test-suite examples
+  import:             base, project-config
+
+  hs-source-dirs:      test
+  main-is:             examples/Main.hs
+  other-modules:       Control.State.Transition.Examples.Sum
+  other-modules:       Control.State.Transition.Examples.GlobalSum
+                     , Control.State.Transition.Examples.CommitReveal
+  type:                exitcode-stdio-1.0
+  default-language:    Haskell2010
+  build-depends:       containers
+                     , hedgehog >= 1.0.4
+                     , mtl
+                     , tasty
+                     , tasty-hedgehog
+                     , tasty-expected-failure
+                     , QuickCheck
+                     , tasty-quickcheck
+                     , tasty-hunit
+                     , Unique
+                     -- IOHK deps
+                     , cardano-crypto-class
+                     , cardano-binary
+                     -- Local deps
+                     , small-steps
+                     , small-steps-test
+  ghc-options:        -threaded

--- a/_sources/small-steps-test/1.0.0.0/meta.toml
+++ b/_sources/small-steps-test/1.0.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-02-23T15:33:46Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "2f5956038233e4df0a065d96db32398605603f9b" }
 subdir = 'libs/small-steps-test'
+
+[[revisions]]
+number = 1
+timestamp = 2024-06-27T01:44:52Z

--- a/_sources/small-steps-test/1.0.0.0/revisions/1.cabal
+++ b/_sources/small-steps-test/1.0.0.0/revisions/1.cabal
@@ -1,0 +1,76 @@
+cabal-version: 3.0
+name:          small-steps-test
+version:       1.0.0.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/input-output-hk/cardano-ledger
+synopsis:      Small step semantics testing library
+category:      Control
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/small-steps-test
+
+library
+    exposed-modules:
+        Control.State.Transition.Invalid.Trace
+        Control.State.Transition.Generator
+        Control.State.Transition.Trace
+        Control.State.Transition.Trace.Generator.QuickCheck
+        Hedgehog.Extra.Manual
+
+    hs-source-dirs:   src
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.12 && <4.17,
+        deepseq,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        hedgehog >=1.0.4,
+        tasty-hunit,
+        microlens,
+        microlens-th,
+        mtl,
+        nothunks,
+        transformers >=0.5,
+        QuickCheck,
+        small-steps ^>=1.0,
+        cardano-strict-containers
+
+test-suite examples
+    type:             exitcode-stdio-1.0
+    main-is:          examples/Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Control.State.Transition.Examples.Sum
+        Control.State.Transition.Examples.GlobalSum
+        Control.State.Transition.Examples.CommitReveal
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded
+
+    build-depends:
+        base,
+        containers,
+        hedgehog >=1.0.4,
+        mtl,
+        tasty,
+        tasty-hedgehog,
+        tasty-expected-failure,
+        QuickCheck,
+        tasty-quickcheck,
+        tasty-hunit,
+        Unique,
+        cardano-crypto-class,
+        cardano-ledger-binary,
+        small-steps,
+        small-steps-test

--- a/_sources/small-steps-test/1.0.0.1/meta.toml
+++ b/_sources/small-steps-test/1.0.0.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-08-01T11:25:26Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "ecdb9c76a3252e1e6fbb8ed743796bf44cc83dbc" }
 subdir = 'libs/small-steps-test'
+
+[[revisions]]
+number = 1
+timestamp = 2024-06-27T01:44:50Z

--- a/_sources/small-steps-test/1.0.0.1/revisions/1.cabal
+++ b/_sources/small-steps-test/1.0.0.1/revisions/1.cabal
@@ -1,0 +1,76 @@
+cabal-version: 3.0
+name:          small-steps-test
+version:       1.0.0.1
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/input-output-hk/cardano-ledger
+synopsis:      Small step semantics testing library
+category:      Control
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/small-steps-test
+
+library
+    exposed-modules:
+        Control.State.Transition.Invalid.Trace
+        Control.State.Transition.Generator
+        Control.State.Transition.Trace
+        Control.State.Transition.Trace.Generator.QuickCheck
+        Hedgehog.Extra.Manual
+
+    hs-source-dirs:   src
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        deepseq,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
+        hedgehog >=1.0.4,
+        tasty-hunit,
+        microlens,
+        microlens-th,
+        mtl,
+        nothunks,
+        transformers >=0.5,
+        QuickCheck,
+        small-steps ^>=1.0,
+        cardano-strict-containers
+
+test-suite examples
+    type:             exitcode-stdio-1.0
+    main-is:          examples/Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Control.State.Transition.Examples.Sum
+        Control.State.Transition.Examples.GlobalSum
+        Control.State.Transition.Examples.CommitReveal
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded
+
+    build-depends:
+        base,
+        containers,
+        hedgehog >=1.0.4,
+        mtl,
+        tasty,
+        tasty-hedgehog,
+        tasty-expected-failure,
+        QuickCheck,
+        tasty-quickcheck,
+        tasty-hunit,
+        Unique,
+        cardano-crypto-class,
+        cardano-ledger-binary,
+        small-steps,
+        small-steps-test

--- a/_sources/small-steps-test/1.0.1.0/meta.toml
+++ b/_sources/small-steps-test/1.0.1.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-01-26T10:34:07Z
 github = { repo = "IntersectMBO/cardano-ledger", rev = "6e2d37cc0f47bd02e89b4ce9f78b59c35c958e96" }
 subdir = 'libs/small-steps-test'
+
+[[revisions]]
+number = 1
+timestamp = 2024-06-27T01:44:37Z

--- a/_sources/small-steps-test/1.0.1.0/revisions/1.cabal
+++ b/_sources/small-steps-test/1.0.1.0/revisions/1.cabal
@@ -1,0 +1,77 @@
+cabal-version:      3.0
+name:               small-steps-test
+version:            1.0.1.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+homepage:           https://github.com/intersectmbo/cardano-ledger
+synopsis:           Small step semantics testing library
+category:           Control
+build-type:         Simple
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/small-steps-test
+
+library
+    exposed-modules:
+        Control.State.Transition.Invalid.Trace
+        Control.State.Transition.Generator
+        Control.State.Transition.Trace
+        Control.State.Transition.Trace.Generator.QuickCheck
+        Hedgehog.Extra.Manual
+
+    hs-source-dirs:   src
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        deepseq,
+        cardano-ledger-binary:testlib ^>=1.3,
+        hedgehog >=1.0.4,
+        tasty-hunit,
+        microlens,
+        microlens-th,
+        mtl,
+        nothunks,
+        transformers >=0.5,
+        QuickCheck,
+        small-steps ^>=1.0,
+        cardano-strict-containers
+
+test-suite examples
+    type:             exitcode-stdio-1.0
+    main-is:          examples/Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Control.State.Transition.Examples.Sum
+        Control.State.Transition.Examples.GlobalSum
+        Control.State.Transition.Examples.CommitReveal
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded
+
+    build-depends:
+        base,
+        containers,
+        hedgehog >=1.0.4,
+        mtl,
+        tasty,
+        tasty-hedgehog,
+        tasty-expected-failure,
+        QuickCheck,
+        tasty-quickcheck,
+        tasty-hunit,
+        Unique,
+        cardano-crypto-class,
+        cardano-ledger-binary,
+        small-steps,
+        small-steps-test


### PR DESCRIPTION
Waiting for CI to pass: https://github.com/IntersectMBO/cardano-ledger/pull/4447

This PR also adds revisions for the deprecated `small-steps-test` package, so it no longer tries to build with newer and incompatible `small-steps` dependency

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
