### PR TITLE
Added cuddle-0.2.0.1

### DIFF
--- a/_sources/cuddle/0.2.0.1/meta.toml
+++ b/_sources/cuddle/0.2.0.1/meta.toml
@@ -1,0 +1,2 @@
+timestamp = 2024-06-27T10:53:24Z
+github = { repo = "input-output-hk/cuddle", rev = "90f57394ec5d12eadc1d9d0d8c99170815cc8079" }


### PR DESCRIPTION
From https://github.com/input-output-hk/cuddle at 90f57394ec5d12eadc1d9d0d8c99170815cc8079

This adds a new release of cuddle:
- Loosens the version bounds on Base
- Does not generate duplicate keys in CBOR maps

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
