### PR TITLE
Added cardano-cli-8.25.0.0

### DIFF
--- a/_sources/cardano-cli/8.25.0.0/meta.toml
+++ b/_sources/cardano-cli/8.25.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-07-01T13:48:42Z
+github = { repo = "IntersectMBO/cardano-cli", rev = "02ef3279560f36eaebe24e041e58708504310100" }
+subdir = 'cardano-cli'


### PR DESCRIPTION
From https://github.com/IntersectMBO/cardano-cli at 02ef3279560f36eaebe24e041e58708504310100

Corresponding CLI PR: https://github.com/IntersectMBO/cardano-cli/pull/807