### PR TITLE
Make `typed-protocols-0.1.1.1` unreachable

### DIFF
--- a/_sources/typed-protocols/0.1.1.1/meta.toml
+++ b/_sources/typed-protocols/0.1.1.1/meta.toml
@@ -5,3 +5,7 @@ subdir = 'typed-protocols'
 [[revisions]]
 number = 1
 timestamp = 2024-08-28T17:27:21Z
+
+[[revisions]]
+number = 2
+timestamp = 2024-09-20T09:00:00Z

--- a/_sources/typed-protocols/0.1.1.1/revisions/2.cabal
+++ b/_sources/typed-protocols/0.1.1.1/revisions/2.cabal
@@ -1,0 +1,46 @@
+cabal-version:       3.0
+name:                typed-protocols
+version:             0.1.1.1
+synopsis:            A framework for strongly typed protocols
+-- description:
+license:             Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+copyright:           2019-2023 Input Output Global Inc (IOG)
+author:              Alexander Vieth, Duncan Coutts, Marcin Szamotulski
+maintainer:          alex@well-typed.com, duncan@well-typed.com, marcin.szamotulski@iohk.io
+category:            Control
+build-type:          Simple
+tested-with:         GHC == {8.10, 9.2, 9.4, 9.6}
+extra-source-files:  CHANGELOG.md
+
+library
+  exposed-modules:   Network.TypedProtocol
+                   , Network.TypedProtocol.Core
+                   , Network.TypedProtocol.Codec
+                   , Network.TypedProtocol.Pipelined
+                   , Network.TypedProtocol.Driver
+                   , Network.TypedProtocol.Proofs
+
+  other-extensions:  GADTs
+                   , RankNTypes
+                   , PolyKinds
+                   , DataKinds
+                   , ScopedTypeVariables
+                   , TypeFamilies
+                   , TypeOperators
+                   , BangPatterns
+  build-depends:     base < 0,
+                     io-classes ^>= 1.6
+
+  hs-source-dirs:    src
+  default-language:  Haskell2010
+  ghc-options:       -Wall
+                     -Wno-unticked-promoted-constructors
+                     -Wcompat
+                     -Wincomplete-uni-patterns
+                     -Wincomplete-record-updates
+                     -Wpartial-fields
+                     -Widentities
+                     -Wredundant-constraints


### PR DESCRIPTION
We'll stick with `io-classes-1.5` for now.  We need to wait for
Hackage.Nix support.
