### PR TITLE
Added cardano-api-8.49.0.0

### DIFF
--- a/_sources/cardano-api/8.49.0.0/meta.toml
+++ b/_sources/cardano-api/8.49.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-06-27T12:26:16Z
+github = { repo = "IntersectMBO/cardano-api", rev = "d280689ba294982b01a80eea0fbe936d3efb6e8d" }
+subdir = 'cardano-api'


### PR DESCRIPTION
From https://github.com/IntersectMBO/cardano-api at d280689ba294982b01a80eea0fbe936d3efb6e8d

Corresponding API PR: https://github.com/IntersectMBO/cardano-api/pull/565