### PR TITLE
Release cardano crypto version 2.2

### DIFF
--- a/_sources/cardano-crypto-class/2.2.0.0/meta.toml
+++ b/_sources/cardano-crypto-class/2.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-12-11T19:48:20Z
+github = { repo = "IntersectMBO/cardano-base", rev = "ded795b240bc86b3e71766e4e896bb4e587af679" }
+subdir = 'cardano-crypto-class'

--- a/_sources/cardano-crypto-praos/2.2.0.0/meta.toml
+++ b/_sources/cardano-crypto-praos/2.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-12-11T19:48:20Z
+github = { repo = "IntersectMBO/cardano-base", rev = "ded795b240bc86b3e71766e4e896bb4e587af679" }
+subdir = 'cardano-crypto-praos'

--- a/_sources/cardano-crypto-tests/2.2.0.0/meta.toml
+++ b/_sources/cardano-crypto-tests/2.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2024-12-11T19:48:20Z
+github = { repo = "IntersectMBO/cardano-base", rev = "ded795b240bc86b3e71766e4e896bb4e587af679" }
+subdir = 'cardano-crypto-tests'

--- a/_sources/cardano-ledger-binary/1.0.0.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.0.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-02-23T15:33:46Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "2f5956038233e4df0a065d96db32398605603f9b" }
 subdir = 'libs/cardano-ledger-binary'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-11T19:54:23Z

--- a/_sources/cardano-ledger-binary/1.0.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.0.0.0/revisions/1.cabal
@@ -1,0 +1,171 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.0.0.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/input-output-hk/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.TreeDiff
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.12 && <4.17,
+        aeson,
+        binary,
+        bytestring,
+        cardano-binary >=1.6,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting,
+        cardano-strict-containers >=0.1.2,
+        cborg,
+        containers,
+        data-fix,
+        deepseq,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.1,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        tree-diff,
+        vector,
+        vector-map >=1.0
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.12 && <4.17,
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances,
+        tasty-hunit,
+        random >=1.2,
+        text,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base >=4.12 && <4.17,
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map

--- a/_sources/cardano-ledger-binary/1.0.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.0.0.0/revisions/1.cabal
@@ -118,7 +118,7 @@ library testlib
         pretty-show,
         primitive,
         QuickCheck,
-        quickcheck-instances,
+        quickcheck-instances <0.3.32,
         tasty-hunit,
         random >=1.2,
         text,

--- a/_sources/cardano-ledger-binary/1.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.1.0.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-binary'
 [[revisions]]
 number = 1
 timestamp = 2023-04-14T12:36:46Z
+
+[[revisions]]
+number = 2
+timestamp = 2024-12-11T19:54:27Z

--- a/_sources/cardano-ledger-binary/1.1.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-binary/1.1.0.0/revisions/2.cabal
@@ -1,0 +1,173 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.1.0.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/input-output-hk/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.TreeDiff
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.17,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.6,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting,
+        cardano-strict-containers >=0.1.2,
+        cborg,
+        containers,
+        data-fix,
+        deepseq,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api >=1.1,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        tree-diff,
+        vector,
+        vector-map >=1.0
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary >=1.0,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances,
+        tasty-hunit,
+        random >=1.2,
+        text,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map

--- a/_sources/cardano-ledger-binary/1.1.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-binary/1.1.0.0/revisions/2.cabal
@@ -119,7 +119,7 @@ library testlib
         pretty-show,
         primitive,
         QuickCheck,
-        quickcheck-instances,
+        quickcheck-instances <0.3.32,
         tasty-hunit,
         random >=1.2,
         text,

--- a/_sources/cardano-ledger-binary/1.1.0.1/meta.toml
+++ b/_sources/cardano-ledger-binary/1.1.0.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-04-26T17:24:56Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "55a58ad476a978a24d56e8ce28b5f4bbaa159169" }
 subdir = 'libs/cardano-ledger-binary'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-11T19:54:29Z

--- a/_sources/cardano-ledger-binary/1.1.0.1/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.1.0.1/revisions/1.cabal
@@ -1,0 +1,173 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.1.0.1
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/input-output-hk/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.TreeDiff
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.17,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.6,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting,
+        cardano-strict-containers >=0.1.2,
+        cborg,
+        containers,
+        data-fix,
+        deepseq,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.1,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        tree-diff,
+        vector,
+        vector-map >=1.0
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary >=1.0,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances,
+        tasty-hunit,
+        random >=1.2,
+        text,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map

--- a/_sources/cardano-ledger-binary/1.1.0.1/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.1.0.1/revisions/1.cabal
@@ -119,7 +119,7 @@ library testlib
         pretty-show,
         primitive,
         QuickCheck,
-        quickcheck-instances,
+        quickcheck-instances <0.3.32,
         tasty-hunit,
         random >=1.2,
         text,

--- a/_sources/cardano-ledger-binary/1.1.1.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.1.1.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-05-11T21:41:19Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "6db84a7b77e19af58feb2f45dfc50aa70435967b" }
 subdir = 'libs/cardano-ledger-binary'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-11T19:54:35Z

--- a/_sources/cardano-ledger-binary/1.1.1.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.1.1.0/revisions/1.cabal
@@ -1,0 +1,173 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.1.1.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/input-output-hk/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.TreeDiff
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.17,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.6,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting,
+        cardano-strict-containers >=0.1.2,
+        cborg,
+        containers,
+        data-fix,
+        deepseq,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.5,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        tree-diff,
+        vector,
+        vector-map >=1.0
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary >=1.0,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances,
+        tasty-hunit,
+        random >=1.2,
+        text,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map

--- a/_sources/cardano-ledger-binary/1.1.1.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.1.1.0/revisions/1.cabal
@@ -119,7 +119,7 @@ library testlib
         pretty-show,
         primitive,
         QuickCheck,
-        quickcheck-instances,
+        quickcheck-instances <0.3.32,
         tasty-hunit,
         random >=1.2,
         text,

--- a/_sources/cardano-ledger-binary/1.1.1.1/meta.toml
+++ b/_sources/cardano-ledger-binary/1.1.1.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-06-08T18:20:50Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "eae43793dc80533fe7f3fc02b76303e7df7d001f" }
 subdir = 'libs/cardano-ledger-binary'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-11T19:54:36Z

--- a/_sources/cardano-ledger-binary/1.1.1.1/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.1.1.1/revisions/1.cabal
@@ -1,0 +1,173 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.1.1.1
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/input-output-hk/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.TreeDiff
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.7,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        tree-diff,
+        vector,
+        vector-map >=1.0
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary >=1.0,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances,
+        tasty-hunit,
+        random >=1.2,
+        text,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map

--- a/_sources/cardano-ledger-binary/1.1.1.1/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.1.1.1/revisions/1.cabal
@@ -119,7 +119,7 @@ library testlib
         pretty-show,
         primitive,
         QuickCheck,
-        quickcheck-instances,
+        quickcheck-instances <0.3.32,
         tasty-hunit,
         random >=1.2,
         text,

--- a/_sources/cardano-ledger-binary/1.1.2.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.1.2.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-08-17T16:07:17Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "bbdfc3fdb6487653f23385c3df1c9c575bf567cf" }
 subdir = 'libs/cardano-ledger-binary'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-11T19:54:41Z

--- a/_sources/cardano-ledger-binary/1.1.2.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.1.2.0/revisions/1.cabal
@@ -1,0 +1,173 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.1.2.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/input-output-hk/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.TreeDiff
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.9,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        tree-diff,
+        vector,
+        vector-map >=1.0
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary >=1.0,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances,
+        tasty-hunit,
+        random >=1.2,
+        text,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map

--- a/_sources/cardano-ledger-binary/1.1.2.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.1.2.0/revisions/1.cabal
@@ -119,7 +119,7 @@ library testlib
         pretty-show,
         primitive,
         QuickCheck,
-        quickcheck-instances,
+        quickcheck-instances <0.3.32,
         tasty-hunit,
         random >=1.2,
         text,

--- a/_sources/cardano-ledger-binary/1.1.3.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.1.3.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-09-26T17:38:01Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "72c1dd752a1761869e8f4b37aafa59858c191bd1" }
 subdir = 'libs/cardano-ledger-binary'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-11T19:54:44Z

--- a/_sources/cardano-ledger-binary/1.1.3.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.1.3.0/revisions/1.cabal
@@ -1,0 +1,173 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.1.3.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/input-output-hk/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.TreeDiff
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.11,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        tree-diff,
+        vector,
+        vector-map >=1.0
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary >=1.0,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances,
+        tasty-hunit,
+        random >=1.2,
+        text,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map

--- a/_sources/cardano-ledger-binary/1.1.3.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.1.3.0/revisions/1.cabal
@@ -119,7 +119,7 @@ library testlib
         pretty-show,
         primitive,
         QuickCheck,
-        quickcheck-instances,
+        quickcheck-instances <0.3.32,
         tasty-hunit,
         random >=1.2,
         text,

--- a/_sources/cardano-ledger-binary/1.2.0.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.2.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-10-25T19:30:47Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "f4269490502fc928c13a86e71c059d88cb5ac995" }
 subdir = 'libs/cardano-ledger-binary'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-11T19:54:53Z

--- a/_sources/cardano-ledger-binary/1.2.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.2.0.0/revisions/1.cabal
@@ -1,0 +1,173 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.2.0.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/input-output-hk/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.TreeDiff
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.15,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        tree-diff,
+        vector,
+        vector-map >=1.0
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary >=1.0,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances,
+        tasty-hunit,
+        random >=1.2,
+        text,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map

--- a/_sources/cardano-ledger-binary/1.2.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.2.0.0/revisions/1.cabal
@@ -119,7 +119,7 @@ library testlib
         pretty-show,
         primitive,
         QuickCheck,
-        quickcheck-instances,
+        quickcheck-instances <0.3.32,
         tasty-hunit,
         random >=1.2,
         text,

--- a/_sources/cardano-ledger-binary/1.2.1.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.2.1.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-11-14T12:07:29Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "f85ec6f2e0a80101009187f79ff154ab33a82a21" }
 subdir = 'libs/cardano-ledger-binary'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-11T19:54:56Z

--- a/_sources/cardano-ledger-binary/1.2.1.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.2.1.0/revisions/1.cabal
@@ -120,7 +120,7 @@ library testlib
         pretty-show,
         primitive,
         QuickCheck,
-        quickcheck-instances,
+        quickcheck-instances <0.3.32,
         tasty-hunit,
         random >=1.2,
         text,

--- a/_sources/cardano-ledger-binary/1.2.1.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.2.1.0/revisions/1.cabal
@@ -1,0 +1,176 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.2.1.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/input-output-hk/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.TreeDiff
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.15,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        tree-diff,
+        vector,
+        vector-map >=1.0
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Cddl
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary >=1.0,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances,
+        tasty-hunit,
+        random >=1.2,
+        text,
+        typed-process,
+        unliftio,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map

--- a/_sources/cardano-ledger-binary/1.3.0.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.3.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-01-26T10:34:07Z
 github = { repo = "IntersectMBO/cardano-ledger", rev = "6e2d37cc0f47bd02e89b4ce9f78b59c35c958e96" }
 subdir = 'libs/cardano-ledger-binary'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-11T19:57:09Z

--- a/_sources/cardano-ledger-binary/1.3.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.3.0.0/revisions/1.cabal
@@ -1,0 +1,194 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.3.0.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/intersectmbo/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        FailT,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.21,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        vector,
+        vector-map ^>=1.1
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Cddl
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting:{cardano-slotting, testlib} >=0.1.2,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances,
+        tasty-hunit,
+        random >=1.2,
+        text,
+        typed-process,
+        unliftio,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map
+
+benchmark bench
+    type:             exitcode-stdio-1.0
+    main-is:          Bench.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        containers,
+        criterion,
+        deepseq,
+        random

--- a/_sources/cardano-ledger-binary/1.3.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.3.0.0/revisions/1.cabal
@@ -119,7 +119,7 @@ library testlib
         pretty-show,
         primitive,
         QuickCheck,
-        quickcheck-instances,
+        quickcheck-instances <0.3.32,
         tasty-hunit,
         random >=1.2,
         text,

--- a/_sources/cardano-ledger-binary/1.3.1.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.3.1.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-03-29T00:54:16Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "ed6d38b0bf0a54504c781b3c274745846476ca3c" }
 subdir = 'libs/cardano-ledger-binary'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-11T19:55:03Z

--- a/_sources/cardano-ledger-binary/1.3.1.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.3.1.0/revisions/1.cabal
@@ -1,0 +1,194 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.3.1.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/intersectmbo/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting >=0.2,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        FailT,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.23.0,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        vector,
+        vector-map ^>=1.1
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Cddl
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting:{cardano-slotting, testlib} >=0.1.2,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances,
+        tasty-hunit,
+        random >=1.2,
+        text,
+        typed-process,
+        unliftio,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map
+
+benchmark bench
+    type:             exitcode-stdio-1.0
+    main-is:          Bench.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        containers,
+        criterion,
+        deepseq,
+        random

--- a/_sources/cardano-ledger-binary/1.3.1.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.3.1.0/revisions/1.cabal
@@ -119,7 +119,7 @@ library testlib
         pretty-show,
         primitive,
         QuickCheck,
-        quickcheck-instances,
+        quickcheck-instances <0.3.32,
         tasty-hunit,
         random >=1.2,
         text,

--- a/_sources/cardano-ledger-binary/1.3.2.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.3.2.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-05-10T03:50:29Z
 github = { repo = "IntersectMBO/cardano-ledger", rev = "15afd0483" }
 subdir = 'libs/cardano-ledger-binary'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-11T19:55:06Z

--- a/_sources/cardano-ledger-binary/1.3.2.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.3.2.0/revisions/1.cabal
@@ -1,0 +1,194 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.3.2.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/intersectmbo/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting >=0.2,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        FailT,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.27.0,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        vector,
+        vector-map ^>=1.1
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Cddl
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting:{cardano-slotting, testlib} >=0.1.2,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances,
+        tasty-hunit,
+        random >=1.2,
+        text,
+        typed-process,
+        unliftio,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map
+
+benchmark bench
+    type:             exitcode-stdio-1.0
+    main-is:          Bench.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        containers,
+        criterion,
+        deepseq,
+        random

--- a/_sources/cardano-ledger-binary/1.3.2.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.3.2.0/revisions/1.cabal
@@ -119,7 +119,7 @@ library testlib
         pretty-show,
         primitive,
         QuickCheck,
-        quickcheck-instances,
+        quickcheck-instances <0.3.32,
         tasty-hunit,
         random >=1.2,
         text,

--- a/_sources/cardano-ledger-binary/1.3.3.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.3.3.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-binary'
 [[revisions]]
 number = 1
 timestamp = 2024-08-08T07:17:26Z
+
+[[revisions]]
+number = 2
+timestamp = 2024-12-11T19:55:09Z

--- a/_sources/cardano-ledger-binary/1.3.3.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-binary/1.3.3.0/revisions/2.cabal
@@ -1,0 +1,194 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.3.3.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/intersectmbo/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting >=0.2,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        FailT,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api >=1.27.0 && <1.32,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        vector,
+        vector-map ^>=1.1
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Cddl
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting:{cardano-slotting, testlib} >=0.1.2,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances,
+        tasty-hunit,
+        random >=1.2,
+        text,
+        typed-process,
+        unliftio,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map
+
+benchmark bench
+    type:             exitcode-stdio-1.0
+    main-is:          Bench.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        containers,
+        criterion,
+        deepseq,
+        random

--- a/_sources/cardano-ledger-binary/1.3.3.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-binary/1.3.3.0/revisions/2.cabal
@@ -119,7 +119,7 @@ library testlib
         pretty-show,
         primitive,
         QuickCheck,
-        quickcheck-instances,
+        quickcheck-instances <0.3.32,
         tasty-hunit,
         random >=1.2,
         text,

--- a/_sources/cardano-ledger-binary/1.3.4.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.3.4.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-08-20T20:11:43Z
 github = { repo = "intersectmbo/cardano-ledger", rev = "068c7a6ff43b154219fb73834f7f0c6ee7d752b1" }
 subdir = 'libs/cardano-ledger-binary'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-11T19:55:11Z

--- a/_sources/cardano-ledger-binary/1.3.4.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.3.4.0/revisions/1.cabal
@@ -123,7 +123,7 @@ library testlib
         prettyprinter,
         primitive,
         QuickCheck,
-        quickcheck-instances,
+        quickcheck-instances <0.3.32,
         tasty-hunit,
         random >=1.2,
         text,

--- a/_sources/cardano-ledger-binary/1.3.4.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.3.4.0/revisions/1.cabal
@@ -1,0 +1,198 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.3.4.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/intersectmbo/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting >=0.2,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        FailT,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api >=1.27.0 && <1.33.0,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        vector,
+        vector-map ^>=1.1
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Cddl
+        Test.Cardano.Ledger.Binary.Cuddle
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting:{cardano-slotting, testlib} >=0.1.2,
+        cborg,
+        containers,
+        cuddle >=0.2.0.0,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        hspec-core,
+        pretty-show,
+        prettyprinter,
+        primitive,
+        QuickCheck,
+        quickcheck-instances,
+        tasty-hunit,
+        random >=1.2,
+        text,
+        typed-process,
+        unliftio,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map
+
+benchmark bench
+    type:             exitcode-stdio-1.0
+    main-is:          Bench.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        containers,
+        criterion,
+        deepseq,
+        random

--- a/_sources/cardano-ledger-binary/1.4.0.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.4.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-10-09T21:29:38Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "0ba8e73c41847142e0bed09e09a8aa166fc10384" }
 subdir = 'libs/cardano-ledger-binary'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-11T19:55:16Z

--- a/_sources/cardano-ledger-binary/1.4.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.4.0.0/revisions/1.cabal
@@ -1,0 +1,199 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.4.0.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/intersectmbo/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting >=0.2,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        FailT,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api >=1.27.0,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        vector,
+        vector-map ^>=1.1
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Cddl
+        Test.Cardano.Ledger.Binary.Cuddle
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting:{cardano-slotting, testlib} >=0.1.2,
+        cborg,
+        containers,
+        cuddle >=0.3.2,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        hspec-core,
+        pretty-show,
+        prettyprinter,
+        prettyprinter-ansi-terminal,
+        primitive,
+        QuickCheck,
+        quickcheck-instances,
+        tasty-hunit,
+        random >=1.2,
+        text,
+        typed-process,
+        unliftio,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map
+
+benchmark bench
+    type:             exitcode-stdio-1.0
+    main-is:          Bench.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        containers,
+        criterion,
+        deepseq,
+        random

--- a/_sources/cardano-ledger-binary/1.4.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.4.0.0/revisions/1.cabal
@@ -124,7 +124,7 @@ library testlib
         prettyprinter-ansi-terminal,
         primitive,
         QuickCheck,
-        quickcheck-instances,
+        quickcheck-instances <0.3.32,
         tasty-hunit,
         random >=1.2,
         text,

--- a/_sources/cardano-ledger-core/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/0.1.0.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-core'
 [[revisions]]
 number = 1
 timestamp = 2023-03-21T14:35:43Z
+
+[[revisions]]
+number = 2
+timestamp = 2024-12-12T00:23:01Z

--- a/_sources/cardano-ledger-core/0.1.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/0.1.0.0/revisions/2.cabal
@@ -1,0 +1,99 @@
+cabal-version:      2.4
+name:               cardano-ledger-core
+version:            0.1.0.0
+synopsis:           Core components of Cardano ledgers from the Shelley release on.
+description:
+  Cardano ledgers from the Shelley release onwards share a core basis rooted in
+  the Shelley ledger specification. This package abstracts a number of components
+  which we expect to be shared amongst all future ledgers implemented around this base.
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+
+license:            Apache-2.0
+author:             IOHK Formal Methods Team
+maintainer:         formal.methods@iohk.io
+copyright:          2021 Input Output (Hong Kong) Ltd.
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/cardano-ledger
+  subdir:   libs/cardano-ledger-core
+
+common base
+  build-depends:
+    base >= 4.12 && < 4.15
+
+common project-config
+  default-language: Haskell2010
+
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wpartial-fields
+    -Wunused-packages
+
+library
+  import:
+    base, project-config
+
+  hs-source-dirs: src
+
+  exposed-modules:
+    Cardano.Ledger.Address
+    Cardano.Ledger.CompactAddress
+    Cardano.Ledger.AuxiliaryData
+    Cardano.Ledger.BaseTypes
+    Cardano.Ledger.BHeaderView
+    Cardano.Ledger.Block
+    Cardano.Ledger.Coin
+    Cardano.Ledger.Compactible
+    Cardano.Ledger.Core
+    Cardano.Ledger.Credential
+    Cardano.Ledger.Crypto
+    Cardano.Ledger.Era
+    Cardano.Ledger.Hashes
+    Cardano.Ledger.Keys
+    Cardano.Ledger.PoolDistr
+    Cardano.Ledger.Rules.ValidationMode
+    Cardano.Ledger.SafeHash
+    Cardano.Ledger.Serialization
+    Cardano.Ledger.Slot
+    Cardano.Ledger.TxIn
+    Cardano.Ledger.UnifiedMap
+    Cardano.Ledger.Val
+
+  build-depends:
+    aeson >= 2,
+    base16-bytestring,
+    binary,
+    bytestring,
+    cardano-binary,
+    cardano-crypto-class < 2.0.0.1,
+    cardano-crypto-praos,
+    cardano-crypto-wrapper,
+    cardano-data,
+    cardano-ledger-byron,
+    cardano-prelude < 0.1.0.1,
+    cardano-slotting,
+    containers,
+    data-default-class < 0.2,
+    deepseq,
+    groups,
+    iproute,
+    mtl,
+    network,
+    nothunks,
+    partial-order,
+    quiet,
+    scientific,
+    set-algebra,
+    non-integral,
+    primitive,
+    small-steps,
+    strict-containers,
+    text,
+    time,
+    transformers,
+    validation-selective,

--- a/_sources/cardano-ledger-core/0.1.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/0.1.0.0/revisions/2.cabal
@@ -78,6 +78,7 @@ library
     cardano-prelude < 0.1.0.1,
     cardano-slotting,
     containers,
+    data-default <0.8,
     data-default-class < 0.2,
     deepseq,
     groups,

--- a/_sources/cardano-ledger-core/0.1.1.1/meta.toml
+++ b/_sources/cardano-ledger-core/0.1.1.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-11-11T00:24:50Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "2fac95ef338ff9622543d08fe16d0fa6716d0019" }
 subdir = 'libs/cardano-ledger-core'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-12T00:23:01Z

--- a/_sources/cardano-ledger-core/0.1.1.1/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/0.1.1.1/revisions/1.cabal
@@ -1,0 +1,106 @@
+cabal-version:      2.4
+name:               cardano-ledger-core
+version:            0.1.1.1
+synopsis:           Core components of Cardano ledgers from the Shelley release on.
+description:
+  Cardano ledgers from the Shelley release onwards share a core basis rooted in
+  the Shelley ledger specification. This package abstracts a number of components
+  which we expect to be shared amongst all future ledgers implemented around this base.
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+
+license:            Apache-2.0
+author:             IOHK Formal Methods Team
+maintainer:         formal.methods@iohk.io
+copyright:          2021 Input Output (Hong Kong) Ltd.
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/cardano-ledger
+  subdir:   libs/cardano-ledger-core
+
+common base
+  build-depends:
+    base >= 4.12 && < 4.15
+
+common project-config
+  default-language: Haskell2010
+
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wpartial-fields
+    -Wunused-packages
+
+library
+  import:
+    base, project-config
+
+  hs-source-dirs: src
+
+  exposed-modules:
+    Cardano.Ledger.Address
+    Cardano.Ledger.CompactAddress
+    Cardano.Ledger.AuxiliaryData
+    Cardano.Ledger.BaseTypes
+    Cardano.Ledger.BHeaderView
+    Cardano.Ledger.Block
+    Cardano.Ledger.Coin
+    Cardano.Ledger.Compactible
+    Cardano.Ledger.Core
+    Cardano.Ledger.Credential
+    Cardano.Ledger.Crypto
+    Cardano.Ledger.Era
+    Cardano.Ledger.Hashes
+    Cardano.Ledger.HKD
+    Cardano.Ledger.Keys
+    Cardano.Ledger.Keys.Bootstrap
+    Cardano.Ledger.Keys.WitVKey
+    Cardano.Ledger.Language
+    Cardano.Ledger.PoolDistr
+    Cardano.Ledger.Rules.ValidationMode
+    Cardano.Ledger.SafeHash
+    Cardano.Ledger.Serialization
+    Cardano.Ledger.Slot
+    Cardano.Ledger.TxIn
+    Cardano.Ledger.UnifiedMap
+    Cardano.Ledger.Val
+
+  build-depends:
+    aeson >= 2,
+    base16-bytestring,
+    binary,
+    bytestring,
+    cardano-binary,
+    cardano-crypto,
+    cardano-crypto-class <2.2,
+    cardano-crypto-praos,
+    cardano-crypto-wrapper,
+    cardano-data,
+    cardano-ledger-byron,
+    cardano-prelude,
+    cardano-slotting,
+    containers,
+    data-default-class <0.2,
+    deepseq,
+    groups,
+    heapwords,
+    iproute,
+    mtl,
+    microlens,
+    network,
+    nothunks,
+    partial-order,
+    quiet,
+    scientific,
+    set-algebra,
+    non-integral,
+    primitive,
+    small-steps,
+    cardano-strict-containers,
+    text,
+    time,
+    transformers,
+    validation-selective,

--- a/_sources/cardano-ledger-core/0.1.1.1/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/0.1.1.1/revisions/1.cabal
@@ -83,6 +83,7 @@ library
     cardano-prelude,
     cardano-slotting,
     containers,
+    data-default <0.8,
     data-default-class <0.2,
     deepseq,
     groups,

--- a/_sources/cardano-ledger-core/0.1.1.2/meta.toml
+++ b/_sources/cardano-ledger-core/0.1.1.2/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-11-14T13:25:11Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "760a73e89ef040d3ad91b4b0386b3bbace9431a9" }
 subdir = 'libs/cardano-ledger-core'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-12T00:23:01Z

--- a/_sources/cardano-ledger-core/0.1.1.2/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/0.1.1.2/revisions/1.cabal
@@ -83,6 +83,7 @@ library
     cardano-prelude,
     cardano-slotting,
     containers,
+    data-default <0.8,
     data-default-class <0.2,
     deepseq,
     groups,

--- a/_sources/cardano-ledger-core/0.1.1.2/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/0.1.1.2/revisions/1.cabal
@@ -1,0 +1,106 @@
+cabal-version:      2.4
+name:               cardano-ledger-core
+version:            0.1.1.2
+synopsis:           Core components of Cardano ledgers from the Shelley release on.
+description:
+  Cardano ledgers from the Shelley release onwards share a core basis rooted in
+  the Shelley ledger specification. This package abstracts a number of components
+  which we expect to be shared amongst all future ledgers implemented around this base.
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+
+license:            Apache-2.0
+author:             IOHK Formal Methods Team
+maintainer:         formal.methods@iohk.io
+copyright:          2021 Input Output (Hong Kong) Ltd.
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/cardano-ledger
+  subdir:   libs/cardano-ledger-core
+
+common base
+  build-depends:
+    base >= 4.12 && < 4.17
+
+common project-config
+  default-language: Haskell2010
+
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wpartial-fields
+    -Wunused-packages
+
+library
+  import:
+    base, project-config
+
+  hs-source-dirs: src
+
+  exposed-modules:
+    Cardano.Ledger.Address
+    Cardano.Ledger.CompactAddress
+    Cardano.Ledger.AuxiliaryData
+    Cardano.Ledger.BaseTypes
+    Cardano.Ledger.BHeaderView
+    Cardano.Ledger.Block
+    Cardano.Ledger.Coin
+    Cardano.Ledger.Compactible
+    Cardano.Ledger.Core
+    Cardano.Ledger.Credential
+    Cardano.Ledger.Crypto
+    Cardano.Ledger.Era
+    Cardano.Ledger.Hashes
+    Cardano.Ledger.HKD
+    Cardano.Ledger.Keys
+    Cardano.Ledger.Keys.Bootstrap
+    Cardano.Ledger.Keys.WitVKey
+    Cardano.Ledger.Language
+    Cardano.Ledger.PoolDistr
+    Cardano.Ledger.Rules.ValidationMode
+    Cardano.Ledger.SafeHash
+    Cardano.Ledger.Serialization
+    Cardano.Ledger.Slot
+    Cardano.Ledger.TxIn
+    Cardano.Ledger.UnifiedMap
+    Cardano.Ledger.Val
+
+  build-depends:
+    aeson >= 2,
+    base16-bytestring,
+    binary,
+    bytestring,
+    cardano-binary,
+    cardano-crypto,
+    cardano-crypto-class <2.2,
+    cardano-crypto-praos,
+    cardano-crypto-wrapper,
+    cardano-data,
+    cardano-ledger-byron,
+    cardano-prelude,
+    cardano-slotting,
+    containers,
+    data-default-class <0.2,
+    deepseq,
+    groups,
+    heapwords,
+    iproute,
+    mtl,
+    microlens,
+    network,
+    nothunks,
+    partial-order,
+    quiet,
+    scientific,
+    set-algebra,
+    non-integral,
+    primitive,
+    small-steps,
+    cardano-strict-containers,
+    text,
+    time,
+    transformers,
+    validation-selective,

--- a/_sources/cardano-ledger-core/1.0.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.0.0.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-core'
 [[revisions]]
 number = 1
 timestamp = 2024-01-25T14:10:44Z
+
+[[revisions]]
+number = 2
+timestamp = 2024-12-12T00:23:01Z

--- a/_sources/cardano-ledger-core/1.0.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.0.0.0/revisions/2.cabal
@@ -1,0 +1,183 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.0.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.CompactAddress
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.DPState
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMapCompact
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.12 && <4.17,
+        aeson >=2,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data >=1.0 && <1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        quiet,
+        scientific,
+        set-algebra,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.0,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        tree-diff,
+        validation-selective,
+        vector-map ^>=1.0
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron-test,
+        containers,
+        deepseq,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        text,
+        vector-map
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core,
+        testlib,
+        cardano-crypto-class,
+        genvalidity,
+        genvalidity-scientific,
+        scientific

--- a/_sources/cardano-ledger-core/1.0.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.0.0.0/revisions/2.cabal
@@ -88,6 +88,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         groups,

--- a/_sources/cardano-ledger-core/1.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.1.0.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-core'
 [[revisions]]
 number = 1
 timestamp = 2024-01-25T14:10:44Z
+
+[[revisions]]
+number = 2
+timestamp = 2024-12-12T00:23:01Z

--- a/_sources/cardano-ledger-core/1.1.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.1.0.0/revisions/2.cabal
@@ -1,0 +1,185 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.1.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.CompactAddress
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.DPState
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMapCompact
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.17,
+        aeson >=2,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary >=1.0,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data >=1.0 && <1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        quiet,
+        scientific,
+        set-algebra,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.0,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        tree-diff,
+        validation-selective,
+        vector-map ^>=1.0
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron-test,
+        containers,
+        deepseq,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        text,
+        vector-map
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core,
+        cardano-crypto-class,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific

--- a/_sources/cardano-ledger-core/1.1.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.1.0.0/revisions/2.cabal
@@ -88,6 +88,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.1.0.1/meta.toml
+++ b/_sources/cardano-ledger-core/1.1.0.1/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-core'
 [[revisions]]
 number = 1
 timestamp = 2024-01-25T14:10:44Z
+
+[[revisions]]
+number = 2
+timestamp = 2024-12-12T00:23:01Z

--- a/_sources/cardano-ledger-core/1.1.0.1/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.1.0.1/revisions/2.cabal
@@ -88,6 +88,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.1.0.1/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.1.0.1/revisions/2.cabal
@@ -1,0 +1,185 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.1.0.1
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.CompactAddress
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.DPState
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMapCompact
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.17,
+        aeson >=2,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary >=1.0,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data >=1.0 && <1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        quiet,
+        scientific,
+        set-algebra,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.0,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        tree-diff,
+        validation-selective,
+        vector-map ^>=1.0
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron-test,
+        containers,
+        deepseq,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        text,
+        vector-map
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core,
+        cardano-crypto-class,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific

--- a/_sources/cardano-ledger-core/1.10.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.10.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-01-26T10:34:07Z
 github = { repo = "IntersectMBO/cardano-ledger", rev = "6e2d37cc0f47bd02e89b4ce9f78b59c35c958e96" }
 subdir = 'libs/cardano-ledger-core'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-12T00:23:01Z

--- a/_sources/cardano-ledger-core/1.10.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/1.10.0.0/revisions/1.cabal
@@ -1,0 +1,269 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.10.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/intersectmbo/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.Ap
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.CertState
+        Cardano.Ledger.DRep
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Plutus
+        Cardano.Ledger.Plutus.CostModels
+        Cardano.Ledger.Plutus.Data
+        Cardano.Ledger.Plutus.ExUnits
+        Cardano.Ledger.Plutus.Language
+        Cardano.Ledger.Plutus.TxInfo
+        Cardano.Ledger.Plutus.Evaluate
+        Cardano.Ledger.Plutus.ToPlutusData
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.Tools
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMap
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Keys.Internal
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+        Cardano.Ledger.Core.TxCert
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson >=2,
+        base16-bytestring,
+        base64-bytestring,
+        base-deriving-via,
+        binary,
+        bytestring,
+        cardano-ledger-binary ^>=1.3,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data ^>=1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        measures,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        plutus-ledger-api,
+        prettyprinter,
+        quiet,
+        serialise,
+        scientific,
+        set-algebra,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.0,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        utf8-string,
+        validation-selective,
+        vector-map ^>=1.1
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.Binary
+        Test.Cardano.Ledger.Core.Binary.RoundTrip
+        Test.Cardano.Ledger.Core.JSON
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+        Test.Cardano.Ledger.Core.Rational
+        Test.Cardano.Ledger.Imp.Common
+        Test.Cardano.Ledger.Plutus
+        Test.Cardano.Ledger.Plutus.Examples
+        Test.Cardano.Ledger.TreeDiff
+        Test.Cardano.Ledger.Plutus.ToPlutusData
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        aeson,
+        aeson-pretty,
+        base,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-crypto-wrapper,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib} ^>=1.3,
+        cardano-ledger-byron,
+        cardano-ledger-byron-test,
+        containers,
+        data-default-class,
+        deepseq,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        HUnit,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib},
+        random >=1.2,
+        text,
+        tree-diff,
+        vector-map:{vector-map, testlib},
+        time,
+        cardano-slotting,
+        unliftio
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.BinarySpec
+        Test.Cardano.Ledger.JsonSpec
+        Test.Cardano.Ledger.PlutusSpec
+        Test.Cardano.Ledger.UMapSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core,
+        cardano-crypto-class,
+        containers,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific
+
+benchmark umap
+    type:             exitcode-stdio-1.0
+    main-is:          UMap.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        cardano-ledger-core,
+        testlib,
+        containers,
+        criterion,
+        QuickCheck
+
+benchmark addr
+    type:             exitcode-stdio-1.0
+    main-is:          Addr.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-core,
+        testlib,
+        criterion,
+        QuickCheck

--- a/_sources/cardano-ledger-core/1.10.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/1.10.0.0/revisions/1.cabal
@@ -102,6 +102,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.11.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.11.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-03-29T00:54:16Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "ed6d38b0bf0a54504c781b3c274745846476ca3c" }
 subdir = 'libs/cardano-ledger-core'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-12T00:23:01Z

--- a/_sources/cardano-ledger-core/1.11.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/1.11.0.0/revisions/1.cabal
@@ -1,0 +1,274 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.11.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/intersectmbo/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.Ap
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.CertState
+        Cardano.Ledger.DRep
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Plutus
+        Cardano.Ledger.Plutus.CostModels
+        Cardano.Ledger.Plutus.Data
+        Cardano.Ledger.Plutus.ExUnits
+        Cardano.Ledger.Plutus.Language
+        Cardano.Ledger.Plutus.TxInfo
+        Cardano.Ledger.Plutus.Evaluate
+        Cardano.Ledger.Plutus.ToPlutusData
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.Tools
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMap
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Keys.Internal
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+        Cardano.Ledger.Core.TxCert
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson >=2,
+        base16-bytestring,
+        base64-bytestring,
+        base-deriving-via,
+        binary,
+        bytestring,
+        cardano-ledger-binary ^>=1.3,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data ^>=1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        measures,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        plutus-ledger-api,
+        prettyprinter,
+        quiet,
+        serialise,
+        scientific,
+        set-algebra,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.1,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        utf8-string,
+        validation-selective,
+        vector-map ^>=1.1
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.Binary
+        Test.Cardano.Ledger.Core.Binary.RoundTrip
+        Test.Cardano.Ledger.Core.JSON
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+        Test.Cardano.Ledger.Core.Rational
+        Test.Cardano.Ledger.Imp.Common
+        Test.Cardano.Ledger.Plutus
+        Test.Cardano.Ledger.Plutus.Examples
+        Test.Cardano.Ledger.TreeDiff
+        Test.Cardano.Ledger.Plutus.ToPlutusData
+        Test.Cardano.Ledger.Plutus.ScriptTestContext
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        aeson,
+        aeson-pretty,
+        base,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-crypto-test,
+        cardano-crypto-wrapper,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib} ^>=1.3,
+        cardano-ledger-byron,
+        cardano-ledger-byron-test,
+        containers,
+        data-default-class,
+        deepseq,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        HUnit,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        quickcheck-transformer,
+        plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib},
+        random >=1.2,
+        text,
+        tree-diff,
+        vector-map:{vector-map, testlib},
+        time,
+        cardano-slotting,
+        unliftio,
+        small-steps >=1.1
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.BinarySpec
+        Test.Cardano.Ledger.JsonSpec
+        Test.Cardano.Ledger.PlutusSpec
+        Test.Cardano.Ledger.UMapSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron,
+        cardano-ledger-core,
+        cardano-crypto-class,
+        containers,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific
+
+benchmark umap
+    type:             exitcode-stdio-1.0
+    main-is:          UMap.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        cardano-ledger-core,
+        testlib,
+        containers,
+        criterion,
+        QuickCheck
+
+benchmark addr
+    type:             exitcode-stdio-1.0
+    main-is:          Addr.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-core,
+        testlib,
+        criterion,
+        QuickCheck

--- a/_sources/cardano-ledger-core/1.11.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/1.11.0.0/revisions/1.cabal
@@ -102,6 +102,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.12.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.12.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-05-10T03:50:29Z
 github = { repo = "IntersectMBO/cardano-ledger", rev = "15afd0483" }
 subdir = 'libs/cardano-ledger-core'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-12T00:23:01Z

--- a/_sources/cardano-ledger-core/1.12.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/1.12.0.0/revisions/1.cabal
@@ -1,0 +1,279 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.12.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/intersectmbo/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.Ap
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.CertState
+        Cardano.Ledger.DRep
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Metadata
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Plutus
+        Cardano.Ledger.Plutus.CostModels
+        Cardano.Ledger.Plutus.Data
+        Cardano.Ledger.Plutus.ExUnits
+        Cardano.Ledger.Plutus.Language
+        Cardano.Ledger.Plutus.TxInfo
+        Cardano.Ledger.Plutus.Evaluate
+        Cardano.Ledger.Plutus.ToPlutusData
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.Tools
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMap
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Keys.Internal
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+        Cardano.Ledger.Core.TxCert
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson >=2,
+        base16-bytestring,
+        base64-bytestring,
+        base-deriving-via,
+        binary,
+        bytestring,
+        cardano-ledger-binary ^>=1.3,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data ^>=1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        measures,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        plutus-ledger-api,
+        prettyprinter,
+        random,
+        quiet,
+        serialise,
+        scientific,
+        set-algebra,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.1,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        utf8-string,
+        validation-selective,
+        vector-map ^>=1.1
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.Binary
+        Test.Cardano.Ledger.Core.Binary.RoundTrip
+        Test.Cardano.Ledger.Core.JSON
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+        Test.Cardano.Ledger.Core.Rational
+        Test.Cardano.Ledger.Core.Tools
+        Test.Cardano.Ledger.Imp.Common
+        Test.Cardano.Ledger.Plutus
+        Test.Cardano.Ledger.Plutus.Examples
+        Test.Cardano.Ledger.TreeDiff
+        Test.Cardano.Ledger.Plutus.ToPlutusData
+        Test.Cardano.Ledger.Plutus.ScriptTestContext
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        aeson,
+        aeson-pretty,
+        base,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-crypto-test,
+        cardano-crypto-wrapper,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib} ^>=1.3,
+        cardano-ledger-byron,
+        cardano-ledger-byron-test,
+        containers,
+        data-default-class,
+        deepseq,
+        FailT,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        HUnit,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        quickcheck-transformer,
+        plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib},
+        random >=1.2,
+        text,
+        tree-diff,
+        vector-map:{vector-map, testlib},
+        time,
+        cardano-slotting,
+        unliftio,
+        small-steps >=1.1,
+        quickcheck-instances
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.BinarySpec
+        Test.Cardano.Ledger.JsonSpec
+        Test.Cardano.Ledger.PlutusSpec
+        Test.Cardano.Ledger.UMapSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron,
+        cardano-ledger-core,
+        cardano-crypto-class,
+        containers,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific
+
+benchmark umap
+    type:             exitcode-stdio-1.0
+    main-is:          UMap.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        cardano-ledger-core,
+        testlib,
+        containers,
+        criterion,
+        QuickCheck
+
+benchmark addr
+    type:             exitcode-stdio-1.0
+    main-is:          Addr.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-core,
+        testlib,
+        criterion,
+        QuickCheck

--- a/_sources/cardano-ledger-core/1.12.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/1.12.0.0/revisions/1.cabal
@@ -103,6 +103,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.13.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.13.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-06-18T12:42:43Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "923e75bf3e16da01f26ed1ab53d9aac7184fc699" }
 subdir = 'libs/cardano-ledger-core'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-12T00:23:01Z

--- a/_sources/cardano-ledger-core/1.13.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/1.13.0.0/revisions/1.cabal
@@ -1,0 +1,279 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.13.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/intersectmbo/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.Ap
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.CertState
+        Cardano.Ledger.DRep
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Metadata
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Plutus
+        Cardano.Ledger.Plutus.CostModels
+        Cardano.Ledger.Plutus.Data
+        Cardano.Ledger.Plutus.ExUnits
+        Cardano.Ledger.Plutus.Language
+        Cardano.Ledger.Plutus.TxInfo
+        Cardano.Ledger.Plutus.Evaluate
+        Cardano.Ledger.Plutus.ToPlutusData
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.Tools
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMap
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Keys.Internal
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+        Cardano.Ledger.Core.TxCert
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson >=2,
+        base16-bytestring,
+        base64-bytestring,
+        base-deriving-via,
+        binary,
+        bytestring,
+        cardano-ledger-binary ^>=1.3,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data ^>=1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        measures,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        plutus-ledger-api,
+        prettyprinter,
+        random,
+        quiet,
+        serialise,
+        scientific,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.1,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        utf8-string,
+        validation-selective,
+        vector-map ^>=1.1
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.Binary
+        Test.Cardano.Ledger.Core.Binary.RoundTrip
+        Test.Cardano.Ledger.Core.JSON
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+        Test.Cardano.Ledger.Core.Rational
+        Test.Cardano.Ledger.Core.Tools
+        Test.Cardano.Ledger.Imp.Common
+        Test.Cardano.Ledger.Plutus
+        Test.Cardano.Ledger.Plutus.Examples
+        Test.Cardano.Ledger.TreeDiff
+        Test.Cardano.Ledger.Plutus.ToPlutusData
+        Test.Cardano.Ledger.Plutus.ScriptTestContext
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        aeson,
+        aeson-pretty,
+        base,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-crypto-test,
+        cardano-crypto-wrapper,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib} ^>=1.3.3,
+        cardano-ledger-byron,
+        cardano-ledger-byron-test,
+        containers,
+        data-default-class,
+        deepseq,
+        FailT,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        HUnit,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        quickcheck-transformer,
+        plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib},
+        random >=1.2,
+        text,
+        tree-diff,
+        vector-map:{vector-map, testlib},
+        time,
+        cardano-slotting,
+        unliftio,
+        small-steps >=1.1,
+        quickcheck-instances
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.BinarySpec
+        Test.Cardano.Ledger.JsonSpec
+        Test.Cardano.Ledger.PlutusSpec
+        Test.Cardano.Ledger.UMapSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron,
+        cardano-ledger-core,
+        cardano-crypto-class,
+        containers,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific
+
+benchmark umap
+    type:             exitcode-stdio-1.0
+    main-is:          UMap.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        cardano-ledger-core,
+        testlib,
+        containers,
+        criterion,
+        QuickCheck
+
+benchmark addr
+    type:             exitcode-stdio-1.0
+    main-is:          Addr.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-core,
+        testlib,
+        criterion,
+        QuickCheck

--- a/_sources/cardano-ledger-core/1.13.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/1.13.0.0/revisions/1.cabal
@@ -103,6 +103,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.13.1.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.13.1.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-06-26T21:39:58Z
 github = { repo = "IntersectMBO/cardano-ledger", rev = "23258c210a73e9e14be8aa3a46ed74d7bc9145e0" }
 subdir = 'libs/cardano-ledger-core'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-12T00:23:02Z

--- a/_sources/cardano-ledger-core/1.13.1.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/1.13.1.0/revisions/1.cabal
@@ -1,0 +1,279 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.13.1.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/intersectmbo/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.Ap
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.CertState
+        Cardano.Ledger.DRep
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Metadata
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Plutus
+        Cardano.Ledger.Plutus.CostModels
+        Cardano.Ledger.Plutus.Data
+        Cardano.Ledger.Plutus.ExUnits
+        Cardano.Ledger.Plutus.Language
+        Cardano.Ledger.Plutus.TxInfo
+        Cardano.Ledger.Plutus.Evaluate
+        Cardano.Ledger.Plutus.ToPlutusData
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.Tools
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMap
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Keys.Internal
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+        Cardano.Ledger.Core.TxCert
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson >=2,
+        base16-bytestring,
+        base64-bytestring,
+        base-deriving-via,
+        binary,
+        bytestring,
+        cardano-ledger-binary ^>=1.3,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data ^>=1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        measures,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        plutus-ledger-api,
+        prettyprinter,
+        random,
+        quiet,
+        serialise,
+        scientific,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.1,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        utf8-string,
+        validation-selective,
+        vector-map ^>=1.1
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.Binary
+        Test.Cardano.Ledger.Core.Binary.RoundTrip
+        Test.Cardano.Ledger.Core.JSON
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+        Test.Cardano.Ledger.Core.Rational
+        Test.Cardano.Ledger.Core.Tools
+        Test.Cardano.Ledger.Imp.Common
+        Test.Cardano.Ledger.Plutus
+        Test.Cardano.Ledger.Plutus.Examples
+        Test.Cardano.Ledger.TreeDiff
+        Test.Cardano.Ledger.Plutus.ToPlutusData
+        Test.Cardano.Ledger.Plutus.ScriptTestContext
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        aeson,
+        aeson-pretty,
+        base,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-crypto-test,
+        cardano-crypto-wrapper,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib} ^>=1.3.3,
+        cardano-ledger-byron,
+        cardano-ledger-byron-test,
+        containers,
+        data-default-class,
+        deepseq,
+        FailT,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        HUnit,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        quickcheck-transformer,
+        plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib},
+        random >=1.2,
+        text,
+        tree-diff,
+        vector-map:{vector-map, testlib},
+        time,
+        cardano-slotting,
+        unliftio,
+        small-steps >=1.1,
+        quickcheck-instances
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.BinarySpec
+        Test.Cardano.Ledger.JsonSpec
+        Test.Cardano.Ledger.PlutusSpec
+        Test.Cardano.Ledger.UMapSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron,
+        cardano-ledger-core,
+        cardano-crypto-class,
+        containers,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific
+
+benchmark umap
+    type:             exitcode-stdio-1.0
+    main-is:          UMap.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        cardano-ledger-core,
+        testlib,
+        containers,
+        criterion,
+        QuickCheck
+
+benchmark addr
+    type:             exitcode-stdio-1.0
+    main-is:          Addr.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-core,
+        testlib,
+        criterion,
+        QuickCheck

--- a/_sources/cardano-ledger-core/1.13.1.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/1.13.1.0/revisions/1.cabal
@@ -103,6 +103,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.13.2.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.13.2.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-07-02T02:47:44Z
 github = { repo = "IntersectMBO/cardano-ledger", rev = "698a24c1b5064468ef614532a6524dce2b41d7f5" }
 subdir = 'libs/cardano-ledger-core'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-12T00:23:02Z

--- a/_sources/cardano-ledger-core/1.13.2.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/1.13.2.0/revisions/1.cabal
@@ -1,0 +1,279 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.13.2.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/intersectmbo/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.Ap
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.CertState
+        Cardano.Ledger.DRep
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Metadata
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Plutus
+        Cardano.Ledger.Plutus.CostModels
+        Cardano.Ledger.Plutus.Data
+        Cardano.Ledger.Plutus.ExUnits
+        Cardano.Ledger.Plutus.Language
+        Cardano.Ledger.Plutus.TxInfo
+        Cardano.Ledger.Plutus.Evaluate
+        Cardano.Ledger.Plutus.ToPlutusData
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.Tools
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMap
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Keys.Internal
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+        Cardano.Ledger.Core.TxCert
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson >=2,
+        base16-bytestring,
+        base64-bytestring,
+        base-deriving-via,
+        binary,
+        bytestring,
+        cardano-ledger-binary ^>=1.3,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data ^>=1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        measures,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        plutus-ledger-api,
+        prettyprinter,
+        random,
+        quiet,
+        serialise,
+        scientific,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.1,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        utf8-string,
+        validation-selective,
+        vector-map ^>=1.1
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.Binary
+        Test.Cardano.Ledger.Core.Binary.RoundTrip
+        Test.Cardano.Ledger.Core.JSON
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+        Test.Cardano.Ledger.Core.Rational
+        Test.Cardano.Ledger.Core.Tools
+        Test.Cardano.Ledger.Imp.Common
+        Test.Cardano.Ledger.Plutus
+        Test.Cardano.Ledger.Plutus.Examples
+        Test.Cardano.Ledger.TreeDiff
+        Test.Cardano.Ledger.Plutus.ToPlutusData
+        Test.Cardano.Ledger.Plutus.ScriptTestContext
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        aeson,
+        aeson-pretty,
+        base,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-crypto-test,
+        cardano-crypto-wrapper,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib} ^>=1.3.3,
+        cardano-ledger-byron,
+        cardano-ledger-byron-test,
+        containers,
+        data-default-class,
+        deepseq,
+        FailT,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        HUnit,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        quickcheck-transformer,
+        plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib},
+        random >=1.2,
+        text,
+        tree-diff,
+        vector-map:{vector-map, testlib},
+        time,
+        cardano-slotting,
+        unliftio,
+        small-steps >=1.1,
+        quickcheck-instances
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.BinarySpec
+        Test.Cardano.Ledger.JsonSpec
+        Test.Cardano.Ledger.PlutusSpec
+        Test.Cardano.Ledger.UMapSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron,
+        cardano-ledger-core,
+        cardano-crypto-class,
+        containers,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific
+
+benchmark umap
+    type:             exitcode-stdio-1.0
+    main-is:          UMap.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        cardano-ledger-core,
+        testlib,
+        containers,
+        criterion,
+        QuickCheck
+
+benchmark addr
+    type:             exitcode-stdio-1.0
+    main-is:          Addr.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-core,
+        testlib,
+        criterion,
+        QuickCheck

--- a/_sources/cardano-ledger-core/1.13.2.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/1.13.2.0/revisions/1.cabal
@@ -103,6 +103,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.14.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.14.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-08-20T20:11:05Z
 github = { repo = "intersectmbo/cardano-ledger", rev = "068c7a6ff43b154219fb73834f7f0c6ee7d752b1" }
 subdir = 'libs/cardano-ledger-core'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-12T00:23:02Z

--- a/_sources/cardano-ledger-core/1.14.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/1.14.0.0/revisions/1.cabal
@@ -1,0 +1,294 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.14.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/intersectmbo/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.Ap
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.CertState
+        Cardano.Ledger.DRep
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Genesis
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Metadata
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Plutus
+        Cardano.Ledger.Plutus.CostModels
+        Cardano.Ledger.Plutus.Data
+        Cardano.Ledger.Plutus.ExUnits
+        Cardano.Ledger.Plutus.Language
+        Cardano.Ledger.Plutus.TxInfo
+        Cardano.Ledger.Plutus.Evaluate
+        Cardano.Ledger.Plutus.ToPlutusData
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.Tools
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMap
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Keys.Internal
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+        Cardano.Ledger.Core.TxCert
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson >=2,
+        base16-bytestring,
+        base64-bytestring,
+        base-deriving-via,
+        binary,
+        bytestring,
+        cardano-ledger-binary ^>=1.3,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data ^>=1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        measures,
+        microlens,
+        network,
+        nothunks >=0.1.5 && <0.3,
+        partial-order,
+        plutus-core,
+        plutus-ledger-api,
+        prettyprinter,
+        random,
+        quiet,
+        serialise,
+        scientific,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.1,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        utf8-string,
+        validation-selective,
+        vector-map ^>=1.1
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.Binary
+        Test.Cardano.Ledger.Core.Binary.RoundTrip
+        Test.Cardano.Ledger.Core.JSON
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+        Test.Cardano.Ledger.Core.Rational
+        Test.Cardano.Ledger.Core.Tools
+        Test.Cardano.Ledger.Imp.Common
+        Test.Cardano.Ledger.Plutus
+        Test.Cardano.Ledger.Plutus.Examples
+        Test.Cardano.Ledger.TreeDiff
+        Test.Cardano.Ledger.Plutus.ToPlutusData
+        Test.Cardano.Ledger.Plutus.ScriptTestContext
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        aeson,
+        aeson-pretty,
+        base,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-crypto-test,
+        cardano-crypto-wrapper,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib} ^>=1.3.3,
+        cardano-ledger-byron,
+        cardano-ledger-byron-test,
+        containers,
+        data-default-class,
+        deepseq,
+        FailT,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        HUnit,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        quickcheck-transformer,
+        plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib},
+        random >=1.2,
+        text,
+        tree-diff,
+        vector-map:{vector-map, testlib},
+        time,
+        cardano-slotting,
+        unliftio,
+        small-steps >=1.1,
+        quickcheck-instances
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+executable plutus-debug
+    main-is:          PlutusDebug.hs
+    hs-source-dirs:   app
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base >=4.14 && <5,
+        cardano-ledger-core
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.BinarySpec
+        Test.Cardano.Ledger.JsonSpec
+        Test.Cardano.Ledger.PlutusSpec
+        Test.Cardano.Ledger.UMapSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron,
+        cardano-ledger-core,
+        cardano-crypto-class,
+        containers,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific
+
+benchmark umap
+    type:             exitcode-stdio-1.0
+    main-is:          UMap.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        cardano-ledger-core,
+        testlib,
+        containers,
+        criterion,
+        QuickCheck
+
+benchmark addr
+    type:             exitcode-stdio-1.0
+    main-is:          Addr.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-core,
+        testlib,
+        criterion,
+        QuickCheck

--- a/_sources/cardano-ledger-core/1.14.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/1.14.0.0/revisions/1.cabal
@@ -104,6 +104,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.14.1.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.14.1.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-09-23T21:46:49Z
 github = { repo = "IntersectMBO/cardano-ledger", rev = "052d07325dcc4bf8a004bcad2c58d7fc7ce65d92" }
 subdir = 'libs/cardano-ledger-core'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-12T00:23:02Z

--- a/_sources/cardano-ledger-core/1.14.1.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/1.14.1.0/revisions/1.cabal
@@ -1,0 +1,294 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.14.1.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/intersectmbo/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.Ap
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.CertState
+        Cardano.Ledger.DRep
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Genesis
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Metadata
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Plutus
+        Cardano.Ledger.Plutus.CostModels
+        Cardano.Ledger.Plutus.Data
+        Cardano.Ledger.Plutus.ExUnits
+        Cardano.Ledger.Plutus.Language
+        Cardano.Ledger.Plutus.TxInfo
+        Cardano.Ledger.Plutus.Evaluate
+        Cardano.Ledger.Plutus.ToPlutusData
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.Tools
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMap
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Keys.Internal
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+        Cardano.Ledger.Core.TxCert
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson >=2,
+        base16-bytestring,
+        base64-bytestring,
+        base-deriving-via,
+        binary,
+        bytestring,
+        cardano-ledger-binary ^>=1.3,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data ^>=1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        measures,
+        microlens,
+        network,
+        nothunks >=0.1.5 && <0.3,
+        partial-order,
+        plutus-core,
+        plutus-ledger-api,
+        prettyprinter,
+        random,
+        quiet,
+        serialise,
+        scientific,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.1,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        utf8-string,
+        validation-selective,
+        vector-map ^>=1.1
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.Binary
+        Test.Cardano.Ledger.Core.Binary.RoundTrip
+        Test.Cardano.Ledger.Core.JSON
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+        Test.Cardano.Ledger.Core.Rational
+        Test.Cardano.Ledger.Core.Tools
+        Test.Cardano.Ledger.Imp.Common
+        Test.Cardano.Ledger.Plutus
+        Test.Cardano.Ledger.Plutus.Examples
+        Test.Cardano.Ledger.TreeDiff
+        Test.Cardano.Ledger.Plutus.ToPlutusData
+        Test.Cardano.Ledger.Plutus.ScriptTestContext
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        aeson,
+        aeson-pretty,
+        base,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-crypto-test,
+        cardano-crypto-wrapper,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib} ^>=1.3.3,
+        cardano-ledger-byron,
+        cardano-ledger-byron-test,
+        containers,
+        data-default-class,
+        deepseq,
+        FailT,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        HUnit,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        quickcheck-transformer,
+        plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib},
+        random >=1.2,
+        text,
+        tree-diff,
+        vector-map:{vector-map, testlib},
+        time,
+        cardano-slotting,
+        unliftio,
+        small-steps >=1.1,
+        quickcheck-instances
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+executable plutus-debug
+    main-is:          PlutusDebug.hs
+    hs-source-dirs:   app
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base >=4.14 && <5,
+        cardano-ledger-core
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.BinarySpec
+        Test.Cardano.Ledger.JsonSpec
+        Test.Cardano.Ledger.PlutusSpec
+        Test.Cardano.Ledger.UMapSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron,
+        cardano-ledger-core,
+        cardano-crypto-class,
+        containers,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific
+
+benchmark umap
+    type:             exitcode-stdio-1.0
+    main-is:          UMap.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        cardano-ledger-core,
+        testlib,
+        containers,
+        criterion,
+        QuickCheck
+
+benchmark addr
+    type:             exitcode-stdio-1.0
+    main-is:          Addr.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-core,
+        testlib,
+        criterion,
+        QuickCheck

--- a/_sources/cardano-ledger-core/1.14.1.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/1.14.1.0/revisions/1.cabal
@@ -104,6 +104,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.15.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.15.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-10-09T21:29:38Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "0ba8e73c41847142e0bed09e09a8aa166fc10384" }
 subdir = 'libs/cardano-ledger-core'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-12T00:23:02Z

--- a/_sources/cardano-ledger-core/1.15.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/1.15.0.0/revisions/1.cabal
@@ -1,0 +1,299 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.15.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/intersectmbo/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.Ap
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.CertState
+        Cardano.Ledger.DRep
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Genesis
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.MemoBytes.Internal
+        Cardano.Ledger.Metadata
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Plutus
+        Cardano.Ledger.Plutus.CostModels
+        Cardano.Ledger.Plutus.Data
+        Cardano.Ledger.Plutus.ExUnits
+        Cardano.Ledger.Plutus.Language
+        Cardano.Ledger.Plutus.TxInfo
+        Cardano.Ledger.Plutus.Evaluate
+        Cardano.Ledger.Plutus.ToPlutusData
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.Tools
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMap
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Keys.Internal
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+        Cardano.Ledger.Core.TxCert
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson >=2,
+        base16-bytestring,
+        base64-bytestring,
+        base-deriving-via,
+        binary,
+        bytestring,
+        cardano-ledger-binary ^>=1.4,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data ^>=1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        measures,
+        microlens,
+        network,
+        nothunks >=0.1.5 && <0.3,
+        partial-order,
+        plutus-core,
+        plutus-ledger-api,
+        prettyprinter,
+        random,
+        quiet,
+        serialise,
+        scientific,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.1,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        utf8-string,
+        validation-selective,
+        vector-map ^>=1.1
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.Binary
+        Test.Cardano.Ledger.Core.Binary.CDDL
+        Test.Cardano.Ledger.Core.Binary.RoundTrip
+        Test.Cardano.Ledger.Core.JSON
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+        Test.Cardano.Ledger.Core.Rational
+        Test.Cardano.Ledger.Core.Tools
+        Test.Cardano.Ledger.Imp.Common
+        Test.Cardano.Ledger.Plutus
+        Test.Cardano.Ledger.Plutus.Examples
+        Test.Cardano.Ledger.TreeDiff
+        Test.Cardano.Ledger.Plutus.ToPlutusData
+        Test.Cardano.Ledger.Plutus.ScriptTestContext
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        aeson,
+        aeson-pretty,
+        base,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-crypto-test,
+        cardano-crypto-wrapper,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.4,
+        cardano-ledger-byron,
+        cardano-ledger-byron-test,
+        containers,
+        cuddle,
+        data-default-class,
+        deepseq,
+        FailT,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        here,
+        HUnit,
+        mtl,
+        nothunks,
+        prettyprinter,
+        primitive,
+        QuickCheck,
+        quickcheck-transformer,
+        plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib},
+        random >=1.2,
+        text,
+        tree-diff,
+        vector-map:{vector-map, testlib},
+        time,
+        cardano-slotting,
+        unliftio,
+        small-steps >=1.1,
+        quickcheck-instances
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+executable plutus-debug
+    main-is:          PlutusDebug.hs
+    hs-source-dirs:   app
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base >=4.14 && <5,
+        cardano-ledger-core
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.BinarySpec
+        Test.Cardano.Ledger.JsonSpec
+        Test.Cardano.Ledger.PlutusSpec
+        Test.Cardano.Ledger.UMapSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron,
+        cardano-ledger-core,
+        cardano-crypto-class,
+        containers,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific
+
+benchmark umap
+    type:             exitcode-stdio-1.0
+    main-is:          UMap.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        cardano-ledger-core,
+        testlib,
+        containers,
+        criterion,
+        QuickCheck
+
+benchmark addr
+    type:             exitcode-stdio-1.0
+    main-is:          Addr.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-core,
+        testlib,
+        criterion,
+        QuickCheck

--- a/_sources/cardano-ledger-core/1.15.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-core/1.15.0.0/revisions/1.cabal
@@ -105,6 +105,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.2.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.2.0.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-core'
 [[revisions]]
 number = 1
 timestamp = 2024-01-25T14:10:44Z
+
+[[revisions]]
+number = 2
+timestamp = 2024-12-12T00:23:02Z

--- a/_sources/cardano-ledger-core/1.2.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.2.0.0/revisions/2.cabal
@@ -1,0 +1,188 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.2.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.CompactAddress
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.CertState
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMap
+        Cardano.Ledger.UMapCompact
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.17,
+        aeson >=2,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary >=1.1.1,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data >=1.0 && <1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        quiet,
+        scientific,
+        set-algebra,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.0,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        tree-diff,
+        validation-selective,
+        vector-map ^>=1.0
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron-test,
+        containers,
+        deepseq,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        text,
+        vector-map
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.UMapSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core,
+        cardano-crypto-class,
+        containers,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific

--- a/_sources/cardano-ledger-core/1.2.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.2.0.0/revisions/2.cabal
@@ -89,6 +89,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.3.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.3.0.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-core'
 [[revisions]]
 number = 1
 timestamp = 2024-01-25T14:10:44Z
+
+[[revisions]]
+number = 2
+timestamp = 2024-12-12T00:23:02Z

--- a/_sources/cardano-ledger-core/1.3.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.3.0.0/revisions/2.cabal
@@ -1,0 +1,190 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.3.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.CompactAddress
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.CertState
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMap
+        Cardano.Ledger.UMapCompact
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Core.TxCert
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson >=2,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary >=1.1.1,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data >=1.0 && <1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        quiet,
+        scientific,
+        set-algebra,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.0,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        tree-diff,
+        validation-selective,
+        vector-map ^>=1.0
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron-test,
+        containers,
+        deepseq,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        random >=1.2,
+        text,
+        vector-map
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.UMapSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core,
+        cardano-crypto-class,
+        containers,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific

--- a/_sources/cardano-ledger-core/1.3.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.3.0.0/revisions/2.cabal
@@ -90,6 +90,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.3.1.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.3.1.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-core'
 [[revisions]]
 number = 1
 timestamp = 2024-01-25T14:10:44Z
+
+[[revisions]]
+number = 2
+timestamp = 2024-12-12T00:23:02Z

--- a/_sources/cardano-ledger-core/1.3.1.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.3.1.0/revisions/2.cabal
@@ -90,6 +90,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.3.1.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.3.1.0/revisions/2.cabal
@@ -1,0 +1,190 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.3.1.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.CompactAddress
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.CertState
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMap
+        Cardano.Ledger.UMapCompact
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Core.TxCert
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson >=2,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary >=1.1.1,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data >=1.0 && <1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        quiet,
+        scientific,
+        set-algebra,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.0,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        tree-diff,
+        validation-selective,
+        vector-map ^>=1.0
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron-test,
+        containers,
+        deepseq,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        random >=1.2,
+        text,
+        vector-map
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.UMapSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core,
+        cardano-crypto-class,
+        containers,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific

--- a/_sources/cardano-ledger-core/1.4.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.4.0.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-core'
 [[revisions]]
 number = 1
 timestamp = 2024-01-25T14:10:44Z
+
+[[revisions]]
+number = 2
+timestamp = 2024-12-12T00:23:02Z

--- a/_sources/cardano-ledger-core/1.4.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.4.0.0/revisions/2.cabal
@@ -90,6 +90,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.4.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.4.0.0/revisions/2.cabal
@@ -1,0 +1,190 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.4.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.CompactAddress
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.CertState
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMap
+        Cardano.Ledger.UMapCompact
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Core.TxCert
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson >=2,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary >=1.1.1,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data >=1.0 && <1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        quiet,
+        scientific,
+        set-algebra,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.0,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        tree-diff,
+        validation-selective,
+        vector-map ^>=1.0
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron-test,
+        containers,
+        deepseq,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        random >=1.2,
+        text,
+        vector-map
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.UMapSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core,
+        cardano-crypto-class,
+        containers,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific

--- a/_sources/cardano-ledger-core/1.4.1.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.4.1.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-core'
 [[revisions]]
 number = 1
 timestamp = 2024-01-25T14:10:44Z
+
+[[revisions]]
+number = 2
+timestamp = 2024-12-12T00:23:02Z

--- a/_sources/cardano-ledger-core/1.4.1.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.4.1.0/revisions/2.cabal
@@ -90,6 +90,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.4.1.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.4.1.0/revisions/2.cabal
@@ -1,0 +1,190 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.4.1.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.CompactAddress
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.CertState
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMap
+        Cardano.Ledger.UMapCompact
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Core.TxCert
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson >=2,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary >=1.1.1,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data >=1.0 && <1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        quiet,
+        scientific,
+        set-algebra,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.0,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        tree-diff,
+        validation-selective,
+        vector-map ^>=1.0
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron-test,
+        containers,
+        deepseq,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        random >=1.2,
+        text,
+        vector-map
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.UMapSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core,
+        cardano-crypto-class,
+        containers,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific

--- a/_sources/cardano-ledger-core/1.5.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.5.0.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-core'
 [[revisions]]
 number = 1
 timestamp = 2024-01-25T14:10:44Z
+
+[[revisions]]
+number = 2
+timestamp = 2024-12-12T00:23:02Z

--- a/_sources/cardano-ledger-core/1.5.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.5.0.0/revisions/2.cabal
@@ -1,0 +1,193 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.5.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.CompactAddress
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.CertState
+        Cardano.Ledger.DRepDistr
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMap
+        Cardano.Ledger.UMapCompact
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Core.TxCert
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson >=2,
+        base16-bytestring,
+        base64-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary >=1.1.1,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data >=1.0 && <1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        quiet,
+        scientific,
+        set-algebra,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.0,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        tree-diff,
+        validation-selective,
+        vector-map ^>=1.0
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.Binary
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron-test,
+        containers,
+        deepseq,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        random >=1.2,
+        text,
+        vector-map
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.UMapSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core,
+        cardano-crypto-class,
+        containers,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific

--- a/_sources/cardano-ledger-core/1.5.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.5.0.0/revisions/2.cabal
@@ -92,6 +92,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.6.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.6.0.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-core'
 [[revisions]]
 number = 1
 timestamp = 2024-01-25T14:10:44Z
+
+[[revisions]]
+number = 2
+timestamp = 2024-12-12T00:23:02Z

--- a/_sources/cardano-ledger-core/1.6.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.6.0.0/revisions/2.cabal
@@ -1,0 +1,230 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.6.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.Ap
+        Cardano.Ledger.CompactAddress
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.CertState
+        Cardano.Ledger.DRepDistr
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMap
+        Cardano.Ledger.UMapCompact
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Core.TxCert
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson >=2,
+        base16-bytestring,
+        base64-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary >=1.1.1,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data >=1.0 && <1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        quiet,
+        scientific,
+        set-algebra,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.0,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        tree-diff,
+        validation-selective,
+        vector-map ^>=1.0
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.Binary
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron-test,
+        containers,
+        deepseq,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        random >=1.2,
+        text,
+        vector-map
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.UMapSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core,
+        cardano-crypto-class,
+        containers,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific
+
+benchmark umap
+    type:             exitcode-stdio-1.0
+    main-is:          UMap.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        cardano-ledger-core,
+        testlib,
+        containers,
+        criterion,
+        QuickCheck
+
+benchmark addr
+    type:             exitcode-stdio-1.0
+    main-is:          Addr.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-core,
+        testlib,
+        criterion,
+        QuickCheck

--- a/_sources/cardano-ledger-core/1.6.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.6.0.0/revisions/2.cabal
@@ -93,6 +93,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.7.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.7.0.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-core'
 [[revisions]]
 number = 1
 timestamp = 2024-01-25T14:10:44Z
+
+[[revisions]]
+number = 2
+timestamp = 2024-12-12T00:23:02Z

--- a/_sources/cardano-ledger-core/1.7.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.7.0.0/revisions/2.cabal
@@ -93,6 +93,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.7.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.7.0.0/revisions/2.cabal
@@ -1,0 +1,233 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.7.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.Ap
+        Cardano.Ledger.CompactAddress
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.CertState
+        Cardano.Ledger.DRepDistr
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMap
+        Cardano.Ledger.UMapCompact
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Core.TxCert
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson >=2,
+        base16-bytestring,
+        base64-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary >=1.1.1,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data >=1.0 && <1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        quiet,
+        scientific,
+        set-algebra,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.0,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        tree-diff,
+        validation-selective,
+        vector-map ^>=1.0
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.Binary
+        Test.Cardano.Ledger.Core.Binary.RoundTrip
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron-test,
+        containers,
+        data-default-class,
+        deepseq,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        random >=1.2,
+        text,
+        vector-map
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.BinarySpec
+        Test.Cardano.Ledger.UMapSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core,
+        cardano-crypto-class,
+        containers,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific
+
+benchmark umap
+    type:             exitcode-stdio-1.0
+    main-is:          UMap.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        cardano-ledger-core,
+        testlib,
+        containers,
+        criterion,
+        QuickCheck
+
+benchmark addr
+    type:             exitcode-stdio-1.0
+    main-is:          Addr.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-core,
+        testlib,
+        criterion,
+        QuickCheck

--- a/_sources/cardano-ledger-core/1.8.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.8.0.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-core'
 [[revisions]]
 number = 1
 timestamp = 2024-01-25T14:10:44Z
+
+[[revisions]]
+number = 2
+timestamp = 2024-12-12T00:23:02Z

--- a/_sources/cardano-ledger-core/1.8.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.8.0.0/revisions/2.cabal
@@ -93,6 +93,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.8.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.8.0.0/revisions/2.cabal
@@ -1,0 +1,236 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.8.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.Ap
+        Cardano.Ledger.CompactAddress
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.CertState
+        Cardano.Ledger.DRep
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMap
+        Cardano.Ledger.UMapCompact
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Core.TxCert
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson >=2,
+        base16-bytestring,
+        base64-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary >=1.1.1,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data >=1.0 && <1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        quiet,
+        scientific,
+        set-algebra,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.0,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        tree-diff,
+        validation-selective,
+        vector-map ^>=1.0
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.Binary
+        Test.Cardano.Ledger.Core.Binary.RoundTrip
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+        Test.Cardano.Ledger.Core.Rational
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron-test,
+        containers,
+        data-default-class,
+        deepseq,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        random >=1.2,
+        text,
+        vector-map,
+        time,
+        cardano-slotting
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.BinarySpec
+        Test.Cardano.Ledger.UMapSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core,
+        cardano-crypto-class,
+        containers,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific
+
+benchmark umap
+    type:             exitcode-stdio-1.0
+    main-is:          UMap.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        cardano-ledger-core,
+        testlib,
+        containers,
+        criterion,
+        QuickCheck
+
+benchmark addr
+    type:             exitcode-stdio-1.0
+    main-is:          Addr.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-core,
+        testlib,
+        criterion,
+        QuickCheck

--- a/_sources/cardano-ledger-core/1.9.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.9.0.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-core'
 [[revisions]]
 number = 1
 timestamp = 2024-01-25T14:10:45Z
+
+[[revisions]]
+number = 2
+timestamp = 2024-12-12T00:23:02Z

--- a/_sources/cardano-ledger-core/1.9.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.9.0.0/revisions/2.cabal
@@ -100,6 +100,7 @@ library
         cardano-prelude,
         cardano-slotting,
         containers,
+        data-default <0.8,
         data-default-class <0.2,
         deepseq,
         FailT,

--- a/_sources/cardano-ledger-core/1.9.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-core/1.9.0.0/revisions/2.cabal
@@ -1,0 +1,255 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.9.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.Ap
+        Cardano.Ledger.CompactAddress
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.CertState
+        Cardano.Ledger.DRep
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Plutus.CostModels
+        Cardano.Ledger.Plutus.Data
+        Cardano.Ledger.Plutus.ExUnits
+        Cardano.Ledger.Plutus.Language
+        Cardano.Ledger.Plutus.TxInfo
+        Cardano.Ledger.Plutus.Evaluate
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMap
+        Cardano.Ledger.UMapCompact
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Core.TxCert
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson >=2.2,
+        base16-bytestring,
+        base64-bytestring,
+        base-deriving-via,
+        binary,
+        bytestring,
+        cardano-ledger-binary >=1.1.1,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data >=1.0 && <1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        measures,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        plutus-ledger-api,
+        plutus-core,
+        prettyprinter,
+        quiet,
+        serialise,
+        scientific,
+        set-algebra,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.0,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        tree-diff,
+        utf8-string,
+        validation-selective,
+        vector-map ^>=1.0
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.Binary
+        Test.Cardano.Ledger.Core.Binary.RoundTrip
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+        Test.Cardano.Ledger.Core.Rational
+        Test.Cardano.Ledger.Imp.Common
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron-test,
+        containers,
+        data-default-class,
+        deepseq,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        HUnit,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        random >=1.2,
+        text,
+        vector-map,
+        time,
+        cardano-slotting,
+        unliftio
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+        Test.Cardano.Ledger.BinarySpec
+        Test.Cardano.Ledger.UMapSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core,
+        cardano-crypto-class,
+        containers,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific
+
+benchmark umap
+    type:             exitcode-stdio-1.0
+    main-is:          UMap.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        cardano-ledger-core,
+        testlib,
+        containers,
+        criterion,
+        QuickCheck
+
+benchmark addr
+    type:             exitcode-stdio-1.0
+    main-is:          Addr.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-core,
+        testlib,
+        criterion,
+        QuickCheck

--- a/_sources/plutus-core/1.37.0.0/meta.toml
+++ b/_sources/plutus-core/1.37.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-11-27T17:49:33Z
 github = { repo = "intersectmbo/plutus", rev = "0effd6caecb0664ae0bc1b9c21363a7e92c35466" }
 subdir = 'plutus-core'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-11T19:50:43Z

--- a/_sources/plutus-core/1.37.0.0/revisions/1.cabal
+++ b/_sources/plutus-core/1.37.0.0/revisions/1.cabal
@@ -1,0 +1,1105 @@
+cabal-version:   3.0
+name:            plutus-core
+version:         1.37.0.0
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+maintainer:      michael.peyton-jones@iohk.io
+author:          Plutus Core Team
+synopsis:        Language library for Plutus Core
+description:     Pretty-printer, parser, and typechecker for Plutus Core.
+category:        Language, Plutus
+build-type:      Simple
+extra-doc-files:
+  CHANGELOG.md
+  README.md
+
+data-files:
+  cost-model/data/*.R
+  cost-model/data/builtinCostModelA.json
+  cost-model/data/builtinCostModelB.json
+  cost-model/data/builtinCostModelC.json
+  cost-model/data/cekMachineCostsA.json
+  cost-model/data/cekMachineCostsB.json
+  cost-model/data/cekMachineCostsC.json
+  plutus-core/test/CostModelInterface/defaultCostModelParams.json
+
+source-repository head
+  type:     git
+  location: https://github.com/IntersectMBO/plutus
+
+-- inline-r is a problematic dependency. It doesn't build with newer
+-- versions of R, so if we depend on it then people need to install
+-- an old R. This is not so bad for people working on plutus itself
+-- (use Nix or work it out), although we may want to eventually
+-- purge it. However, due to a cabal bug (https://github.com/haskell/cabal/issues/4087),
+-- in some cases cabal will require R to be installed _at solving time_,
+-- even though it never wants to build it. This means that the problem
+-- leaks into our downstream dependencies. So our solution is to guard
+-- the dependency behind a flag, off by default, and turn it on for
+-- ourselves locally.
+flag with-inline-r
+  description: Enable build of packages that use `inline-r`.
+  manual:      True
+  default:     False
+
+flag with-cert
+  description: Enable build of packages that use `plutus-cert`.
+  manual:      True
+  default:     False
+
+common lang
+  default-language:   Haskell2010
+  default-extensions:
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveLift
+    DeriveTraversable
+    DerivingStrategies
+    DerivingVia
+    ExplicitForAll
+    FlexibleContexts
+    GeneralizedNewtypeDeriving
+    ImportQualifiedPost
+    ScopedTypeVariables
+    StandaloneDeriving
+
+  ghc-options:
+    -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wredundant-constraints -Widentities
+    -Wunused-packages -Wmissing-deriving-strategies
+
+  if impl(ghc >=9.8)
+    ghc-options: -Wno-x-partial
+
+-- This contains UPLC+TPLC, PIR must be explicitly included by depending
+-- on the public sub-library.
+-- In due course UPLC and TPLC should be split, with the main library
+-- containing UPLC.
+library
+  import:             lang
+  exposed-modules:
+    Codec.Extras.FlatViaSerialise
+    Codec.Extras.SerialiseViaFlat
+    Data.Aeson.THReader
+    Data.Either.Extras
+    Data.List.Extras
+    Data.MultiSet.Lens
+    PlutusCore
+    PlutusCore.Analysis.Definitions
+    PlutusCore.Annotation
+    PlutusCore.Arity
+    PlutusCore.Bitwise
+    PlutusCore.Builtin
+    PlutusCore.Builtin.Debug
+    PlutusCore.Builtin.Elaborate
+    PlutusCore.Check.Normal
+    PlutusCore.Check.Scoping
+    PlutusCore.Check.Uniques
+    PlutusCore.Check.Value
+    PlutusCore.Compiler
+    PlutusCore.Compiler.Erase
+    PlutusCore.Compiler.Opts
+    PlutusCore.Compiler.Types
+    PlutusCore.Core
+    PlutusCore.Core.Plated
+    PlutusCore.Crypto.BLS12_381.Error
+    PlutusCore.Crypto.BLS12_381.G1
+    PlutusCore.Crypto.BLS12_381.G2
+    PlutusCore.Crypto.BLS12_381.Pairing
+    PlutusCore.Crypto.Ed25519
+    PlutusCore.Crypto.ExpMod
+    PlutusCore.Crypto.Hash
+    PlutusCore.Crypto.Secp256k1
+    PlutusCore.Data
+    PlutusCore.DataFilePaths
+    PlutusCore.DeBruijn
+    PlutusCore.DeBruijn.Internal
+    PlutusCore.Default
+    PlutusCore.Default.Builtins
+    PlutusCore.Error
+    PlutusCore.Evaluation.Error
+    PlutusCore.Evaluation.ErrorWithCause
+    PlutusCore.Evaluation.Machine.BuiltinCostModel
+    PlutusCore.Evaluation.Machine.Ck
+    PlutusCore.Evaluation.Machine.CostingFun.Core
+    PlutusCore.Evaluation.Machine.CostingFun.JSON
+    PlutusCore.Evaluation.Machine.CostingFun.SimpleJSON
+    PlutusCore.Evaluation.Machine.CostModelInterface
+    PlutusCore.Evaluation.Machine.CostStream
+    PlutusCore.Evaluation.Machine.ExBudget
+    PlutusCore.Evaluation.Machine.ExBudgetingDefaults
+    PlutusCore.Evaluation.Machine.ExBudgetStream
+    PlutusCore.Evaluation.Machine.Exception
+    PlutusCore.Evaluation.Machine.ExMemory
+    PlutusCore.Evaluation.Machine.ExMemoryUsage
+    PlutusCore.Evaluation.Machine.MachineParameters
+    PlutusCore.Evaluation.Machine.MachineParameters.Default
+    PlutusCore.Evaluation.Machine.SimpleBuiltinCostModel
+    PlutusCore.Evaluation.Result
+    PlutusCore.Examples.Builtins
+    PlutusCore.Examples.Data.Data
+    PlutusCore.Examples.Data.Function
+    PlutusCore.Examples.Data.InterList
+    PlutusCore.Examples.Data.List
+    PlutusCore.Examples.Data.Pair
+    PlutusCore.Examples.Data.Shad
+    PlutusCore.Examples.Data.TreeForest
+    PlutusCore.Examples.Data.Vec
+    PlutusCore.Examples.Everything
+    PlutusCore.Flat
+    PlutusCore.FsTree
+    PlutusCore.Mark
+    PlutusCore.MkPlc
+    PlutusCore.Name.Unique
+    PlutusCore.Name.UniqueMap
+    PlutusCore.Name.UniqueSet
+    PlutusCore.Normalize
+    PlutusCore.Normalize.Internal
+    PlutusCore.Parser
+    PlutusCore.Pretty
+    PlutusCore.Quote
+    PlutusCore.Rename
+    PlutusCore.Rename.Internal
+    PlutusCore.Rename.Monad
+    PlutusCore.Size
+    PlutusCore.StdLib.Data.Bool
+    PlutusCore.StdLib.Data.ChurchNat
+    PlutusCore.StdLib.Data.Data
+    PlutusCore.StdLib.Data.Function
+    PlutusCore.StdLib.Data.Integer
+    PlutusCore.StdLib.Data.List
+    PlutusCore.StdLib.Data.MatchOption
+    PlutusCore.StdLib.Data.Nat
+    PlutusCore.StdLib.Data.Pair
+    PlutusCore.StdLib.Data.ScottList
+    PlutusCore.StdLib.Data.ScottUnit
+    PlutusCore.StdLib.Data.Sum
+    PlutusCore.StdLib.Data.Unit
+    PlutusCore.StdLib.Everything
+    PlutusCore.StdLib.Meta
+    PlutusCore.StdLib.Meta.Data.Function
+    PlutusCore.StdLib.Meta.Data.Tuple
+    PlutusCore.StdLib.Type
+    PlutusCore.Subst
+    PlutusCore.TypeCheck
+    PlutusCore.TypeCheck.Internal
+    PlutusCore.Version
+    PlutusPrelude
+    Prettyprinter.Custom
+    Universe
+    UntypedPlutusCore
+    UntypedPlutusCore.Check.Scope
+    UntypedPlutusCore.Check.Uniques
+    UntypedPlutusCore.Core
+    UntypedPlutusCore.Core.Plated
+    UntypedPlutusCore.Core.Type
+    UntypedPlutusCore.Core.Zip
+    UntypedPlutusCore.DeBruijn
+    UntypedPlutusCore.Evaluation.Machine.Cek
+    UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts
+    UntypedPlutusCore.Evaluation.Machine.Cek.Internal
+    UntypedPlutusCore.Evaluation.Machine.Cek.StepCounter
+    UntypedPlutusCore.Evaluation.Machine.SteppableCek
+    UntypedPlutusCore.Evaluation.Machine.SteppableCek.DebugDriver
+    UntypedPlutusCore.Evaluation.Machine.SteppableCek.Internal
+    UntypedPlutusCore.MkUPlc
+    UntypedPlutusCore.Parser
+    UntypedPlutusCore.Purity
+    UntypedPlutusCore.Rename
+    UntypedPlutusCore.Size
+    UntypedPlutusCore.Transform.CaseOfCase
+    UntypedPlutusCore.Transform.Simplifier
+
+  other-modules:
+    Data.Aeson.Flatten
+    Data.Functor.Foldable.Monadic
+    PlutusCore.Builtin.HasConstant
+    PlutusCore.Builtin.KnownKind
+    PlutusCore.Builtin.KnownType
+    PlutusCore.Builtin.KnownTypeAst
+    PlutusCore.Builtin.Meaning
+    PlutusCore.Builtin.Polymorphism
+    PlutusCore.Builtin.Result
+    PlutusCore.Builtin.Runtime
+    PlutusCore.Builtin.TestKnown
+    PlutusCore.Builtin.TypeScheme
+    PlutusCore.Core.Instance
+    PlutusCore.Core.Instance.Eq
+    PlutusCore.Core.Instance.Pretty
+    PlutusCore.Core.Instance.Pretty.Classic
+    PlutusCore.Core.Instance.Pretty.Default
+    PlutusCore.Core.Instance.Pretty.Plc
+    PlutusCore.Core.Instance.Pretty.Readable
+    PlutusCore.Core.Instance.Scoping
+    PlutusCore.Core.Type
+    PlutusCore.Crypto.Utils
+    PlutusCore.Default.Universe
+    PlutusCore.Eq
+    PlutusCore.Parser.Builtin
+    PlutusCore.Parser.ParserCommon
+    PlutusCore.Parser.Type
+    PlutusCore.Pretty.Classic
+    PlutusCore.Pretty.ConfigName
+    PlutusCore.Pretty.Default
+    PlutusCore.Pretty.Extra
+    PlutusCore.Pretty.Plc
+    PlutusCore.Pretty.PrettyConst
+    PlutusCore.Pretty.Readable
+    PlutusCore.Pretty.Utils
+    Universe.Core
+    UntypedPlutusCore.Analysis.Definitions
+    UntypedPlutusCore.Analysis.Usages
+    UntypedPlutusCore.Core.Instance
+    UntypedPlutusCore.Core.Instance.Eq
+    UntypedPlutusCore.Core.Instance.Flat
+    UntypedPlutusCore.Core.Instance.Pretty
+    UntypedPlutusCore.Core.Instance.Pretty.Classic
+    UntypedPlutusCore.Core.Instance.Pretty.Default
+    UntypedPlutusCore.Core.Instance.Pretty.Plc
+    UntypedPlutusCore.Core.Instance.Pretty.Readable
+    UntypedPlutusCore.Evaluation.Machine.Cek.EmitterMode
+    UntypedPlutusCore.Evaluation.Machine.Cek.ExBudgetMode
+    UntypedPlutusCore.Evaluation.Machine.CommonAPI
+    UntypedPlutusCore.Mark
+    UntypedPlutusCore.Rename.Internal
+    UntypedPlutusCore.Simplify
+    UntypedPlutusCore.Simplify.Opts
+    UntypedPlutusCore.Subst
+    UntypedPlutusCore.Transform.CaseReduce
+    UntypedPlutusCore.Transform.Cse
+    UntypedPlutusCore.Transform.FloatDelay
+    UntypedPlutusCore.Transform.ForceDelay
+    UntypedPlutusCore.Transform.Inline
+
+  reexported-modules: Data.SatInt
+  hs-source-dirs:
+    plutus-core/src plutus-core/stdlib plutus-core/examples
+    untyped-plutus-core/src prelude
+
+  -- Notes on dependencies:
+  -- * Bound on cardano-crypto-class for the fixed SECP primitives and 9.6 support
+  -- * The bound on 'dependent-sum' is needed to avoid https://github.com/obsidiansystems/dependent-sum/issues/72
+  build-depends:
+    , aeson
+    , array
+    , barbies
+    , base                        >=4.9     && <5
+    , base64-bytestring
+    , bimap
+    , bytestring
+    , bytestring-strict-builder
+    , cardano-crypto
+    , cardano-crypto-class        >=2.1.5   && <2.3
+    , cassava
+    , cborg
+    , composition-prelude         >=1.1.0.1
+    , containers
+    , cryptonite
+    , data-default-class
+    , deepseq
+    , dependent-sum               >=0.7.1.0
+    , deriving-aeson              >=0.2.3
+    , deriving-compat
+    , dlist
+    , exceptions
+    , extra
+    , filepath
+    , flat                        ^>=0.6
+    , free
+    , ghc-prim
+    , hashable                    >=1.4
+    , hedgehog                    >=1.0
+    , index-envs
+    , lens
+    , megaparsec
+    , mmorph
+    , mono-traversable
+    , monoidal-containers
+    , mtl
+    , multiset
+    , nothunks                    ^>=0.2
+    , parser-combinators          >=0.4.0
+    , prettyprinter               >=1.1.0.1
+    , prettyprinter-configurable
+    , primitive
+    , profunctors
+    , recursion-schemes
+    , satint
+    , semigroups                  >=0.19.1
+    , serialise
+    , some
+    , template-haskell
+    , text
+    , th-compat
+    , th-lift
+    , th-lift-instances
+    , th-utilities
+    , time
+    , transformers
+    , unordered-containers
+    , vector
+    , witherable
+
+  if impl(ghc <9.0)
+    build-depends: integer-gmp
+
+test-suite plutus-core-test
+  import:           lang
+
+  -- needs linux 'diff' available
+  if os(windows)
+    buildable: False
+
+  type:             exitcode-stdio-1.0
+  main-is:          Spec.hs
+  hs-source-dirs:   plutus-core/test
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
+  other-modules:
+    CBOR.DataStability
+    Check.Spec
+    CostModelInterface.Spec
+    CostModelSafety.Spec
+    Evaluation.Machines
+    Evaluation.Spec
+    Generators.QuickCheck.Utils
+    Names.Spec
+    Normalization.Check
+    Normalization.Type
+    Parser.Spec
+    Pretty.Readable
+    TypeSynthesis.Spec
+
+  default-language: Haskell2010
+  build-depends:
+    , aeson
+    , base                             >=4.9   && <5
+    , bytestring
+    , containers
+    , data-default-class
+    , extra
+    , filepath
+    , flat                             ^>=0.6
+    , hedgehog
+    , hex-text
+    , mmorph
+    , mtl
+    , plutus-core                      ^>=1.37
+    , plutus-core:plutus-core-testlib
+    , prettyprinter
+    , serialise
+    , tasty
+    , tasty-golden
+    , tasty-hedgehog
+    , tasty-hunit
+    , tasty-quickcheck
+    , template-haskell
+    , text
+    , th-lift-instances
+    , th-utilities
+
+test-suite untyped-plutus-core-test
+  import:         lang
+
+  -- needs linux 'diff' available
+  if os(windows)
+    buildable: False
+
+  type:           exitcode-stdio-1.0
+  main-is:        Spec.hs
+  hs-source-dirs: untyped-plutus-core/test
+  ghc-options:    -O2 -threaded -rtsopts -with-rtsopts=-N
+  other-modules:
+    Analysis.Spec
+    DeBruijn.FlatNatWord
+    DeBruijn.Scope
+    DeBruijn.Spec
+    DeBruijn.UnDeBruijnify
+    Evaluation.Builtins
+    Evaluation.Builtins.Bitwise
+    Evaluation.Builtins.BLS12_381
+    Evaluation.Builtins.BLS12_381.TestClasses
+    Evaluation.Builtins.BLS12_381.Utils
+    Evaluation.Builtins.Common
+    Evaluation.Builtins.Conversion
+    Evaluation.Builtins.Costing
+    Evaluation.Builtins.Definition
+    Evaluation.Builtins.Laws
+    Evaluation.Builtins.MakeRead
+    Evaluation.Builtins.SignatureVerification
+    Evaluation.Debug
+    Evaluation.FreeVars
+    Evaluation.Golden
+    Evaluation.Helpers
+    Evaluation.Machines
+    Evaluation.Regressions
+    Flat.Spec
+    Generators
+    Transform.CaseOfCase.Test
+    Transform.Simplify
+    Transform.Simplify.Lib
+
+  build-depends:
+    , base                             >=4.9   && <5
+    , base16-bytestring
+    , bytestring
+    , cardano-crypto-class
+    , dlist
+    , flat                             ^>=0.6
+    , hedgehog
+    , lens
+    , mtl
+    , plutus-core                      ^>=1.37
+    , plutus-core:plutus-core-testlib
+    , pretty-show
+    , prettyprinter
+    , QuickCheck
+    , serialise
+    , split
+    , tasty
+    , tasty-golden
+    , tasty-hedgehog
+    , tasty-hunit
+    , tasty-quickcheck
+    , text
+    , vector
+
+----------------------------------------------
+-- plutus-ir
+----------------------------------------------
+
+library plutus-ir
+  import:          lang
+  visibility:      public
+  hs-source-dirs:  plutus-ir/src
+  exposed-modules:
+    PlutusIR
+    PlutusIR.Analysis.Builtins
+    PlutusIR.Analysis.Dependencies
+    PlutusIR.Analysis.RetainedSize
+    PlutusIR.Analysis.Size
+    PlutusIR.Analysis.VarInfo
+    PlutusIR.Check.Uniques
+    PlutusIR.Compiler
+    PlutusIR.Compiler.Datatype
+    PlutusIR.Compiler.Definitions
+    PlutusIR.Compiler.Let
+    PlutusIR.Compiler.Names
+    PlutusIR.Compiler.Provenance
+    PlutusIR.Compiler.Types
+    PlutusIR.Contexts
+    PlutusIR.Core
+    PlutusIR.Core.Instance
+    PlutusIR.Core.Instance.Flat
+    PlutusIR.Core.Instance.Pretty
+    PlutusIR.Core.Instance.Pretty.Readable
+    PlutusIR.Core.Instance.Scoping
+    PlutusIR.Core.Plated
+    PlutusIR.Core.Type
+    PlutusIR.Error
+    PlutusIR.Mark
+    PlutusIR.MkPir
+    PlutusIR.Parser
+    PlutusIR.Pass
+    PlutusIR.Purity
+    PlutusIR.Subst
+    PlutusIR.Transform.Beta
+    PlutusIR.Transform.CaseOfCase
+    PlutusIR.Transform.CaseReduce
+    PlutusIR.Transform.DeadCode
+    PlutusIR.Transform.EvaluateBuiltins
+    PlutusIR.Transform.Inline.CallSiteInline
+    PlutusIR.Transform.Inline.Inline
+    PlutusIR.Transform.Inline.Utils
+    PlutusIR.Transform.KnownCon
+    PlutusIR.Transform.LetFloatIn
+    PlutusIR.Transform.LetFloatOut
+    PlutusIR.Transform.LetMerge
+    PlutusIR.Transform.NonStrict
+    PlutusIR.Transform.RecSplit
+    PlutusIR.Transform.Rename
+    PlutusIR.Transform.RewriteRules
+    PlutusIR.Transform.RewriteRules.CommuteFnWithConst
+    PlutusIR.Transform.RewriteRules.RemoveTrace
+    PlutusIR.Transform.StrictifyBindings
+    PlutusIR.Transform.Substitute
+    PlutusIR.Transform.ThunkRecursions
+    PlutusIR.Transform.Unwrap
+    PlutusIR.TypeCheck
+    PlutusIR.TypeCheck.Internal
+
+  other-modules:
+    PlutusIR.Analysis.Definitions
+    PlutusIR.Analysis.Usages
+    PlutusIR.Compiler.Error
+    PlutusIR.Compiler.Lower
+    PlutusIR.Compiler.Recursion
+    PlutusIR.Normalize
+    PlutusIR.Transform.RewriteRules.Common
+    PlutusIR.Transform.RewriteRules.Internal
+    PlutusIR.Transform.RewriteRules.UnConstrConstrData
+
+  build-depends:
+    , algebraic-graphs     >=0.7
+    , base                 >=4.9     && <5
+    , containers
+    , dlist
+    , dom-lt
+    , extra
+    , flat                 ^>=0.6
+    , hashable
+    , lens
+    , megaparsec
+    , mmorph
+    , monoidal-containers
+    , mtl
+    , multiset
+    , parser-combinators   >=0.4.0
+    , plutus-core          ^>=1.37
+    , prettyprinter        >=1.1.0.1
+    , profunctors
+    , semigroupoids
+    , semigroups           >=0.19.1
+    , text
+    , transformers
+    , witherable
+
+  if impl(ghc <9.0)
+    build-depends: integer-gmp
+
+test-suite plutus-ir-test
+  import:             lang
+
+  -- needs linux 'diff' available
+  if os(windows)
+    buildable: False
+
+  type:               exitcode-stdio-1.0
+  main-is:            Driver.hs
+  hs-source-dirs:     plutus-ir/test
+  ghc-options:        -threaded -rtsopts -with-rtsopts=-N
+  other-modules:
+    PlutusCore.Generators.QuickCheck.BuiltinsTests
+    PlutusCore.Generators.QuickCheck.SubstitutionTests
+    PlutusCore.Generators.QuickCheck.TypesTests
+    PlutusIR.Analysis.RetainedSize.Tests
+    PlutusIR.Check.Uniques.Tests
+    PlutusIR.Compiler.Datatype.Tests
+    PlutusIR.Compiler.Error.Tests
+    PlutusIR.Compiler.Let.Tests
+    PlutusIR.Compiler.Recursion.Tests
+    PlutusIR.Contexts.Tests
+    PlutusIR.Core.Tests
+    PlutusIR.Generators.QuickCheck.Tests
+    PlutusIR.Parser.Tests
+    PlutusIR.Purity.Tests
+    PlutusIR.Scoping.Tests
+    PlutusIR.Transform.Beta.Tests
+    PlutusIR.Transform.CaseOfCase.Tests
+    PlutusIR.Transform.CaseReduce.Tests
+    PlutusIR.Transform.DeadCode.Tests
+    PlutusIR.Transform.EvaluateBuiltins.Tests
+    PlutusIR.Transform.Inline.Tests
+    PlutusIR.Transform.KnownCon.Tests
+    PlutusIR.Transform.LetFloatIn.Tests
+    PlutusIR.Transform.LetFloatOut.Tests
+    PlutusIR.Transform.NonStrict.Tests
+    PlutusIR.Transform.RecSplit.Tests
+    PlutusIR.Transform.Rename.Tests
+    PlutusIR.Transform.RewriteRules.Tests
+    PlutusIR.Transform.StrictifyBindings.Tests
+    PlutusIR.Transform.StrictLetRec.Tests
+    PlutusIR.Transform.StrictLetRec.Tests.Lib
+    PlutusIR.Transform.ThunkRecursions.Tests
+    PlutusIR.Transform.Unwrap.Tests
+    PlutusIR.TypeCheck.Tests
+
+  build-tool-depends: tasty-discover:tasty-discover
+  build-depends:
+    , base                             >=4.9   && <5
+    , containers
+    , filepath
+    , flat                             ^>=0.6
+    , hashable
+    , hedgehog
+    , lens
+    , mtl
+    , plutus-core                      ^>=1.37
+    , plutus-core:plutus-core-testlib
+    , plutus-core:plutus-ir
+    , QuickCheck
+    , serialise
+    , tasty
+    , tasty-expected-failure
+    , tasty-hedgehog
+    , tasty-hunit
+    , tasty-quickcheck
+    , text
+    , unordered-containers
+
+executable plutus
+  import:             lang
+  main-is:            Main.hs
+  hs-source-dirs:     executables/plutus
+
+  -- singletons-th does not support GHC<=8.10
+  if impl(ghc <9.6)
+    buildable: False
+
+  -- Hydra complains that this is not buildable on mingw32 because of brick.
+  -- Strange, because I thought vty added support for windows.
+  if os(windows)
+    buildable: False
+
+  other-modules:
+    AnyProgram.Apply
+    AnyProgram.Bench
+    AnyProgram.Compile
+    AnyProgram.Debug
+    AnyProgram.Example
+    AnyProgram.IO
+    AnyProgram.Parse
+    AnyProgram.Run
+    AnyProgram.With
+    Common
+    Debugger.TUI.Draw
+    Debugger.TUI.Event
+    Debugger.TUI.Main
+    Debugger.TUI.Types
+    GetOpt
+    Mode.Compile
+    Mode.HelpVersion
+    Mode.ListExamples
+    Mode.PrintBuiltins
+    Mode.PrintCostModel
+    Types
+
+  build-depends:
+    , aeson-pretty
+    , base                   >=4.9   && <5
+    , brick
+    , bytestring
+    , containers
+    , exceptions
+    , filepath
+    , flat
+    , lens
+    , megaparsec
+    , microlens
+    , microlens-th           ^>=0.4
+    , mono-traversable
+    , mtl
+    , plutus-core            ^>=1.37
+    , plutus-core:plutus-ir
+    , prettyprinter
+    , primitive
+    , serialise
+    , singletons
+    , singletons-th
+    , text
+    , text-zipper
+    , vty                    ^>=6
+    , vty-crossplatform      ^>=0.2
+
+  ghc-options:        -O2 -threaded -rtsopts -with-rtsopts=-N
+  default-extensions:
+    GADTs
+    TypeApplications
+
+----------------------------------------------
+-- support libs
+----------------------------------------------
+
+library plutus-core-execlib
+  import:          lang
+  visibility:      public
+  hs-source-dirs:  executables/src
+  exposed-modules:
+    PlutusCore.Executable.AstIO
+    PlutusCore.Executable.Common
+    PlutusCore.Executable.Parsers
+    PlutusCore.Executable.Types
+
+  build-depends:
+    , aeson
+    , base                             >=4.9   && <5
+    , bytestring
+    , flat                             ^>=0.6
+    , lens
+    , megaparsec
+    , monoidal-containers
+    , mtl
+    , optparse-applicative
+    , plutus-core                      ^>=1.37
+    , plutus-core:plutus-core-testlib
+    , plutus-core:plutus-ir
+    , prettyprinter
+    , text
+
+-- could split this up if we split up the main library for UPLC/PLC/PIR
+library plutus-core-testlib
+  import:          lang
+  visibility:      public
+  hs-source-dirs:  testlib
+  exposed-modules:
+    PlutusCore.Generators.Hedgehog
+    PlutusCore.Generators.Hedgehog.AST
+    PlutusCore.Generators.Hedgehog.Builtin
+    PlutusCore.Generators.Hedgehog.Denotation
+    PlutusCore.Generators.Hedgehog.Entity
+    PlutusCore.Generators.Hedgehog.Interesting
+    PlutusCore.Generators.Hedgehog.Test
+    PlutusCore.Generators.Hedgehog.TypedBuiltinGen
+    PlutusCore.Generators.Hedgehog.TypeEvalCheck
+    PlutusCore.Generators.Hedgehog.Utils
+    PlutusCore.Generators.NEAT.Common
+    PlutusCore.Generators.NEAT.Spec
+    PlutusCore.Generators.NEAT.Term
+    PlutusCore.Generators.NEAT.Type
+    PlutusCore.Generators.QuickCheck
+    PlutusCore.Generators.QuickCheck.Builtin
+    PlutusCore.Generators.QuickCheck.Common
+    PlutusCore.Generators.QuickCheck.GenerateKinds
+    PlutusCore.Generators.QuickCheck.GenerateTypes
+    PlutusCore.Generators.QuickCheck.GenTm
+    PlutusCore.Generators.QuickCheck.ShrinkTypes
+    PlutusCore.Generators.QuickCheck.Split
+    PlutusCore.Generators.QuickCheck.Substitutions
+    PlutusCore.Generators.QuickCheck.Unification
+    PlutusCore.Generators.QuickCheck.Utils
+    PlutusCore.Test
+    PlutusIR.Generators.AST
+    PlutusIR.Generators.QuickCheck
+    PlutusIR.Generators.QuickCheck.Common
+    PlutusIR.Generators.QuickCheck.GenerateTerms
+    PlutusIR.Generators.QuickCheck.ShrinkTerms
+    PlutusIR.Pass.Test
+    PlutusIR.Test
+    Test.Tasty.Extras
+    UntypedPlutusCore.Generators.Hedgehog
+    UntypedPlutusCore.Test.DeBruijn.Bad
+    UntypedPlutusCore.Test.DeBruijn.Good
+
+  build-depends:
+    , base                        >=4.9     && <5
+    , bifunctors
+    , bytestring
+    , containers
+    , data-default-class
+    , dependent-map               >=0.4.0.0
+    , filepath
+    , free
+    , hashable
+    , hedgehog                    >=1.0
+    , hedgehog-quickcheck
+    , lazy-search
+    , lens
+    , mmorph
+    , mtl
+    , multiset
+    , plutus-core                 ^>=1.37
+    , plutus-core:plutus-ir
+    , prettyprinter               >=1.1.0.1
+    , prettyprinter-configurable
+    , QuickCheck
+    , quickcheck-instances
+    , quickcheck-transformer
+    , size-based
+    , Stream
+    , tagged
+    , tasty
+    , tasty-golden
+    , tasty-hedgehog
+    , tasty-hunit
+    , text
+
+-- This wraps up the use of the certifier library
+-- so we can present a consistent inteface whether we
+-- are building with it or not. If we aren't building
+-- with it, we present a conservative stub implementation
+-- that just always says everything is fine.
+library plutus-ir-cert
+  import:           lang
+
+  if flag(with-cert)
+    hs-source-dirs: plutus-ir/cert
+    build-depends:  plutus-cert
+
+  else
+    hs-source-dirs: plutus-ir/cert-stub
+
+  default-language: Haskell2010
+  exposed-modules:  PlutusIR.Certifier
+  build-depends:
+    , base
+    , plutus-core            ^>=1.37
+    , plutus-core:plutus-ir
+
+----------------------------------------------
+-- profiling
+----------------------------------------------
+
+executable traceToStacks
+  import:         lang
+  main-is:        Main.hs
+  hs-source-dirs: executables/traceToStacks
+  other-modules:  Common
+  build-depends:
+    , base                  >=4.9 && <5
+    , bytestring
+    , cassava
+    , optparse-applicative
+    , text
+    , vector
+
+-- Tests for functions called by @traceToStacks@.
+test-suite traceToStacks-test
+  import:           lang
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   executables/traceToStacks
+  default-language: Haskell2010
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
+  main-is:          TestGetStacks.hs
+  other-modules:    Common
+  build-depends:
+    , base         >=4.9 && <5
+    , bytestring
+    , cassava
+    , tasty
+    , tasty-hunit
+    , text
+    , vector
+
+----------------------------------------------
+-- cost-model
+----------------------------------------------
+
+-- This runs the microbenchmarks used to generate the cost models for built-in
+-- functions, saving the results in a CSV file which must be specified on the
+-- commmand line.  It will take several hours.
+executable cost-model-budgeting-bench
+  import:         lang
+  main-is:        Main.hs
+  other-modules:
+    Benchmarks.Bitwise
+    Benchmarks.Bool
+    Benchmarks.ByteStrings
+    Benchmarks.Crypto
+    Benchmarks.Data
+    Benchmarks.Integers
+    Benchmarks.Lists
+    Benchmarks.Misc
+    Benchmarks.Nops
+    Benchmarks.Pairs
+    Benchmarks.Strings
+    Benchmarks.Tracing
+    Benchmarks.Unit
+    Common
+    CriterionExtensions
+    Generators
+
+  hs-source-dirs: cost-model/budgeting-bench
+  build-depends:
+    , base                   >=4.9   && <5
+    , bytestring
+    , cardano-crypto-class
+    , criterion
+    , criterion-measurement
+    , deepseq
+    , directory
+    , filepath
+    , hedgehog
+    , mtl
+    , optparse-applicative
+    , plutus-core            ^>=1.37
+    , QuickCheck
+    , quickcheck-instances
+    , random
+    , text
+    , time
+
+-- This reads CSV data generated by cost-model-budgeting-bench, uses R to build
+-- the cost models for built-in functions, and saves them in a specified
+-- JSON file (see the help).  The 'official' cost model should be checked in
+-- in plutus-core/cost-model/data/builtinCostModel.json.
+executable generate-cost-model
+  import:         lang
+  main-is:        Main.hs
+  hs-source-dirs: cost-model/create-cost-model
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
+
+  if !flag(with-inline-r)
+    buildable: False
+
+  -- This fails on Darwin with strange errors and I don't know why
+  -- > Error: C stack usage  17556409549320 is too close to the limit
+  -- > Fatal error: unable to initialize the JI
+  if os(osx)
+    buildable: False
+
+  -- Can't build on windows as it depends on R.
+  if os(windows)
+    buildable: False
+
+  build-depends:
+    , aeson-pretty
+    , barbies
+    , base                  >=4.9   && <5
+    , bytestring
+    , directory
+    , inline-r              >=1.0.1
+    , optparse-applicative
+    , plutus-core           ^>=1.37
+    , text
+
+  --    , exceptions
+  other-modules:
+    BuiltinMemoryModels
+    CreateBuiltinCostModel
+
+-- The cost models for builtins are generated using R and converted into a JSON
+-- form that can later be used to construct Haskell functions.  This tests that
+-- the predictions of the Haskell version are (approximately) identical to the R
+-- ones. This test is problematic in CI: pretending that it's a benchmark will
+-- prevent it from being run automatically but will still allow us to run it
+-- manually; `cabal bench` also sets the working directory to the root of the
+-- relevant package, which makes it easier to find the cost model data files
+-- (unlike `cabal run` for executables, which sets the working directory to the
+-- current shell directory).
+benchmark cost-model-test
+  import:         lang
+  type:           exitcode-stdio-1.0
+  main-is:        TestCostModels.hs
+  other-modules:  TH
+  hs-source-dirs: cost-model/test cost-model/create-cost-model
+
+  if !flag(with-inline-r)
+    buildable: False
+
+  -- This fails on Darwin with strange errors and I don't know why
+  -- > Error: C stack usage  17556409549320 is too close to the limit
+  -- > Fatal error: unable to initialize the JI
+  if os(osx)
+    buildable: False
+
+  -- Can't build on windows as it depends on R.
+  if os(windows)
+    buildable: False
+
+  build-depends:
+    , barbies
+    , base              >=4.9   && <5
+    , bytestring
+    , hedgehog
+    , inline-r          >=1.0.1
+    , mmorph
+    , plutus-core       ^>=1.37
+    , template-haskell
+    , text
+
+  other-modules:
+    BuiltinMemoryModels
+    CreateBuiltinCostModel
+
+executable print-cost-model
+  import:         lang
+  main-is:        Main.hs
+  hs-source-dirs: cost-model/print-cost-model
+  other-modules:  Paths_plutus_core
+  build-depends:
+    , aeson
+    , base         >=4.9   && <5
+    , bytestring
+    , plutus-core  ^>=1.37
+
+----------------------------------------------
+-- satint
+----------------------------------------------
+
+library satint
+  import:          lang
+  exposed-modules: Data.SatInt
+  hs-source-dirs:  satint/src
+  build-depends:
+    , aeson
+    , base              >=4.9 && <5
+    , cassava
+    , deepseq
+    , nothunks
+    , primitive
+    , serialise
+    , template-haskell
+
+test-suite satint-test
+  import:           lang
+  type:             exitcode-stdio-1.0
+  main-is:          TestSatInt.hs
+  build-depends:
+    , base                        >=4.9 && <5
+    , HUnit
+    , QuickCheck
+    , satint
+    , test-framework
+    , test-framework-hunit
+    , test-framework-quickcheck2
+
+  default-language: Haskell2010
+  hs-source-dirs:   satint/test
+
+----------------------------------------------
+-- index-envs
+----------------------------------------------
+
+library index-envs
+  import:           lang
+  visibility:       public
+  hs-source-dirs:   index-envs/src
+  default-language: Haskell2010
+  exposed-modules:
+    Data.RandomAccessList.Class
+    Data.RandomAccessList.RelativizedMap
+    Data.RandomAccessList.SkewBinary
+    Data.RandomAccessList.SkewBinarySlab
+
+  build-depends:
+    , base             >=4.9  && <5
+    , containers
+    , extra
+    , nonempty-vector
+    , ral              ^>=0.2
+
+-- broken for ral-0.2 conflicts with cardano-binary:recursion-schemes
+benchmark index-envs-bench
+  import:           lang
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   index-envs/bench
+  default-language: Haskell2010
+  main-is:          Main.hs
+  build-depends:
+    , base             >=4.9     && <5
+    , criterion        >=1.5.9.0
+    , index-envs
+    , nonempty-vector
+    , ral              ^>=0.2
+    , random           >=1.2.0
+
+-- broken for ral-0.2 conflicts with cardano-binary:recursion-schemes
+test-suite index-envs-test
+  import:           lang
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   index-envs/test
+  default-language: Haskell2010
+  main-is:          Spec.hs
+  other-modules:    RAList.Spec
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+    , base                  >=4.9 && <5
+    , index-envs
+    , nonempty-vector
+    , QuickCheck
+    , quickcheck-instances
+    , tasty
+    , tasty-quickcheck

--- a/_sources/plutus-core/1.38.0.0/meta.toml
+++ b/_sources/plutus-core/1.38.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-12-11T15:05:22Z
 github = { repo = "IntersectMBO/plutus", rev = "d2ab34ed8f412aa719115b70e9e214bddb901542" }
 subdir = 'plutus-core'
+
+[[revisions]]
+number = 1
+timestamp = 2024-12-11T19:50:40Z

--- a/_sources/plutus-core/1.38.0.0/revisions/1.cabal
+++ b/_sources/plutus-core/1.38.0.0/revisions/1.cabal
@@ -1,0 +1,1105 @@
+cabal-version:   3.0
+name:            plutus-core
+version:         1.38.0.0
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+maintainer:      michael.peyton-jones@iohk.io
+author:          Plutus Core Team
+synopsis:        Language library for Plutus Core
+description:     Pretty-printer, parser, and typechecker for Plutus Core.
+category:        Language, Plutus
+build-type:      Simple
+extra-doc-files:
+  CHANGELOG.md
+  README.md
+
+data-files:
+  cost-model/data/*.R
+  cost-model/data/builtinCostModelA.json
+  cost-model/data/builtinCostModelB.json
+  cost-model/data/builtinCostModelC.json
+  cost-model/data/cekMachineCostsA.json
+  cost-model/data/cekMachineCostsB.json
+  cost-model/data/cekMachineCostsC.json
+  plutus-core/test/CostModelInterface/defaultCostModelParams.json
+
+source-repository head
+  type:     git
+  location: https://github.com/IntersectMBO/plutus
+
+-- inline-r is a problematic dependency. It doesn't build with newer
+-- versions of R, so if we depend on it then people need to install
+-- an old R. This is not so bad for people working on plutus itself
+-- (use Nix or work it out), although we may want to eventually
+-- purge it. However, due to a cabal bug (https://github.com/haskell/cabal/issues/4087),
+-- in some cases cabal will require R to be installed _at solving time_,
+-- even though it never wants to build it. This means that the problem
+-- leaks into our downstream dependencies. So our solution is to guard
+-- the dependency behind a flag, off by default, and turn it on for
+-- ourselves locally.
+flag with-inline-r
+  description: Enable build of packages that use `inline-r`.
+  manual:      True
+  default:     False
+
+flag with-cert
+  description: Enable build of packages that use `plutus-cert`.
+  manual:      True
+  default:     False
+
+common lang
+  default-language:   Haskell2010
+  default-extensions:
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveLift
+    DeriveTraversable
+    DerivingStrategies
+    DerivingVia
+    ExplicitForAll
+    FlexibleContexts
+    GeneralizedNewtypeDeriving
+    ImportQualifiedPost
+    ScopedTypeVariables
+    StandaloneDeriving
+
+  ghc-options:
+    -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wredundant-constraints -Widentities
+    -Wunused-packages -Wmissing-deriving-strategies
+
+  if impl(ghc >=9.8)
+    ghc-options: -Wno-x-partial
+
+-- This contains UPLC+TPLC, PIR must be explicitly included by depending
+-- on the public sub-library.
+-- In due course UPLC and TPLC should be split, with the main library
+-- containing UPLC.
+library
+  import:             lang
+  exposed-modules:
+    Codec.Extras.FlatViaSerialise
+    Codec.Extras.SerialiseViaFlat
+    Data.Aeson.THReader
+    Data.Either.Extras
+    Data.List.Extras
+    Data.MultiSet.Lens
+    PlutusCore
+    PlutusCore.Analysis.Definitions
+    PlutusCore.Annotation
+    PlutusCore.Arity
+    PlutusCore.Bitwise
+    PlutusCore.Builtin
+    PlutusCore.Builtin.Debug
+    PlutusCore.Builtin.Elaborate
+    PlutusCore.Check.Normal
+    PlutusCore.Check.Scoping
+    PlutusCore.Check.Uniques
+    PlutusCore.Check.Value
+    PlutusCore.Compiler
+    PlutusCore.Compiler.Erase
+    PlutusCore.Compiler.Opts
+    PlutusCore.Compiler.Types
+    PlutusCore.Core
+    PlutusCore.Core.Plated
+    PlutusCore.Crypto.BLS12_381.Error
+    PlutusCore.Crypto.BLS12_381.G1
+    PlutusCore.Crypto.BLS12_381.G2
+    PlutusCore.Crypto.BLS12_381.Pairing
+    PlutusCore.Crypto.Ed25519
+    PlutusCore.Crypto.ExpMod
+    PlutusCore.Crypto.Hash
+    PlutusCore.Crypto.Secp256k1
+    PlutusCore.Data
+    PlutusCore.DataFilePaths
+    PlutusCore.DeBruijn
+    PlutusCore.DeBruijn.Internal
+    PlutusCore.Default
+    PlutusCore.Default.Builtins
+    PlutusCore.Error
+    PlutusCore.Evaluation.Error
+    PlutusCore.Evaluation.ErrorWithCause
+    PlutusCore.Evaluation.Machine.BuiltinCostModel
+    PlutusCore.Evaluation.Machine.Ck
+    PlutusCore.Evaluation.Machine.CostingFun.Core
+    PlutusCore.Evaluation.Machine.CostingFun.JSON
+    PlutusCore.Evaluation.Machine.CostingFun.SimpleJSON
+    PlutusCore.Evaluation.Machine.CostModelInterface
+    PlutusCore.Evaluation.Machine.CostStream
+    PlutusCore.Evaluation.Machine.ExBudget
+    PlutusCore.Evaluation.Machine.ExBudgetingDefaults
+    PlutusCore.Evaluation.Machine.ExBudgetStream
+    PlutusCore.Evaluation.Machine.Exception
+    PlutusCore.Evaluation.Machine.ExMemory
+    PlutusCore.Evaluation.Machine.ExMemoryUsage
+    PlutusCore.Evaluation.Machine.MachineParameters
+    PlutusCore.Evaluation.Machine.MachineParameters.Default
+    PlutusCore.Evaluation.Machine.SimpleBuiltinCostModel
+    PlutusCore.Evaluation.Result
+    PlutusCore.Examples.Builtins
+    PlutusCore.Examples.Data.Data
+    PlutusCore.Examples.Data.Function
+    PlutusCore.Examples.Data.InterList
+    PlutusCore.Examples.Data.List
+    PlutusCore.Examples.Data.Pair
+    PlutusCore.Examples.Data.Shad
+    PlutusCore.Examples.Data.TreeForest
+    PlutusCore.Examples.Data.Vec
+    PlutusCore.Examples.Everything
+    PlutusCore.Flat
+    PlutusCore.FsTree
+    PlutusCore.Mark
+    PlutusCore.MkPlc
+    PlutusCore.Name.Unique
+    PlutusCore.Name.UniqueMap
+    PlutusCore.Name.UniqueSet
+    PlutusCore.Normalize
+    PlutusCore.Normalize.Internal
+    PlutusCore.Parser
+    PlutusCore.Pretty
+    PlutusCore.Quote
+    PlutusCore.Rename
+    PlutusCore.Rename.Internal
+    PlutusCore.Rename.Monad
+    PlutusCore.Size
+    PlutusCore.StdLib.Data.Bool
+    PlutusCore.StdLib.Data.ChurchNat
+    PlutusCore.StdLib.Data.Data
+    PlutusCore.StdLib.Data.Function
+    PlutusCore.StdLib.Data.Integer
+    PlutusCore.StdLib.Data.List
+    PlutusCore.StdLib.Data.MatchOption
+    PlutusCore.StdLib.Data.Nat
+    PlutusCore.StdLib.Data.Pair
+    PlutusCore.StdLib.Data.ScottList
+    PlutusCore.StdLib.Data.ScottUnit
+    PlutusCore.StdLib.Data.Sum
+    PlutusCore.StdLib.Data.Unit
+    PlutusCore.StdLib.Everything
+    PlutusCore.StdLib.Meta
+    PlutusCore.StdLib.Meta.Data.Function
+    PlutusCore.StdLib.Meta.Data.Tuple
+    PlutusCore.StdLib.Type
+    PlutusCore.Subst
+    PlutusCore.TypeCheck
+    PlutusCore.TypeCheck.Internal
+    PlutusCore.Version
+    PlutusPrelude
+    Prettyprinter.Custom
+    Universe
+    UntypedPlutusCore
+    UntypedPlutusCore.Check.Scope
+    UntypedPlutusCore.Check.Uniques
+    UntypedPlutusCore.Core
+    UntypedPlutusCore.Core.Plated
+    UntypedPlutusCore.Core.Type
+    UntypedPlutusCore.Core.Zip
+    UntypedPlutusCore.DeBruijn
+    UntypedPlutusCore.Evaluation.Machine.Cek
+    UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts
+    UntypedPlutusCore.Evaluation.Machine.Cek.Internal
+    UntypedPlutusCore.Evaluation.Machine.Cek.StepCounter
+    UntypedPlutusCore.Evaluation.Machine.SteppableCek
+    UntypedPlutusCore.Evaluation.Machine.SteppableCek.DebugDriver
+    UntypedPlutusCore.Evaluation.Machine.SteppableCek.Internal
+    UntypedPlutusCore.MkUPlc
+    UntypedPlutusCore.Parser
+    UntypedPlutusCore.Purity
+    UntypedPlutusCore.Rename
+    UntypedPlutusCore.Size
+    UntypedPlutusCore.Transform.CaseOfCase
+    UntypedPlutusCore.Transform.Simplifier
+
+  other-modules:
+    Data.Aeson.Flatten
+    Data.Functor.Foldable.Monadic
+    PlutusCore.Builtin.HasConstant
+    PlutusCore.Builtin.KnownKind
+    PlutusCore.Builtin.KnownType
+    PlutusCore.Builtin.KnownTypeAst
+    PlutusCore.Builtin.Meaning
+    PlutusCore.Builtin.Polymorphism
+    PlutusCore.Builtin.Result
+    PlutusCore.Builtin.Runtime
+    PlutusCore.Builtin.TestKnown
+    PlutusCore.Builtin.TypeScheme
+    PlutusCore.Core.Instance
+    PlutusCore.Core.Instance.Eq
+    PlutusCore.Core.Instance.Pretty
+    PlutusCore.Core.Instance.Pretty.Classic
+    PlutusCore.Core.Instance.Pretty.Default
+    PlutusCore.Core.Instance.Pretty.Plc
+    PlutusCore.Core.Instance.Pretty.Readable
+    PlutusCore.Core.Instance.Scoping
+    PlutusCore.Core.Type
+    PlutusCore.Crypto.Utils
+    PlutusCore.Default.Universe
+    PlutusCore.Eq
+    PlutusCore.Parser.Builtin
+    PlutusCore.Parser.ParserCommon
+    PlutusCore.Parser.Type
+    PlutusCore.Pretty.Classic
+    PlutusCore.Pretty.ConfigName
+    PlutusCore.Pretty.Default
+    PlutusCore.Pretty.Extra
+    PlutusCore.Pretty.Plc
+    PlutusCore.Pretty.PrettyConst
+    PlutusCore.Pretty.Readable
+    PlutusCore.Pretty.Utils
+    Universe.Core
+    UntypedPlutusCore.Analysis.Definitions
+    UntypedPlutusCore.Analysis.Usages
+    UntypedPlutusCore.Core.Instance
+    UntypedPlutusCore.Core.Instance.Eq
+    UntypedPlutusCore.Core.Instance.Flat
+    UntypedPlutusCore.Core.Instance.Pretty
+    UntypedPlutusCore.Core.Instance.Pretty.Classic
+    UntypedPlutusCore.Core.Instance.Pretty.Default
+    UntypedPlutusCore.Core.Instance.Pretty.Plc
+    UntypedPlutusCore.Core.Instance.Pretty.Readable
+    UntypedPlutusCore.Evaluation.Machine.Cek.EmitterMode
+    UntypedPlutusCore.Evaluation.Machine.Cek.ExBudgetMode
+    UntypedPlutusCore.Evaluation.Machine.CommonAPI
+    UntypedPlutusCore.Mark
+    UntypedPlutusCore.Rename.Internal
+    UntypedPlutusCore.Simplify
+    UntypedPlutusCore.Simplify.Opts
+    UntypedPlutusCore.Subst
+    UntypedPlutusCore.Transform.CaseReduce
+    UntypedPlutusCore.Transform.Cse
+    UntypedPlutusCore.Transform.FloatDelay
+    UntypedPlutusCore.Transform.ForceDelay
+    UntypedPlutusCore.Transform.Inline
+
+  reexported-modules: Data.SatInt
+  hs-source-dirs:
+    plutus-core/src plutus-core/stdlib plutus-core/examples
+    untyped-plutus-core/src prelude
+
+  -- Notes on dependencies:
+  -- * Bound on cardano-crypto-class for the fixed SECP primitives and 9.6 support
+  -- * The bound on 'dependent-sum' is needed to avoid https://github.com/obsidiansystems/dependent-sum/issues/72
+  build-depends:
+    , aeson
+    , array
+    , barbies
+    , base                        >=4.9     && <5
+    , base64-bytestring
+    , bimap
+    , bytestring
+    , bytestring-strict-builder
+    , cardano-crypto
+    , cardano-crypto-class        >=2.1.5   && <2.3
+    , cassava
+    , cborg
+    , composition-prelude         >=1.1.0.1
+    , containers
+    , cryptonite
+    , data-default-class
+    , deepseq
+    , dependent-sum               >=0.7.1.0
+    , deriving-aeson              >=0.2.3
+    , deriving-compat
+    , dlist
+    , exceptions
+    , extra
+    , filepath
+    , flat                        ^>=0.6
+    , free
+    , ghc-prim
+    , hashable                    >=1.4
+    , hedgehog                    >=1.0
+    , index-envs
+    , lens
+    , megaparsec
+    , mmorph
+    , mono-traversable
+    , monoidal-containers
+    , mtl
+    , multiset
+    , nothunks                    ^>=0.2
+    , parser-combinators          >=0.4.0
+    , prettyprinter               >=1.1.0.1
+    , prettyprinter-configurable
+    , primitive
+    , profunctors
+    , recursion-schemes
+    , satint
+    , semigroups                  >=0.19.1
+    , serialise
+    , some
+    , template-haskell
+    , text
+    , th-compat
+    , th-lift
+    , th-lift-instances
+    , th-utilities
+    , time
+    , transformers
+    , unordered-containers
+    , vector
+    , witherable
+
+  if impl(ghc <9.0)
+    build-depends: integer-gmp
+
+test-suite plutus-core-test
+  import:           lang
+
+  -- needs linux 'diff' available
+  if os(windows)
+    buildable: False
+
+  type:             exitcode-stdio-1.0
+  main-is:          Spec.hs
+  hs-source-dirs:   plutus-core/test
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
+  other-modules:
+    CBOR.DataStability
+    Check.Spec
+    CostModelInterface.Spec
+    CostModelSafety.Spec
+    Evaluation.Machines
+    Evaluation.Spec
+    Generators.QuickCheck.Utils
+    Names.Spec
+    Normalization.Check
+    Normalization.Type
+    Parser.Spec
+    Pretty.Readable
+    TypeSynthesis.Spec
+
+  default-language: Haskell2010
+  build-depends:
+    , aeson
+    , base                             >=4.9   && <5
+    , bytestring
+    , containers
+    , data-default-class
+    , extra
+    , filepath
+    , flat                             ^>=0.6
+    , hedgehog
+    , hex-text
+    , mmorph
+    , mtl
+    , plutus-core                      ^>=1.38
+    , plutus-core:plutus-core-testlib
+    , prettyprinter
+    , serialise
+    , tasty
+    , tasty-golden
+    , tasty-hedgehog
+    , tasty-hunit
+    , tasty-quickcheck
+    , template-haskell
+    , text
+    , th-lift-instances
+    , th-utilities
+
+test-suite untyped-plutus-core-test
+  import:         lang
+
+  -- needs linux 'diff' available
+  if os(windows)
+    buildable: False
+
+  type:           exitcode-stdio-1.0
+  main-is:        Spec.hs
+  hs-source-dirs: untyped-plutus-core/test
+  ghc-options:    -O2 -threaded -rtsopts -with-rtsopts=-N
+  other-modules:
+    Analysis.Spec
+    DeBruijn.FlatNatWord
+    DeBruijn.Scope
+    DeBruijn.Spec
+    DeBruijn.UnDeBruijnify
+    Evaluation.Builtins
+    Evaluation.Builtins.Bitwise
+    Evaluation.Builtins.BLS12_381
+    Evaluation.Builtins.BLS12_381.TestClasses
+    Evaluation.Builtins.BLS12_381.Utils
+    Evaluation.Builtins.Common
+    Evaluation.Builtins.Conversion
+    Evaluation.Builtins.Costing
+    Evaluation.Builtins.Definition
+    Evaluation.Builtins.Laws
+    Evaluation.Builtins.MakeRead
+    Evaluation.Builtins.SignatureVerification
+    Evaluation.Debug
+    Evaluation.FreeVars
+    Evaluation.Golden
+    Evaluation.Helpers
+    Evaluation.Machines
+    Evaluation.Regressions
+    Flat.Spec
+    Generators
+    Transform.CaseOfCase.Test
+    Transform.Simplify
+    Transform.Simplify.Lib
+
+  build-depends:
+    , base                             >=4.9   && <5
+    , base16-bytestring
+    , bytestring
+    , cardano-crypto-class
+    , dlist
+    , flat                             ^>=0.6
+    , hedgehog
+    , lens
+    , mtl
+    , plutus-core                      ^>=1.38
+    , plutus-core:plutus-core-testlib
+    , pretty-show
+    , prettyprinter
+    , QuickCheck
+    , serialise
+    , split
+    , tasty
+    , tasty-golden
+    , tasty-hedgehog
+    , tasty-hunit
+    , tasty-quickcheck
+    , text
+    , vector
+
+----------------------------------------------
+-- plutus-ir
+----------------------------------------------
+
+library plutus-ir
+  import:          lang
+  visibility:      public
+  hs-source-dirs:  plutus-ir/src
+  exposed-modules:
+    PlutusIR
+    PlutusIR.Analysis.Builtins
+    PlutusIR.Analysis.Dependencies
+    PlutusIR.Analysis.RetainedSize
+    PlutusIR.Analysis.Size
+    PlutusIR.Analysis.VarInfo
+    PlutusIR.Check.Uniques
+    PlutusIR.Compiler
+    PlutusIR.Compiler.Datatype
+    PlutusIR.Compiler.Definitions
+    PlutusIR.Compiler.Let
+    PlutusIR.Compiler.Names
+    PlutusIR.Compiler.Provenance
+    PlutusIR.Compiler.Types
+    PlutusIR.Contexts
+    PlutusIR.Core
+    PlutusIR.Core.Instance
+    PlutusIR.Core.Instance.Flat
+    PlutusIR.Core.Instance.Pretty
+    PlutusIR.Core.Instance.Pretty.Readable
+    PlutusIR.Core.Instance.Scoping
+    PlutusIR.Core.Plated
+    PlutusIR.Core.Type
+    PlutusIR.Error
+    PlutusIR.Mark
+    PlutusIR.MkPir
+    PlutusIR.Parser
+    PlutusIR.Pass
+    PlutusIR.Purity
+    PlutusIR.Subst
+    PlutusIR.Transform.Beta
+    PlutusIR.Transform.CaseOfCase
+    PlutusIR.Transform.CaseReduce
+    PlutusIR.Transform.DeadCode
+    PlutusIR.Transform.EvaluateBuiltins
+    PlutusIR.Transform.Inline.CallSiteInline
+    PlutusIR.Transform.Inline.Inline
+    PlutusIR.Transform.Inline.Utils
+    PlutusIR.Transform.KnownCon
+    PlutusIR.Transform.LetFloatIn
+    PlutusIR.Transform.LetFloatOut
+    PlutusIR.Transform.LetMerge
+    PlutusIR.Transform.NonStrict
+    PlutusIR.Transform.RecSplit
+    PlutusIR.Transform.Rename
+    PlutusIR.Transform.RewriteRules
+    PlutusIR.Transform.RewriteRules.CommuteFnWithConst
+    PlutusIR.Transform.RewriteRules.RemoveTrace
+    PlutusIR.Transform.StrictifyBindings
+    PlutusIR.Transform.Substitute
+    PlutusIR.Transform.ThunkRecursions
+    PlutusIR.Transform.Unwrap
+    PlutusIR.TypeCheck
+    PlutusIR.TypeCheck.Internal
+
+  other-modules:
+    PlutusIR.Analysis.Definitions
+    PlutusIR.Analysis.Usages
+    PlutusIR.Compiler.Error
+    PlutusIR.Compiler.Lower
+    PlutusIR.Compiler.Recursion
+    PlutusIR.Normalize
+    PlutusIR.Transform.RewriteRules.Common
+    PlutusIR.Transform.RewriteRules.Internal
+    PlutusIR.Transform.RewriteRules.UnConstrConstrData
+
+  build-depends:
+    , algebraic-graphs     >=0.7
+    , base                 >=4.9     && <5
+    , containers
+    , dlist
+    , dom-lt
+    , extra
+    , flat                 ^>=0.6
+    , hashable
+    , lens
+    , megaparsec
+    , mmorph
+    , monoidal-containers
+    , mtl
+    , multiset
+    , parser-combinators   >=0.4.0
+    , plutus-core          ^>=1.38
+    , prettyprinter        >=1.1.0.1
+    , profunctors
+    , semigroupoids
+    , semigroups           >=0.19.1
+    , text
+    , transformers
+    , witherable
+
+  if impl(ghc <9.0)
+    build-depends: integer-gmp
+
+test-suite plutus-ir-test
+  import:             lang
+
+  -- needs linux 'diff' available
+  if os(windows)
+    buildable: False
+
+  type:               exitcode-stdio-1.0
+  main-is:            Driver.hs
+  hs-source-dirs:     plutus-ir/test
+  ghc-options:        -threaded -rtsopts -with-rtsopts=-N
+  other-modules:
+    PlutusCore.Generators.QuickCheck.BuiltinsTests
+    PlutusCore.Generators.QuickCheck.SubstitutionTests
+    PlutusCore.Generators.QuickCheck.TypesTests
+    PlutusIR.Analysis.RetainedSize.Tests
+    PlutusIR.Check.Uniques.Tests
+    PlutusIR.Compiler.Datatype.Tests
+    PlutusIR.Compiler.Error.Tests
+    PlutusIR.Compiler.Let.Tests
+    PlutusIR.Compiler.Recursion.Tests
+    PlutusIR.Contexts.Tests
+    PlutusIR.Core.Tests
+    PlutusIR.Generators.QuickCheck.Tests
+    PlutusIR.Parser.Tests
+    PlutusIR.Purity.Tests
+    PlutusIR.Scoping.Tests
+    PlutusIR.Transform.Beta.Tests
+    PlutusIR.Transform.CaseOfCase.Tests
+    PlutusIR.Transform.CaseReduce.Tests
+    PlutusIR.Transform.DeadCode.Tests
+    PlutusIR.Transform.EvaluateBuiltins.Tests
+    PlutusIR.Transform.Inline.Tests
+    PlutusIR.Transform.KnownCon.Tests
+    PlutusIR.Transform.LetFloatIn.Tests
+    PlutusIR.Transform.LetFloatOut.Tests
+    PlutusIR.Transform.NonStrict.Tests
+    PlutusIR.Transform.RecSplit.Tests
+    PlutusIR.Transform.Rename.Tests
+    PlutusIR.Transform.RewriteRules.Tests
+    PlutusIR.Transform.StrictifyBindings.Tests
+    PlutusIR.Transform.StrictLetRec.Tests
+    PlutusIR.Transform.StrictLetRec.Tests.Lib
+    PlutusIR.Transform.ThunkRecursions.Tests
+    PlutusIR.Transform.Unwrap.Tests
+    PlutusIR.TypeCheck.Tests
+
+  build-tool-depends: tasty-discover:tasty-discover
+  build-depends:
+    , base                             >=4.9   && <5
+    , containers
+    , filepath
+    , flat                             ^>=0.6
+    , hashable
+    , hedgehog
+    , lens
+    , mtl
+    , plutus-core                      ^>=1.38
+    , plutus-core:plutus-core-testlib
+    , plutus-core:plutus-ir
+    , QuickCheck
+    , serialise
+    , tasty
+    , tasty-expected-failure
+    , tasty-hedgehog
+    , tasty-hunit
+    , tasty-quickcheck
+    , text
+    , unordered-containers
+
+executable plutus
+  import:             lang
+  main-is:            Main.hs
+  hs-source-dirs:     executables/plutus
+
+  -- singletons-th does not support GHC<=8.10
+  if impl(ghc <9.6)
+    buildable: False
+
+  -- Hydra complains that this is not buildable on mingw32 because of brick.
+  -- Strange, because I thought vty added support for windows.
+  if os(windows)
+    buildable: False
+
+  other-modules:
+    AnyProgram.Apply
+    AnyProgram.Bench
+    AnyProgram.Compile
+    AnyProgram.Debug
+    AnyProgram.Example
+    AnyProgram.IO
+    AnyProgram.Parse
+    AnyProgram.Run
+    AnyProgram.With
+    Common
+    Debugger.TUI.Draw
+    Debugger.TUI.Event
+    Debugger.TUI.Main
+    Debugger.TUI.Types
+    GetOpt
+    Mode.Compile
+    Mode.HelpVersion
+    Mode.ListExamples
+    Mode.PrintBuiltins
+    Mode.PrintCostModel
+    Types
+
+  build-depends:
+    , aeson-pretty
+    , base                   >=4.9   && <5
+    , brick
+    , bytestring
+    , containers
+    , exceptions
+    , filepath
+    , flat
+    , lens
+    , megaparsec
+    , microlens
+    , microlens-th           ^>=0.4
+    , mono-traversable
+    , mtl
+    , plutus-core            ^>=1.38
+    , plutus-core:plutus-ir
+    , prettyprinter
+    , primitive
+    , serialise
+    , singletons
+    , singletons-th
+    , text
+    , text-zipper
+    , vty                    ^>=6
+    , vty-crossplatform      ^>=0.2
+
+  ghc-options:        -O2 -threaded -rtsopts -with-rtsopts=-N
+  default-extensions:
+    GADTs
+    TypeApplications
+
+----------------------------------------------
+-- support libs
+----------------------------------------------
+
+library plutus-core-execlib
+  import:          lang
+  visibility:      public
+  hs-source-dirs:  executables/src
+  exposed-modules:
+    PlutusCore.Executable.AstIO
+    PlutusCore.Executable.Common
+    PlutusCore.Executable.Parsers
+    PlutusCore.Executable.Types
+
+  build-depends:
+    , aeson
+    , base                             >=4.9   && <5
+    , bytestring
+    , flat                             ^>=0.6
+    , lens
+    , megaparsec
+    , monoidal-containers
+    , mtl
+    , optparse-applicative
+    , plutus-core                      ^>=1.38
+    , plutus-core:plutus-core-testlib
+    , plutus-core:plutus-ir
+    , prettyprinter
+    , text
+
+-- could split this up if we split up the main library for UPLC/PLC/PIR
+library plutus-core-testlib
+  import:          lang
+  visibility:      public
+  hs-source-dirs:  testlib
+  exposed-modules:
+    PlutusCore.Generators.Hedgehog
+    PlutusCore.Generators.Hedgehog.AST
+    PlutusCore.Generators.Hedgehog.Builtin
+    PlutusCore.Generators.Hedgehog.Denotation
+    PlutusCore.Generators.Hedgehog.Entity
+    PlutusCore.Generators.Hedgehog.Interesting
+    PlutusCore.Generators.Hedgehog.Test
+    PlutusCore.Generators.Hedgehog.TypedBuiltinGen
+    PlutusCore.Generators.Hedgehog.TypeEvalCheck
+    PlutusCore.Generators.Hedgehog.Utils
+    PlutusCore.Generators.NEAT.Common
+    PlutusCore.Generators.NEAT.Spec
+    PlutusCore.Generators.NEAT.Term
+    PlutusCore.Generators.NEAT.Type
+    PlutusCore.Generators.QuickCheck
+    PlutusCore.Generators.QuickCheck.Builtin
+    PlutusCore.Generators.QuickCheck.Common
+    PlutusCore.Generators.QuickCheck.GenerateKinds
+    PlutusCore.Generators.QuickCheck.GenerateTypes
+    PlutusCore.Generators.QuickCheck.GenTm
+    PlutusCore.Generators.QuickCheck.ShrinkTypes
+    PlutusCore.Generators.QuickCheck.Split
+    PlutusCore.Generators.QuickCheck.Substitutions
+    PlutusCore.Generators.QuickCheck.Unification
+    PlutusCore.Generators.QuickCheck.Utils
+    PlutusCore.Test
+    PlutusIR.Generators.AST
+    PlutusIR.Generators.QuickCheck
+    PlutusIR.Generators.QuickCheck.Common
+    PlutusIR.Generators.QuickCheck.GenerateTerms
+    PlutusIR.Generators.QuickCheck.ShrinkTerms
+    PlutusIR.Pass.Test
+    PlutusIR.Test
+    Test.Tasty.Extras
+    UntypedPlutusCore.Generators.Hedgehog
+    UntypedPlutusCore.Test.DeBruijn.Bad
+    UntypedPlutusCore.Test.DeBruijn.Good
+
+  build-depends:
+    , base                        >=4.9     && <5
+    , bifunctors
+    , bytestring
+    , containers
+    , data-default-class
+    , dependent-map               >=0.4.0.0
+    , filepath
+    , free
+    , hashable
+    , hedgehog                    >=1.0
+    , hedgehog-quickcheck
+    , lazy-search
+    , lens
+    , mmorph
+    , mtl
+    , multiset
+    , plutus-core                 ^>=1.38
+    , plutus-core:plutus-ir
+    , prettyprinter               >=1.1.0.1
+    , prettyprinter-configurable
+    , QuickCheck
+    , quickcheck-instances
+    , quickcheck-transformer
+    , size-based
+    , Stream
+    , tagged
+    , tasty
+    , tasty-golden
+    , tasty-hedgehog
+    , tasty-hunit
+    , text
+
+-- This wraps up the use of the certifier library
+-- so we can present a consistent inteface whether we
+-- are building with it or not. If we aren't building
+-- with it, we present a conservative stub implementation
+-- that just always says everything is fine.
+library plutus-ir-cert
+  import:           lang
+
+  if flag(with-cert)
+    hs-source-dirs: plutus-ir/cert
+    build-depends:  plutus-cert
+
+  else
+    hs-source-dirs: plutus-ir/cert-stub
+
+  default-language: Haskell2010
+  exposed-modules:  PlutusIR.Certifier
+  build-depends:
+    , base
+    , plutus-core            ^>=1.38
+    , plutus-core:plutus-ir
+
+----------------------------------------------
+-- profiling
+----------------------------------------------
+
+executable traceToStacks
+  import:         lang
+  main-is:        Main.hs
+  hs-source-dirs: executables/traceToStacks
+  other-modules:  Common
+  build-depends:
+    , base                  >=4.9 && <5
+    , bytestring
+    , cassava
+    , optparse-applicative
+    , text
+    , vector
+
+-- Tests for functions called by @traceToStacks@.
+test-suite traceToStacks-test
+  import:           lang
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   executables/traceToStacks
+  default-language: Haskell2010
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
+  main-is:          TestGetStacks.hs
+  other-modules:    Common
+  build-depends:
+    , base         >=4.9 && <5
+    , bytestring
+    , cassava
+    , tasty
+    , tasty-hunit
+    , text
+    , vector
+
+----------------------------------------------
+-- cost-model
+----------------------------------------------
+
+-- This runs the microbenchmarks used to generate the cost models for built-in
+-- functions, saving the results in a CSV file which must be specified on the
+-- commmand line.  It will take several hours.
+executable cost-model-budgeting-bench
+  import:         lang
+  main-is:        Main.hs
+  other-modules:
+    Benchmarks.Bitwise
+    Benchmarks.Bool
+    Benchmarks.ByteStrings
+    Benchmarks.Crypto
+    Benchmarks.Data
+    Benchmarks.Integers
+    Benchmarks.Lists
+    Benchmarks.Misc
+    Benchmarks.Nops
+    Benchmarks.Pairs
+    Benchmarks.Strings
+    Benchmarks.Tracing
+    Benchmarks.Unit
+    Common
+    CriterionExtensions
+    Generators
+
+  hs-source-dirs: cost-model/budgeting-bench
+  build-depends:
+    , base                   >=4.9   && <5
+    , bytestring
+    , cardano-crypto-class
+    , criterion
+    , criterion-measurement
+    , deepseq
+    , directory
+    , filepath
+    , hedgehog
+    , mtl
+    , optparse-applicative
+    , plutus-core            ^>=1.38
+    , QuickCheck
+    , quickcheck-instances
+    , random
+    , text
+    , time
+
+-- This reads CSV data generated by cost-model-budgeting-bench, uses R to build
+-- the cost models for built-in functions, and saves them in a specified
+-- JSON file (see the help).  The 'official' cost model should be checked in
+-- in plutus-core/cost-model/data/builtinCostModel.json.
+executable generate-cost-model
+  import:         lang
+  main-is:        Main.hs
+  hs-source-dirs: cost-model/create-cost-model
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
+
+  if !flag(with-inline-r)
+    buildable: False
+
+  -- This fails on Darwin with strange errors and I don't know why
+  -- > Error: C stack usage  17556409549320 is too close to the limit
+  -- > Fatal error: unable to initialize the JI
+  if os(osx)
+    buildable: False
+
+  -- Can't build on windows as it depends on R.
+  if os(windows)
+    buildable: False
+
+  build-depends:
+    , aeson-pretty
+    , barbies
+    , base                  >=4.9   && <5
+    , bytestring
+    , directory
+    , inline-r              >=1.0.1
+    , optparse-applicative
+    , plutus-core           ^>=1.38
+    , text
+
+  --    , exceptions
+  other-modules:
+    BuiltinMemoryModels
+    CreateBuiltinCostModel
+
+-- The cost models for builtins are generated using R and converted into a JSON
+-- form that can later be used to construct Haskell functions.  This tests that
+-- the predictions of the Haskell version are (approximately) identical to the R
+-- ones. This test is problematic in CI: pretending that it's a benchmark will
+-- prevent it from being run automatically but will still allow us to run it
+-- manually; `cabal bench` also sets the working directory to the root of the
+-- relevant package, which makes it easier to find the cost model data files
+-- (unlike `cabal run` for executables, which sets the working directory to the
+-- current shell directory).
+benchmark cost-model-test
+  import:         lang
+  type:           exitcode-stdio-1.0
+  main-is:        TestCostModels.hs
+  other-modules:  TH
+  hs-source-dirs: cost-model/test cost-model/create-cost-model
+
+  if !flag(with-inline-r)
+    buildable: False
+
+  -- This fails on Darwin with strange errors and I don't know why
+  -- > Error: C stack usage  17556409549320 is too close to the limit
+  -- > Fatal error: unable to initialize the JI
+  if os(osx)
+    buildable: False
+
+  -- Can't build on windows as it depends on R.
+  if os(windows)
+    buildable: False
+
+  build-depends:
+    , barbies
+    , base              >=4.9   && <5
+    , bytestring
+    , hedgehog
+    , inline-r          >=1.0.1
+    , mmorph
+    , plutus-core       ^>=1.38
+    , template-haskell
+    , text
+
+  other-modules:
+    BuiltinMemoryModels
+    CreateBuiltinCostModel
+
+executable print-cost-model
+  import:         lang
+  main-is:        Main.hs
+  hs-source-dirs: cost-model/print-cost-model
+  other-modules:  Paths_plutus_core
+  build-depends:
+    , aeson
+    , base         >=4.9   && <5
+    , bytestring
+    , plutus-core  ^>=1.38
+
+----------------------------------------------
+-- satint
+----------------------------------------------
+
+library satint
+  import:          lang
+  exposed-modules: Data.SatInt
+  hs-source-dirs:  satint/src
+  build-depends:
+    , aeson
+    , base              >=4.9 && <5
+    , cassava
+    , deepseq
+    , nothunks
+    , primitive
+    , serialise
+    , template-haskell
+
+test-suite satint-test
+  import:           lang
+  type:             exitcode-stdio-1.0
+  main-is:          TestSatInt.hs
+  build-depends:
+    , base                        >=4.9 && <5
+    , HUnit
+    , QuickCheck
+    , satint
+    , test-framework
+    , test-framework-hunit
+    , test-framework-quickcheck2
+
+  default-language: Haskell2010
+  hs-source-dirs:   satint/test
+
+----------------------------------------------
+-- index-envs
+----------------------------------------------
+
+library index-envs
+  import:           lang
+  visibility:       public
+  hs-source-dirs:   index-envs/src
+  default-language: Haskell2010
+  exposed-modules:
+    Data.RandomAccessList.Class
+    Data.RandomAccessList.RelativizedMap
+    Data.RandomAccessList.SkewBinary
+    Data.RandomAccessList.SkewBinarySlab
+
+  build-depends:
+    , base             >=4.9  && <5
+    , containers
+    , extra
+    , nonempty-vector
+    , ral              ^>=0.2
+
+-- broken for ral-0.2 conflicts with cardano-binary:recursion-schemes
+benchmark index-envs-bench
+  import:           lang
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   index-envs/bench
+  default-language: Haskell2010
+  main-is:          Main.hs
+  build-depends:
+    , base             >=4.9     && <5
+    , criterion        >=1.5.9.0
+    , index-envs
+    , nonempty-vector
+    , ral              ^>=0.2
+    , random           >=1.2.0
+
+-- broken for ral-0.2 conflicts with cardano-binary:recursion-schemes
+test-suite index-envs-test
+  import:           lang
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   index-envs/test
+  default-language: Haskell2010
+  main-is:          Spec.hs
+  other-modules:    RAList.Spec
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+    , base                  >=4.9 && <5
+    , index-envs
+    , nonempty-vector
+    , QuickCheck
+    , quickcheck-instances
+    , tasty
+    , tasty-quickcheck

--- a/flake.lock
+++ b/flake.lock
@@ -201,11 +201,11 @@
     "hackage-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1725064645,
-        "narHash": "sha256-wD/BO9+AI37kV5B/JbhZRmAWGoiK4nE4ulphTY3aQHY=",
+        "lastModified": 1733877006,
+        "narHash": "sha256-rNpSFS/ziUQBPgo6iAbKgU00yRpeCngv215TW0D+kCo=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "3b084a690ecf7f660db1a91dcf481d4ef7a2a876",
+        "rev": "583f569545854160b6bc5606374bf5006a9f6929",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1725036201,
-        "narHash": "sha256-qzGLca3p54f1uBgYjlicnWllzyx0s3TDyEaK3ou+VAg=",
+        "lastModified": 1733946732,
+        "narHash": "sha256-8RwIGx4z0LELkL5d8Xg85/O5yqox6mHtusrNoIqSeCU=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "34bd896a4ac67d5637b36f39d87842ebd2c580c2",
+        "rev": "6d857b7864e15267825582b785a6b1ce71942c1d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1724806249,
-        "narHash": "sha256-TG9Mhl1QBppdnjeYmEIKan8XLJZpbQXtcMGBlm1KIF8=",
+        "lastModified": 1733956415,
+        "narHash": "sha256-QECLKb+pGFqfZBujt8XwZ/DgwVhw0WRwXBhoKR5LbN4=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "57defd49a7800af2bd91ba3606d444b10fbae393",
+        "rev": "6aeb986c46b6c854408d4cbf733f591190f53c5f",
         "type": "github"
       },
       "original": {
@@ -425,16 +425,16 @@
     "hls-2.9": {
       "flake": false,
       "locked": {
-        "lastModified": 1718469202,
-        "narHash": "sha256-THXSz+iwB1yQQsr/PY151+2GvtoJnTIB2pIQ4OzfjD4=",
+        "lastModified": 1720003792,
+        "narHash": "sha256-qnDx8Pk0UxtoPr7BimEsAZh9g2WuTuMB/kGqnmdryKs=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "40891bccb235ebacce020b598b083eab9dda80f1",
+        "rev": "0c1817cb2babef0765e4e72dd297c013e8e3d12b",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
-        "ref": "2.9.0.0",
+        "ref": "2.9.0.1",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -685,11 +685,11 @@
     },
     "nixpkgs-2405": {
       "locked": {
-        "lastModified": 1720122915,
-        "narHash": "sha256-Nby8WWxj0elBu1xuRaUcRjPi/rU3xVbkAt2kj4QwX2U=",
+        "lastModified": 1729242558,
+        "narHash": "sha256-VgcLDu4igNT0eYua6OAl9pWCI0cYXhDbR+pWP44tte0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "835cf2d3f37989c5db6585a28de967a667a75fb1",
+        "rev": "4a3f2d3195b60d07530574988df92e049372c10e",
         "type": "github"
       },
       "original": {
@@ -717,11 +717,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1720181791,
-        "narHash": "sha256-i4vJL12/AdyuQuviMMd1Hk2tsGt02hDNhA0Zj1m16N8=",
+        "lastModified": 1729980323,
+        "narHash": "sha256-eWPRZAlhf446bKSmzw6x7RWEE4IuZgAp8NW3eXZwRAY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4284c2b73c8bce4b46a6adf23e16d9e2ec8da4bb",
+        "rev": "86e78d3d2084ff87688da662cf78c2af085d8e73",
         "type": "github"
       },
       "original": {
@@ -799,11 +799,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1724717508,
-        "narHash": "sha256-FeGR8x/iFDB6zmu3pjRFVcXc6gD/jEct/aM1kZF9gWs=",
+        "lastModified": 1733789551,
+        "narHash": "sha256-0tSxhYw3RqNEHYFYIwJZ99mFDpGr8Dekf+p2ZCEygYY=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "3cdad9ccd2f0232659e147b16ca979d08f77e63e",
+        "rev": "db7b3e7ae59867ce0ba21df45f57ea38f57710ab",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -230,9 +230,10 @@
 
       # Extra configurations (possibly compiler-dependent) to add to all projects.
       extraConfig = compiler:
-        {
+        let addPackageKeys = x: x // { package-keys = builtins.attrNames x.packages; };
+        in {
           modules = [
-            {
+            (addPackageKeys {
               # Packages that depend on the plutus-tx plugin have broken haddock
               packages = {
                 cardano-node-emulator.doHaddock = false;
@@ -240,25 +241,25 @@
                 plutus-script-utils.doHaddock = false;
                 plutus-scripts-bench.doHaddock = false;
               };
-            }
-            {
+            })
+            (addPackageKeys {
               # Packages that have haddock that is broken on 8.10
               # See https://github.com/input-output-hk/cardano-haskell-packages/issues/482
-              packages = lib.mkIf (compiler == "ghc810") {
-                cardano-ledger-allegra.doHaddock = false;
-                cardano-ledger-alonzo.doHaddock = false;
-                cardano-ledger-api.doHaddock = false;
-                cardano-ledger-conway.doHaddock = false;
-                cardano-ledger-core.doHaddock = false;
-                cardano-ledger-babbage.doHaddock = false;
-                cardano-ledger-shelley.doHaddock = false;
-                cardano-protocol-tpraos.doHaddock = false;
-                ouroboros-consensus-cardano.doHaddock = false;
-                ouroboros-consensus.doHaddock = false;
-                ouroboros-network.doHaddock = false;
-                plutus-ledger-api.doHaddock = false;
+              packages = {
+                cardano-ledger-allegra.doHaddock = compiler != "ghc810";
+                cardano-ledger-alonzo.doHaddock = compiler != "ghc810";
+                cardano-ledger-api.doHaddock = compiler != "ghc810";
+                cardano-ledger-conway.doHaddock = compiler != "ghc810";
+                cardano-ledger-core.doHaddock = compiler != "ghc810";
+                cardano-ledger-babbage.doHaddock = compiler != "ghc810";
+                cardano-ledger-shelley.doHaddock = compiler != "ghc810";
+                cardano-protocol-tpraos.doHaddock = compiler != "ghc810";
+                ouroboros-consensus-cardano.doHaddock = compiler != "ghc810";
+                ouroboros-consensus.doHaddock = compiler != "ghc810";
+                ouroboros-network.doHaddock = compiler != "ghc810";
+                plutus-ledger-api.doHaddock = compiler != "ghc810";
               };
-            }
+            })
           ];
         };
 


### PR DESCRIPTION
A long overdue release of `cardano-crypto-class[tests]-2.2` and `cardano-crypto-praos-2.2`

This PR also adds revisions with bounds fixups. For plutus-1.37 and 1.38 upper bound is relaxed to allow this new version, while for all released versions of `cardano-ledger-binary` upper bound was added to prevent this version of crypto being used until a compatible version of this package is released.

This effectively allows for future version of ledger and other downstream packages to use new version of crypto packages, while preventing its usage with any existing releases.

Other revisions added to the PR:
* upper bound on `data-default-class <0.2`, since it has recently been decided that it is better been switched to use `data-default` and dependency was inverted with `data-default-0.8`
* upper bound `data-default <0.8`, for the above reason and because `cardano-ledger-core` historically provided an instance for `Bool` that now conflicts with the one provided in `data-default-0.8`
* upper bound `quickcheck-instances <0.3.32`, since it provides an `Arbitrary` instance for primitive `Vector`, which also conflicted with the orphan instance historically provided by `cardano-ledger-binary`

It also required a bump to `hackage.nix` and `haskell.nix`, which was brought over from #953 