### PR TITLE
Release ouroboros-network-0.17.1.2 & co 

### DIFF
--- a/_sources/cardano-client/0.3.1.6/meta.toml
+++ b/_sources/cardano-client/0.3.1.6/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-10-11T13:55:02Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "df3431f95ef9e47a8a26fd3376efd61ed0837747" }
+subdir = 'cardano-client'

--- a/_sources/cardano-ping/0.5.0.0/meta.toml
+++ b/_sources/cardano-ping/0.5.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-10-11T13:55:03Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "df3431f95ef9e47a8a26fd3376efd61ed0837747" }
+subdir = 'cardano-ping'

--- a/_sources/ouroboros-network-api/0.10.0.0/meta.toml
+++ b/_sources/ouroboros-network-api/0.10.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-10-11T13:55:06Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "df3431f95ef9e47a8a26fd3376efd61ed0837747" }
+subdir = 'ouroboros-network-api'

--- a/_sources/ouroboros-network-framework/0.13.2.5/meta.toml
+++ b/_sources/ouroboros-network-framework/0.13.2.5/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-10-11T13:55:08Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "df3431f95ef9e47a8a26fd3376efd61ed0837747" }
+subdir = 'ouroboros-network-framework'

--- a/_sources/ouroboros-network-protocols/0.11.0.0/meta.toml
+++ b/_sources/ouroboros-network-protocols/0.11.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-10-11T13:55:09Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "df3431f95ef9e47a8a26fd3376efd61ed0837747" }
+subdir = 'ouroboros-network-protocols'

--- a/_sources/ouroboros-network/0.17.1.2/meta.toml
+++ b/_sources/ouroboros-network/0.17.1.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-10-11T13:55:05Z
+github = { repo = "intersectmbo/ouroboros-network", rev = "df3431f95ef9e47a8a26fd3376efd61ed0837747" }
+subdir = 'ouroboros-network'


### PR DESCRIPTION
From https://github.com/intersectmbo/ouroboros-network at 4bdf801bbaf4aaddb2ec394891697fe6d3185bf0
checked with build-with-chap.sh in ouroboros-network