### PR TITLE
Release cardano-api-10.0.0.0

### DIFF
--- a/_sources/cardano-api-gen/10.0.0.0/meta.toml
+++ b/_sources/cardano-api-gen/10.0.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-10-16T12:44:42Z
+github = { repo = "IntersectMBO/cardano-api", rev = "06265fe58ffbc868203385632e1b86734f169b48" }
+subdir = 'cardano-api-gen'

--- a/_sources/cardano-api/10.0.0.0/meta.toml
+++ b/_sources/cardano-api/10.0.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-10-16T12:44:42Z
+github = { repo = "IntersectMBO/cardano-api", rev = "06265fe58ffbc868203385632e1b86734f169b48" }
+subdir = 'cardano-api'


### PR DESCRIPTION
From https://github.com/IntersectMBO/cardano-api at 06265fe58

Corresponding PR IntersectMBO/cardano-api#655
<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
