### PR TITLE
Update cardano-ledger

### DIFF
--- a/_sources/cardano-ledger-allegra/1.6.1.0/meta.toml
+++ b/_sources/cardano-ledger-allegra/1.6.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-12-13T21:20:02Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "b7fe1c31edabf8863669d8948f362e78bbbae14c" }
+subdir = 'eras/allegra/impl'

--- a/_sources/cardano-ledger-alonzo/1.12.0.0/meta.toml
+++ b/_sources/cardano-ledger-alonzo/1.12.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-12-13T21:20:02Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "b7fe1c31edabf8863669d8948f362e78bbbae14c" }
+subdir = 'eras/alonzo/impl'

--- a/_sources/cardano-ledger-api/1.10.0.0/meta.toml
+++ b/_sources/cardano-ledger-api/1.10.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-12-13T21:20:02Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "b7fe1c31edabf8863669d8948f362e78bbbae14c" }
+subdir = 'libs/cardano-ledger-api'

--- a/_sources/cardano-ledger-babbage/1.10.1.0/meta.toml
+++ b/_sources/cardano-ledger-babbage/1.10.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-12-13T21:20:02Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "b7fe1c31edabf8863669d8948f362e78bbbae14c" }
+subdir = 'eras/babbage/impl'

--- a/_sources/cardano-ledger-binary/1.5.0.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.5.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-12-13T21:20:02Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "b7fe1c31edabf8863669d8948f362e78bbbae14c" }
+subdir = 'libs/cardano-ledger-binary'

--- a/_sources/cardano-ledger-byron-test/1.5.2.0/meta.toml
+++ b/_sources/cardano-ledger-byron-test/1.5.2.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-12-13T21:20:02Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "b7fe1c31edabf8863669d8948f362e78bbbae14c" }
+subdir = 'eras/byron/ledger/impl/test'

--- a/_sources/cardano-ledger-byron/1.0.2.0/meta.toml
+++ b/_sources/cardano-ledger-byron/1.0.2.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-12-13T21:20:02Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "b7fe1c31edabf8863669d8948f362e78bbbae14c" }
+subdir = 'eras/byron/ledger/impl'

--- a/_sources/cardano-ledger-conway/1.18.0.0/meta.toml
+++ b/_sources/cardano-ledger-conway/1.18.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-12-13T21:20:02Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "b7fe1c31edabf8863669d8948f362e78bbbae14c" }
+subdir = 'eras/conway/impl'

--- a/_sources/cardano-ledger-core/1.16.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.16.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-12-13T21:20:02Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "b7fe1c31edabf8863669d8948f362e78bbbae14c" }
+subdir = 'libs/cardano-ledger-core'

--- a/_sources/cardano-ledger-mary/1.7.1.0/meta.toml
+++ b/_sources/cardano-ledger-mary/1.7.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-12-13T21:20:02Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "b7fe1c31edabf8863669d8948f362e78bbbae14c" }
+subdir = 'eras/mary/impl'

--- a/_sources/cardano-ledger-shelley-test/1.5.1.0/meta.toml
+++ b/_sources/cardano-ledger-shelley-test/1.5.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-12-13T21:20:02Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "b7fe1c31edabf8863669d8948f362e78bbbae14c" }
+subdir = 'eras/shelley/test-suite'

--- a/_sources/cardano-ledger-shelley/1.15.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley/1.15.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-12-13T21:20:02Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "b7fe1c31edabf8863669d8948f362e78bbbae14c" }
+subdir = 'eras/shelley/impl'

--- a/_sources/cardano-protocol-tpraos/1.3.0.0/meta.toml
+++ b/_sources/cardano-protocol-tpraos/1.3.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-12-13T21:20:02Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "b7fe1c31edabf8863669d8948f362e78bbbae14c" }
+subdir = 'libs/cardano-protocol-tpraos'


### PR DESCRIPTION
* cardano-ledger-allegra-1.6.1.0
* cardano-ledger-alonzo-1.12.0.0
* cardano-ledger-api-1.10.0.0
* cardano-ledger-babbage-1.10.1.0
* cardano-ledger-binary-1.5.0.0
* cardano-ledger-byron-1.0.2.0
* cardano-ledger-byron-test-1.5.2.0
* cardano-ledger-conway-1.18.0.0
* cardano-ledger-core-1.16.0.0
* cardano-ledger-mary-1.7.0.2
* cardano-ledger-shelley-1.15.0.0
* cardano-ledger-shelley-test-1.5.1.0
* cardano-protocol-tpraos-1.3.0.0