### PR TITLE
Lossen upper bounds on plutus-ledger-api

### DIFF
--- a/_sources/cardano-ledger-alonzo-test/1.2.1.2/meta.toml
+++ b/_sources/cardano-ledger-alonzo-test/1.2.1.2/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-06-18T12:42:43Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "923e75bf3e16da01f26ed1ab53d9aac7184fc699" }
 subdir = 'eras/alonzo/test-suite'
+
+[[revisions]]
+number = 1
+timestamp = 2024-08-08T07:12:17Z

--- a/_sources/cardano-ledger-alonzo-test/1.2.1.2/revisions/1.cabal
+++ b/_sources/cardano-ledger-alonzo-test/1.2.1.2/revisions/1.cabal
@@ -1,0 +1,130 @@
+cabal-version: 3.0
+name:          cardano-ledger-alonzo-test
+version:       1.2.1.2
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+bug-reports:   https://github.com/intersectmbo/cardano-ledger/issues
+synopsis:      Tests for Cardano ledger introducing Plutus Core
+description:
+    This package builds upon the Mary ledger with support for extended UTxO
+    via Plutus Core.
+
+category:      Network
+build-type:    Simple
+data-files:
+    golden/*.cbor
+    golden/*.json
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   eras/alonzo/test-suite
+
+library
+    exposed-modules:
+        Test.Cardano.Ledger.Alonzo.AlonzoEraGen
+        Test.Cardano.Ledger.Alonzo.EraMapping
+        Test.Cardano.Ledger.Alonzo.Examples.Consensus
+        Test.Cardano.Ledger.Alonzo.Serialisation.Generators
+        Test.Cardano.Ledger.Alonzo.Scripts
+        Test.Cardano.Ledger.Alonzo.Translation.TranslationInstance
+        Test.Cardano.Ledger.Alonzo.Translation.TranslatableGen
+        Test.Cardano.Ledger.Alonzo.Translation.Golden
+        Test.Cardano.Ledger.Alonzo.Trace
+
+    hs-source-dirs:   src
+    other-modules:    Paths_cardano_ledger_alonzo_test
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        bytestring,
+        cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib} >=1.7,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.0,
+        cardano-ledger-core:{cardano-ledger-core, testlib} >=1.11 && <1.14,
+        cardano-ledger-allegra >=1.2,
+        cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.6 && <1.13,
+        cardano-ledger-shelley-test >=1.2,
+        cardano-ledger-shelley-ma-test ^>=1.2,
+        cardano-ledger-mary >=1.4,
+        cardano-protocol-tpraos >=1.0,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        data-default-class,
+        microlens,
+        plutus-ledger-api ^>=1.30 || ^>=1.31,
+        QuickCheck,
+        random,
+        serialise,
+        small-steps:{small-steps, testlib} >=1.1,
+        tasty-hunit,
+        time,
+        transformers
+
+executable gen-golden
+    main-is:          GenerateGoldenFileMain.hs
+    hs-source-dirs:   test
+    other-modules:    Paths_cardano_ledger_alonzo_test
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+        -Wunused-packages
+
+    build-depends:
+        base,
+        cardano-ledger-alonzo,
+        cardano-ledger-alonzo-test
+
+test-suite cardano-ledger-alonzo-test
+    type:             exitcode-stdio-1.0
+    main-is:          Tests.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Alonzo.ChainTrace
+        Test.Cardano.Ledger.Alonzo.Golden
+        Test.Cardano.Ledger.Alonzo.GoldenTranslation
+        Test.Cardano.Ledger.Alonzo.Serialisation.Canonical
+        Test.Cardano.Ledger.Alonzo.Serialisation.Tripping
+        Test.Cardano.Ledger.Alonzo.Translation
+        Test.Cardano.Ledger.Alonzo.TxInfo
+        Paths_cardano_ledger_alonzo_test
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+        -Wunused-packages -rtsopts
+
+    build-depends:
+        base,
+        aeson >=2,
+        base16-bytestring,
+        bytestring,
+        cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
+        cardano-ledger-alonzo-test,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core:{cardano-ledger-core, testlib},
+        cardano-ledger-mary:{cardano-ledger-mary, testlib},
+        cardano-ledger-shelley-ma-test,
+        cardano-protocol-tpraos,
+        cardano-slotting,
+        containers,
+        plutus-ledger-api,
+        QuickCheck,
+        small-steps:{small-steps, testlib} >=1.1,
+        cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
+        cardano-ledger-shelley-test,
+        microlens,
+        cardano-strict-containers,
+        tasty,
+        tasty-hunit,
+        tasty-quickcheck,
+        time

--- a/_sources/cardano-ledger-alonzo/1.10.0.0/meta.toml
+++ b/_sources/cardano-ledger-alonzo/1.10.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-07-02T02:47:44Z
 github = { repo = "IntersectMBO/cardano-ledger", rev = "698a24c1b5064468ef614532a6524dce2b41d7f5" }
 subdir = 'eras/alonzo/impl'
+
+[[revisions]]
+number = 1
+timestamp = 2024-08-08T07:09:30Z

--- a/_sources/cardano-ledger-alonzo/1.10.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-alonzo/1.10.0.0/revisions/1.cabal
@@ -1,0 +1,167 @@
+cabal-version:      3.0
+name:               cardano-ledger-alonzo
+version:            1.10.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/intersectmbo/cardano-ledger/issues
+synopsis:           Cardano ledger introducing Plutus Core
+description:
+    This package builds upon the Mary ledger with support for extended UTxO
+    via Plutus Core.
+
+category:           Network
+build-type:         Simple
+data-files:
+    cddl-files/alonzo.cddl
+    cddl-files/crypto.cddl
+    cddl-files/extras.cddl
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   eras/alonzo/impl
+
+library
+    exposed-modules:
+        Cardano.Ledger.Alonzo
+        Cardano.Ledger.Alonzo.Core
+        Cardano.Ledger.Alonzo.Data
+        Cardano.Ledger.Alonzo.Transition
+        Cardano.Ledger.Alonzo.Genesis
+        Cardano.Ledger.Alonzo.Language
+        Cardano.Ledger.Alonzo.Plutus.Context
+        Cardano.Ledger.Alonzo.Plutus.Evaluate
+        Cardano.Ledger.Alonzo.Plutus.TxInfo
+        Cardano.Ledger.Alonzo.PParams
+        Cardano.Ledger.Alonzo.Rules
+        Cardano.Ledger.Alonzo.Scripts
+        Cardano.Ledger.Alonzo.Scripts.Data
+        Cardano.Ledger.Alonzo.Translation
+        Cardano.Ledger.Alonzo.Tx
+        Cardano.Ledger.Alonzo.TxAuxData
+        Cardano.Ledger.Alonzo.TxBody
+        Cardano.Ledger.Alonzo.TxOut
+        Cardano.Ledger.Alonzo.TxSeq
+        Cardano.Ledger.Alonzo.TxWits
+        Cardano.Ledger.Alonzo.UTxO
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Alonzo.TxCert
+        Cardano.Ledger.Alonzo.Era
+        Cardano.Ledger.Alonzo.Rules.Bbody
+        Cardano.Ledger.Alonzo.Rules.Deleg
+        Cardano.Ledger.Alonzo.Rules.Delegs
+        Cardano.Ledger.Alonzo.Rules.Delpl
+        Cardano.Ledger.Alonzo.Rules.Pool
+        Cardano.Ledger.Alonzo.Rules.Ppup
+        Cardano.Ledger.Alonzo.Rules.Ledger
+        Cardano.Ledger.Alonzo.Rules.Ledgers
+        Cardano.Ledger.Alonzo.Rules.Utxo
+        Cardano.Ledger.Alonzo.Rules.Utxos
+        Cardano.Ledger.Alonzo.Rules.Utxow
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson >=2.2,
+        base64-bytestring,
+        bytestring,
+        cardano-data ^>=1.2.1,
+        cardano-ledger-allegra ^>=1.5,
+        cardano-crypto-class,
+        cardano-ledger-binary ^>=1.3,
+        cardano-ledger-core ^>=1.13,
+        cardano-ledger-mary ^>=1.6.0,
+        cardano-ledger-shelley ^>=1.12.1,
+        cardano-slotting,
+        cardano-strict-containers,
+        containers,
+        data-default-class,
+        deepseq,
+        mtl,
+        microlens,
+        nothunks,
+        plutus-ledger-api ^>=1.30 || ^>=1.31,
+        set-algebra >=1.0,
+        small-steps >=1.1,
+        text,
+        transformers,
+        validation-selective
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Alonzo.Arbitrary
+        Test.Cardano.Ledger.Alonzo.Binary.Cddl
+        Test.Cardano.Ledger.Alonzo.Binary.CostModelsSpec
+        Test.Cardano.Ledger.Alonzo.Binary.RoundTrip
+        Test.Cardano.Ledger.Alonzo.Binary.TxWitsSpec
+        Test.Cardano.Ledger.Alonzo.Imp
+        Test.Cardano.Ledger.Alonzo.Imp.UtxosSpec
+        Test.Cardano.Ledger.Alonzo.Imp.UtxowSpec
+        Test.Cardano.Ledger.Alonzo.Imp.UtxowSpec.Valid
+        Test.Cardano.Ledger.Alonzo.Imp.UtxowSpec.Invalid
+        Test.Cardano.Ledger.Alonzo.ImpTest
+        Test.Cardano.Ledger.Alonzo.TreeDiff
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    other-modules:    Paths_cardano_ledger_alonzo
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+        -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        containers,
+        cardano-crypto-class,
+        cardano-data,
+        cardano-ledger-alonzo,
+        cardano-ledger-allegra,
+        cardano-ledger-binary,
+        cardano-ledger-mary:testlib,
+        cardano-ledger-core:{cardano-ledger-core, testlib},
+        cardano-ledger-shelley:{cardano-ledger-shelley, testlib},
+        cardano-strict-containers,
+        plutus-ledger-api,
+        generic-random,
+        microlens,
+        microlens-mtl,
+        text,
+        tree-diff
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Alonzo.BinarySpec
+        Test.Cardano.Ledger.Alonzo.Binary.CddlSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        cardano-ledger-allegra,
+        cardano-ledger-alonzo,
+        cardano-ledger-binary:testlib,
+        cardano-ledger-core:{cardano-ledger-core, testlib},
+        testlib

--- a/_sources/cardano-ledger-babbage/1.8.2.0/meta.toml
+++ b/_sources/cardano-ledger-babbage/1.8.2.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-07-02T02:47:44Z
 github = { repo = "IntersectMBO/cardano-ledger", rev = "698a24c1b5064468ef614532a6524dce2b41d7f5" }
 subdir = 'eras/babbage/impl'
+
+[[revisions]]
+number = 1
+timestamp = 2024-08-08T07:13:25Z

--- a/_sources/cardano-ledger-babbage/1.8.2.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-babbage/1.8.2.0/revisions/1.cabal
@@ -1,0 +1,151 @@
+cabal-version:      3.0
+name:               cardano-ledger-babbage
+version:            1.8.2.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/intersectmbo/cardano-ledger/issues
+synopsis:
+    Cardano ledger introducing refrence scripts and inline datums
+
+description:
+    This package builds upon the Alonzo ledger with support for reference scripts,
+    reference inputs and inline datums.
+
+category:           Network
+build-type:         Simple
+data-files:
+    cddl-files/babbage.cddl
+    cddl-files/crypto.cddl
+    cddl-files/extras.cddl
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   eras/babbage/impl
+
+library
+    exposed-modules:
+        Cardano.Ledger.Babbage
+        Cardano.Ledger.Babbage.Collateral
+        Cardano.Ledger.Babbage.Core
+        Cardano.Ledger.Babbage.PParams
+        Cardano.Ledger.Babbage.Rules
+        Cardano.Ledger.Babbage.Scripts
+        Cardano.Ledger.Babbage.Tx
+        Cardano.Ledger.Babbage.TxBody
+        Cardano.Ledger.Babbage.TxOut
+        Cardano.Ledger.Babbage.TxInfo
+        Cardano.Ledger.Babbage.TxWits
+        Cardano.Ledger.Babbage.Transition
+        Cardano.Ledger.Babbage.Translation
+        Cardano.Ledger.Babbage.UTxO
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Babbage.Era
+        Cardano.Ledger.Babbage.TxAuxData
+        Cardano.Ledger.Babbage.TxCert
+        Cardano.Ledger.Babbage.Rules.Bbody
+        Cardano.Ledger.Babbage.Rules.Deleg
+        Cardano.Ledger.Babbage.Rules.Delegs
+        Cardano.Ledger.Babbage.Rules.Delpl
+        Cardano.Ledger.Babbage.Rules.Pool
+        Cardano.Ledger.Babbage.Rules.Ppup
+        Cardano.Ledger.Babbage.Rules.Ledger
+        Cardano.Ledger.Babbage.Rules.Ledgers
+        Cardano.Ledger.Babbage.Rules.Utxo
+        Cardano.Ledger.Babbage.Rules.Utxos
+        Cardano.Ledger.Babbage.Rules.Utxow
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson >=2.2,
+        bytestring,
+        cardano-crypto-class,
+        cardano-data >=1.2,
+        cardano-ledger-allegra ^>=1.5,
+        cardano-ledger-alonzo >=1.9 && <1.11,
+        cardano-ledger-binary ^>=1.3,
+        cardano-ledger-core ^>=1.13,
+        cardano-ledger-mary ^>=1.6,
+        cardano-ledger-shelley ^>=1.12.1,
+        cardano-strict-containers,
+        containers,
+        deepseq,
+        microlens,
+        nothunks,
+        plutus-ledger-api ^>=1.30 || ^>=1.31,
+        set-algebra,
+        small-steps >=1.1,
+        text,
+        transformers,
+        validation-selective
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Babbage.Arbitrary
+        Test.Cardano.Ledger.Babbage.Binary.Cddl
+        Test.Cardano.Ledger.Babbage.Imp
+        Test.Cardano.Ledger.Babbage.Imp.UtxowSpec
+        Test.Cardano.Ledger.Babbage.ImpTest
+        Test.Cardano.Ledger.Babbage.TreeDiff
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    other-modules:    Paths_cardano_ledger_babbage
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+        -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
+        cardano-ledger-shelley,
+        cardano-crypto-class,
+        cardano-ledger-babbage,
+        cardano-ledger-binary,
+        cardano-ledger-core:{cardano-ledger-core, testlib} >=1.13.2,
+        cardano-strict-containers,
+        generic-random,
+        microlens,
+        microlens-mtl,
+        small-steps >=1.1,
+        QuickCheck
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Babbage.BinarySpec
+        Test.Cardano.Ledger.Babbage.Binary.CddlSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        cardano-ledger-alonzo,
+        cardano-ledger-allegra,
+        cardano-ledger-babbage,
+        cardano-ledger-core,
+        cardano-ledger-binary:testlib,
+        cardano-ledger-core:testlib,
+        cardano-ledger-alonzo:testlib,
+        data-default-class,
+        testlib

--- a/_sources/cardano-ledger-binary/1.3.3.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.3.3.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-06-18T12:42:43Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "923e75bf3e16da01f26ed1ab53d9aac7184fc699" }
 subdir = 'libs/cardano-ledger-binary'
+
+[[revisions]]
+number = 1
+timestamp = 2024-08-08T07:17:26Z

--- a/_sources/cardano-ledger-binary/1.3.3.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.3.3.0/revisions/1.cabal
@@ -1,0 +1,194 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.3.3.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/intersectmbo/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class >=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting >=0.2,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        FailT,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api >=1.27.0 && <1.32,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        vector,
+        vector-map ^>=1.1
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Cddl
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting:{cardano-slotting, testlib} >=0.1.2,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances,
+        tasty-hunit,
+        random >=1.2,
+        text,
+        typed-process,
+        unliftio,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map
+
+benchmark bench
+    type:             exitcode-stdio-1.0
+    main-is:          Bench.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        containers,
+        criterion,
+        deepseq,
+        random

--- a/_sources/cardano-ledger-conway/1.16.0.0/meta.toml
+++ b/_sources/cardano-ledger-conway/1.16.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-07-02T04:22:05Z
 github = { repo = "IntersectMBO/cardano-ledger", rev = "f0a0864eab00cd269befcdcd1931250dbb329f80" }
 subdir = 'eras/conway/impl'
+
+[[revisions]]
+number = 1
+timestamp = 2024-08-08T07:19:00Z

--- a/_sources/cardano-ledger-conway/1.16.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-conway/1.16.0.0/revisions/1.cabal
@@ -1,0 +1,205 @@
+cabal-version:      3.0
+name:               cardano-ledger-conway
+version:            1.16.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/intersectmbo/cardano-ledger/issues
+synopsis:           Cardano ledger with an updated on-chain governance system.
+description:
+    This package builds upon the Babbage ledger with an updated on-chain governance system.
+
+category:           Network
+build-type:         Simple
+data-files:
+    test/data/*.json
+    cddl-files/conway.cddl
+    cddl-files/crypto.cddl
+    cddl-files/extra.cddl
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   eras/conway/impl
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Conway.Genesis
+        Cardano.Ledger.Conway.Governance
+        Cardano.Ledger.Conway.Governance.DRepPulser
+        Cardano.Ledger.Conway.PParams
+        Cardano.Ledger.Conway.Tx
+        Cardano.Ledger.Conway.TxBody
+        Cardano.Ledger.Conway.TxInfo
+        Cardano.Ledger.Conway.TxWits
+        Cardano.Ledger.Conway.Transition
+        Cardano.Ledger.Conway.Translation
+        Cardano.Ledger.Conway.Scripts
+        Cardano.Ledger.Conway
+        Cardano.Ledger.Conway.Rules
+        Cardano.Ledger.Conway.Core
+        Cardano.Ledger.Conway.TxCert
+        Cardano.Ledger.Conway.UTxO
+        Cardano.Ledger.Conway.Plutus.Context
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Conway.Era
+        Cardano.Ledger.Conway.Governance.Internal
+        Cardano.Ledger.Conway.Governance.Procedures
+        Cardano.Ledger.Conway.Governance.Proposals
+        Cardano.Ledger.Conway.Rules.Bbody
+        Cardano.Ledger.Conway.Rules.Cert
+        Cardano.Ledger.Conway.Rules.Deleg
+        Cardano.Ledger.Conway.Rules.GovCert
+        Cardano.Ledger.Conway.Rules.Certs
+        Cardano.Ledger.Conway.Rules.Enact
+        Cardano.Ledger.Conway.Rules.Epoch
+        Cardano.Ledger.Conway.Rules.Ledger
+        Cardano.Ledger.Conway.Rules.Ledgers
+        Cardano.Ledger.Conway.Rules.NewEpoch
+        Cardano.Ledger.Conway.Rules.Gov
+        Cardano.Ledger.Conway.Rules.Pool
+        Cardano.Ledger.Conway.Rules.Ratify
+        Cardano.Ledger.Conway.Rules.Tickf
+        Cardano.Ledger.Conway.Rules.Utxo
+        Cardano.Ledger.Conway.Rules.Utxos
+        Cardano.Ledger.Conway.Rules.Utxow
+        Cardano.Ledger.Conway.TxAuxData
+        Cardano.Ledger.Conway.TxOut
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson >=2.2,
+        data-default-class,
+        cardano-crypto-class,
+        cardano-data >=1.2.3,
+        cardano-ledger-binary >=1.3.2,
+        cardano-ledger-allegra ^>=1.5,
+        cardano-ledger-alonzo ^>=1.10,
+        cardano-ledger-babbage ^>=1.8,
+        cardano-ledger-core ^>=1.13.2,
+        cardano-ledger-mary ^>=1.6,
+        cardano-ledger-shelley ^>=1.12.2,
+        cardano-slotting,
+        cardano-strict-containers,
+        containers,
+        deepseq,
+        microlens,
+        nothunks,
+        plutus-ledger-api ^>=1.30 || ^>=1.31,
+        set-algebra,
+        small-steps >=1.1,
+        text,
+        transformers,
+        validation-selective
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Conway.Arbitrary
+        Test.Cardano.Ledger.Conway.Binary.Cddl
+        Test.Cardano.Ledger.Conway.Binary.RoundTrip
+        Test.Cardano.Ledger.Conway.Binary.Regression
+        Test.Cardano.Ledger.Conway.ImpTest
+        Test.Cardano.Ledger.Conway.Imp
+        Test.Cardano.Ledger.Conway.Imp.BbodySpec
+        Test.Cardano.Ledger.Conway.Imp.EpochSpec
+        Test.Cardano.Ledger.Conway.Imp.EnactSpec
+        Test.Cardano.Ledger.Conway.Imp.GovSpec
+        Test.Cardano.Ledger.Conway.Imp.GovCertSpec
+        Test.Cardano.Ledger.Conway.Imp.LedgerSpec
+        Test.Cardano.Ledger.Conway.Imp.RatifySpec
+        Test.Cardano.Ledger.Conway.Imp.UtxoSpec
+        Test.Cardano.Ledger.Conway.Imp.UtxosSpec
+        Test.Cardano.Ledger.Conway.Proposals
+        Test.Cardano.Ledger.Conway.TreeDiff
+        Test.Cardano.Ledger.Conway.Genesis
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    other-modules:    Paths_cardano_ledger_conway
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+        -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-data:{cardano-data, testlib},
+        containers,
+        plutus-ledger-api,
+        deepseq,
+        microlens,
+        cardano-crypto-class,
+        cardano-ledger-allegra,
+        cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
+        cardano-ledger-binary,
+        cardano-ledger-babbage:{cardano-ledger-babbage, testlib} >=1.8.2,
+        cardano-ledger-conway,
+        cardano-ledger-core:{cardano-ledger-core, testlib},
+        cardano-ledger-mary,
+        cardano-ledger-shelley,
+        cardano-strict-containers,
+        data-default-class,
+        generic-random,
+        microlens-mtl,
+        mtl,
+        text,
+        small-steps >=1.1
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Conway.Spec
+        Test.Cardano.Ledger.Conway.BinarySpec
+        Test.Cardano.Ledger.Conway.Binary.CddlSpec
+        Test.Cardano.Ledger.Conway.DRepRatifySpec
+        Test.Cardano.Ledger.Conway.CommitteeRatifySpec
+        Test.Cardano.Ledger.Conway.GenesisSpec
+        Test.Cardano.Ledger.Conway.GovActionReorderSpec
+        Test.Cardano.Ledger.Conway.Plutus.PlutusSpec
+        Paths_cardano_ledger_conway
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        aeson,
+        base,
+        cardano-ledger-core:testlib,
+        cardano-ledger-allegra,
+        cardano-ledger-alonzo:testlib,
+        cardano-ledger-alonzo,
+        cardano-ledger-babbage,
+        cardano-ledger-conway,
+        cardano-ledger-shelley:testlib,
+        cardano-ledger-core,
+        cardano-ledger-binary:testlib,
+        cardano-slotting:testlib,
+        cardano-strict-containers,
+        containers,
+        data-default-class,
+        microlens,
+        testlib


### PR DESCRIPTION
@lehins All I have done is added `^>=1.31` to the bounds of `plutus-ledger-api` so it looks like:
```
plutus-ledger-api ^>=1.30 || ^>= 1.31
```
to allow me to remove all the `allow-newer` stanzas in my `cardano-cli` PR.

If this is ok with you, please merge it.