### PR TITLE
release cardano-node 10.1.1

### DIFF
--- a/_sources/cardano-node-chairman/10.0.1/meta.toml
+++ b/_sources/cardano-node-chairman/10.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-10-24T10:49:32Z
+github = { repo = "IntersectMBO/cardano-node", rev = "4184f9297bf7306713bfbb8f39eef61c056198cc" }
+subdir = 'cardano-node-chairman'

--- a/_sources/cardano-node/10.1.1/meta.toml
+++ b/_sources/cardano-node/10.1.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-10-24T10:49:32Z
+github = { repo = "IntersectMBO/cardano-node", rev = "4184f9297bf7306713bfbb8f39eef61c056198cc" }
+subdir = 'cardano-node'


### PR DESCRIPTION
From https://github.com/IntersectMBO/cardano-node at 76e90db0647ab3d8aadf8f83cf081993c03e340d
Related PR https://github.com/IntersectMBO/cardano-node/pull/6022