### PR TITLE
Plutus core Release 1.35.0.0

### DIFF
--- a/_sources/plutus-core/1.35.0.0/meta.toml
+++ b/_sources/plutus-core/1.35.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-10-07T08:25:01Z
+github = { repo = "IntersectMBO/plutus", rev = "384997b4f395c984685a10a8317c7f729c37ff26" }
+subdir = 'plutus-core'

--- a/_sources/plutus-ledger-api/1.35.0.0/meta.toml
+++ b/_sources/plutus-ledger-api/1.35.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-10-07T08:25:01Z
+github = { repo = "IntersectMBO/plutus", rev = "384997b4f395c984685a10a8317c7f729c37ff26" }
+subdir = 'plutus-ledger-api'

--- a/_sources/plutus-tx-plugin/1.35.0.0/meta.toml
+++ b/_sources/plutus-tx-plugin/1.35.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-10-07T08:25:01Z
+github = { repo = "IntersectMBO/plutus", rev = "384997b4f395c984685a10a8317c7f729c37ff26" }
+subdir = 'plutus-tx-plugin'

--- a/_sources/plutus-tx/1.35.0.0/meta.toml
+++ b/_sources/plutus-tx/1.35.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-10-07T08:25:01Z
+github = { repo = "IntersectMBO/plutus", rev = "384997b4f395c984685a10a8317c7f729c37ff26" }
+subdir = 'plutus-tx'

--- a/_sources/prettyprinter-configurable/1.35.0.0/meta.toml
+++ b/_sources/prettyprinter-configurable/1.35.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-10-07T08:25:01Z
+github = { repo = "IntersectMBO/plutus", rev = "384997b4f395c984685a10a8317c7f729c37ff26" }
+subdir = 'prettyprinter-configurable'


### PR DESCRIPTION
Deleted the previous PR because the timestamps became unmanageably broken.
