### PR TITLE
Release ouroboros-network-0.17.1.1 & co

### DIFF
--- a/_sources/cardano-client/0.3.1.5/meta.toml
+++ b/_sources/cardano-client/0.3.1.5/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-08-27T16:27:55Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "5dd745f32652132cd24ec34e7164688c0e40dd48" }
+subdir = 'cardano-client'

--- a/_sources/cardano-ping/0.4.0.1/meta.toml
+++ b/_sources/cardano-ping/0.4.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-08-27T16:27:57Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "5dd745f32652132cd24ec34e7164688c0e40dd48" }
+subdir = 'cardano-ping'

--- a/_sources/ouroboros-network-api/0.9.0.1/meta.toml
+++ b/_sources/ouroboros-network-api/0.9.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-08-27T16:27:59Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "5dd745f32652132cd24ec34e7164688c0e40dd48" }
+subdir = 'ouroboros-network-api'

--- a/_sources/ouroboros-network-framework/0.13.2.4/meta.toml
+++ b/_sources/ouroboros-network-framework/0.13.2.4/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-08-27T16:28:00Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "5dd745f32652132cd24ec34e7164688c0e40dd48" }
+subdir = 'ouroboros-network-framework'

--- a/_sources/ouroboros-network-protocols/0.10.0.2/meta.toml
+++ b/_sources/ouroboros-network-protocols/0.10.0.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-08-27T16:28:01Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "5dd745f32652132cd24ec34e7164688c0e40dd48" }
+subdir = 'ouroboros-network-protocols'

--- a/_sources/ouroboros-network/0.17.1.1/meta.toml
+++ b/_sources/ouroboros-network/0.17.1.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-08-27T16:27:58Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "5dd745f32652132cd24ec34e7164688c0e40dd48" }
+subdir = 'ouroboros-network'


### PR DESCRIPTION
From https://github.com/intersectmbo/ouroboros-network at 5dd745f32652132cd24ec34e7164688c0e40dd48
checked with build-with-chap.sh in ouroboros-network

This PR fixes the non-existent git ref in release 0.17.1.0.