### PR TITLE
Added cardano-tracer-0.3

### DIFF
--- a/_sources/cardano-tracer/0.3/meta.toml
+++ b/_sources/cardano-tracer/0.3/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-10-30T11:23:17Z
+github = { repo = "IntersectMBO/cardano-node", rev = "4184f9297bf7306713bfbb8f39eef61c056198cc" }
+subdir = 'cardano-tracer'


### PR DESCRIPTION
From https://github.com/IntersectMBO/cardano-node at 4184f9297bf7306713bfbb8f39eef61c056198cc
(identical commit as cardano-node-10.1.1)