### PR TITLE
Added cardano-ledger-conway-1.17.2.0

### DIFF
--- a/_sources/cardano-ledger-conway/1.17.2.0/meta.toml
+++ b/_sources/cardano-ledger-conway/1.17.2.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-10-23T20:55:17Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "0268e812b19f9d7a88859253b884dbe4d0bce1e6" }
+subdir = 'eras/conway/impl'


### PR DESCRIPTION
Backport release of `cardano-ledger-conway-1.17.2.0`: https://github.com/IntersectMBO/cardano-ledger/pull/4716

From https://github.com/IntersectMBO/cardano-ledger at 0268e812b19f9d7a88859253b884dbe4d0bce1e6

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
