### PR TITLE
Prepare `cardano-ledger-conway-1.16.2.0` release

### DIFF
--- a/_sources/cardano-ledger-conway/1.16.2.0/meta.toml
+++ b/_sources/cardano-ledger-conway/1.16.2.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-09-23T21:46:49Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "052d07325dcc4bf8a004bcad2c58d7fc7ce65d92" }
+subdir = 'eras/conway/impl'

--- a/_sources/cardano-ledger-core/1.14.1.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.14.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-09-23T21:46:49Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "052d07325dcc4bf8a004bcad2c58d7fc7ce65d92" }
+subdir = 'libs/cardano-ledger-core'


### PR DESCRIPTION
This PR is the backport of nice performance improvements from this PR: https://github.com/IntersectMBO/cardano-ledger/pull/4644