### PR TITLE
Backport ledger state deserialization fix

### DIFF
--- a/_sources/cardano-ledger-shelley/1.12.3.0/meta.toml
+++ b/_sources/cardano-ledger-shelley/1.12.3.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-09-01T03:49:37Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "01ce1d8e377f5ee6d24879f2afa933f7874b8db4" }
+subdir = 'eras/shelley/impl'

--- a/_sources/cardano-ledger-shelley/1.13.1.0/meta.toml
+++ b/_sources/cardano-ledger-shelley/1.13.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-09-01T03:50:08Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "ead6175cbb07f6bb272d534c17a59d89b6e5b8b8" }
+subdir = 'eras/shelley/impl'


### PR DESCRIPTION
This is a backport of https://github.com/IntersectMBO/cardano-ledger/pull/4589 for:
* `cardano-node-9.1`: https://github.com/IntersectMBO/cardano-ledger/pull/4591
* `cardano-node-9.2`: https://github.com/IntersectMBO/cardano-ledger/pull/4590