### PR TITLE
Crypto upper bound revisions

### DIFF
--- a/_sources/cardano-crypto-praos/2.0.0.0.1/meta.toml
+++ b/_sources/cardano-crypto-praos/2.0.0.0.1/meta.toml
@@ -2,3 +2,7 @@ timestamp = 2022-10-25T16:40:34Z
 github = { repo = "input-output-hk/cardano-base", rev = "cc049d7c9b9a0129c15b1355fd1dff9e1a1a551c" }
 subdir = 'cardano-crypto-praos'
 force-version = true
+
+[[revisions]]
+number = 1
+timestamp = 2025-01-29T20:54:25Z

--- a/_sources/cardano-crypto-praos/2.0.0.0.1/revisions/1.cabal
+++ b/_sources/cardano-crypto-praos/2.0.0.0.1/revisions/1.cabal
@@ -1,0 +1,78 @@
+cabal-version:      2.2
+name:               cardano-crypto-praos
+version:            2.0.0.0.1
+license:            Apache-2.0
+license-file:       LICENSE NOTICE
+copyright:          2019-2021 IOHK
+maintainer:         operations@iohk.io
+author:             IOHK
+synopsis:           Crypto primitives from libsodium
+description:        VRF (and KES, tba) primitives from libsodium.
+category:           Currency
+build-type:         Simple
+extra-source-files:
+    README.md
+    cbits/crypto_vrf.h
+    cbits/vrf03/crypto_vrf_ietfdraft03.h
+    cbits/vrf03/vrf_ietfdraft03.h
+    cbits/private/common.h
+    cbits/private/quirks.h
+    cbits/private/ed25519_ref10.h
+    cbits/private/ed25519_ref10_fe_25_5.h
+    cbits/private/ed25519_ref10_fe_51.h
+    cbits/private/fe_25_5/constants.h
+    cbits/private/fe_25_5/base.h
+    cbits/private/fe_25_5/base2.h
+    cbits/private/fe_25_5/fe.h
+    cbits/private/fe_51/constants.h
+    cbits/private/fe_51/base.h
+    cbits/private/fe_51/base2.h
+    cbits/private/fe_51/fe.h
+
+flag development
+    description: Disable `-Werror`
+    default:     False
+    manual:      True
+
+flag external-libsodium-vrf
+    description:
+        Rely on a special libsodium fork containing the VRF code.
+        Otherwise expect a normal unaltered system libsodium, and
+        bundle the VRF code.
+
+    manual:      True
+
+library
+    exposed-modules:
+        Cardano.Crypto.VRF.Praos
+        Cardano.Crypto.RandomBytes
+
+    pkgconfig-depends: libsodium
+    hs-source-dirs:    src
+    default-language:  Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.15,
+        base,
+        bytestring,
+        cardano-binary,
+        cardano-crypto-class <2.2,
+        cardano-prelude,
+        nothunks
+
+    if !flag(development)
+        ghc-options: -Werror
+
+    if !flag(external-libsodium-vrf)
+        c-sources:
+            cbits/crypto_vrf.c
+            cbits/vrf03/convert.c
+            cbits/vrf03/keypair.c
+            cbits/vrf03/prove.c
+            cbits/vrf03/verify.c
+            cbits/vrf03/vrf.c
+            cbits/private/ed25519_ref10.c

--- a/_sources/cardano-crypto-praos/2.0.0.1/meta.toml
+++ b/_sources/cardano-crypto-praos/2.0.0.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-10-17T00:00:00Z
 github = { repo = "input-output-hk/cardano-base", rev = "4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1" }
 subdir = 'cardano-crypto-praos'
+
+[[revisions]]
+number = 1
+timestamp = 2025-01-29T20:54:25Z

--- a/_sources/cardano-crypto-praos/2.0.0.1/revisions/1.cabal
+++ b/_sources/cardano-crypto-praos/2.0.0.1/revisions/1.cabal
@@ -1,0 +1,102 @@
+cabal-version: 2.2
+
+name:                cardano-crypto-praos
+version:             2.0.0.1
+synopsis:            Crypto primitives from libsodium
+description:         VRF (and KES, tba) primitives from libsodium.
+license:             Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2019-2021 IOHK
+category:            Currency
+build-type:          Simple
+extra-source-files:  README.md
+
+extra-source-files:    cbits/crypto_vrf.h
+
+                       cbits/vrf03/crypto_vrf_ietfdraft03.h
+                       cbits/vrf03/vrf_ietfdraft03.h
+
+                       -- cbits/vrf10_batchcompat/crypto_vrf_ietfdraft10.h
+                       -- cbits/vrf10_batchcompat/vrf_ietfdraft10.h
+
+                       cbits/private/common.h
+                       cbits/private/quirks.h
+                       cbits/private/ed25519_ref10.h
+                       --cbits/private/hash_to_curve.h
+                       cbits/private/ed25519_ref10_fe_25_5.h
+                       cbits/private/ed25519_ref10_fe_51.h
+
+                       cbits/private/fe_25_5/constants.h
+                       cbits/private/fe_25_5/base.h
+                       cbits/private/fe_25_5/base2.h
+                       cbits/private/fe_25_5/fe.h
+                       cbits/private/fe_51/constants.h
+                       cbits/private/fe_51/base.h
+                       cbits/private/fe_51/base2.h
+                       cbits/private/fe_51/fe.h
+
+flag development
+    description: Disable `-Werror`
+    default: False
+    manual: True
+
+flag external-libsodium-vrf
+    description: Rely on a special libsodium fork containing the VRF code.
+                 Otherwise expect a normal unaltered system libsodium, and
+                 bundle the VRF code.
+    default: True
+    manual: True
+
+common base                         { build-depends: base >= 4.14 && < 4.17 }
+
+common project-config
+  default-language:     Haskell2010
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+
+  if (!flag(development))
+    ghc-options:        -Werror
+
+library
+  import:               base, project-config
+  hs-source-dirs:       src
+  exposed-modules:      Cardano.Crypto.VRF.Praos
+                 -- Disabled until the full audit is complete:
+                 -- ,      Cardano.Crypto.VRF.PraosBatchCompat
+                 ,      Cardano.Crypto.RandomBytes
+
+  build-depends:        base
+                      , bytestring
+                      , cardano-binary
+                      , cardano-crypto-class <2.2
+                      , deepseq
+                      , nothunks
+
+  pkgconfig-depends: libsodium
+
+  if !flag(external-libsodium-vrf)
+    c-sources:          cbits/crypto_vrf.c
+                        cbits/vrf03/convert.c
+                        cbits/vrf03/keypair.c
+                        cbits/vrf03/prove.c
+                        cbits/vrf03/verify.c
+                        cbits/vrf03/vrf.c
+
+                        -- cbits/vrf10_batchcompat/convert.c
+                        -- cbits/vrf10_batchcompat/verify.c
+                        -- cbits/vrf10_batchcompat/keypair.c
+                        -- cbits/vrf10_batchcompat/prove.c
+                        -- cbits/vrf10_batchcompat/vrf.c
+
+                        -- cbits/private/hash_to_curve.c
+                        cbits/private/ed25519_ref10.c

--- a/_sources/cardano-crypto-praos/2.0.0/meta.toml
+++ b/_sources/cardano-crypto-praos/2.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-10-17T00:00:00Z
 github = { repo = "input-output-hk/cardano-base", rev = "0f3a867493059e650cda69e20a5cbf1ace289a57" }
 subdir = 'cardano-crypto-praos'
+
+[[revisions]]
+number = 1
+timestamp = 2025-01-29T20:54:25Z

--- a/_sources/cardano-crypto-praos/2.0.0/revisions/1.cabal
+++ b/_sources/cardano-crypto-praos/2.0.0/revisions/1.cabal
@@ -1,0 +1,102 @@
+cabal-version: 2.2
+
+name:                cardano-crypto-praos
+version:             2.0.0
+synopsis:            Crypto primitives from libsodium
+description:         VRF (and KES, tba) primitives from libsodium.
+license:             Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2019-2021 IOHK
+category:            Currency
+build-type:          Simple
+extra-source-files:  README.md
+
+extra-source-files:    cbits/crypto_vrf.h
+
+                       cbits/vrf03/crypto_vrf_ietfdraft03.h
+                       cbits/vrf03/vrf_ietfdraft03.h
+
+                       -- cbits/vrf10_batchcompat/crypto_vrf_ietfdraft10.h
+                       -- cbits/vrf10_batchcompat/vrf_ietfdraft10.h
+
+                       cbits/private/common.h
+                       cbits/private/quirks.h
+                       cbits/private/ed25519_ref10.h
+                       --cbits/private/hash_to_curve.h
+                       cbits/private/ed25519_ref10_fe_25_5.h
+                       cbits/private/ed25519_ref10_fe_51.h
+
+                       cbits/private/fe_25_5/constants.h
+                       cbits/private/fe_25_5/base.h
+                       cbits/private/fe_25_5/base2.h
+                       cbits/private/fe_25_5/fe.h
+                       cbits/private/fe_51/constants.h
+                       cbits/private/fe_51/base.h
+                       cbits/private/fe_51/base2.h
+                       cbits/private/fe_51/fe.h
+
+flag development
+    description: Disable `-Werror`
+    default: False
+    manual: True
+
+flag external-libsodium-vrf
+    description: Rely on a special libsodium fork containing the VRF code.
+                 Otherwise expect a normal unaltered system libsodium, and
+                 bundle the VRF code.
+    default: True
+    manual: True
+
+common base                         { build-depends: base                             >= 4.14       && < 4.15     }
+
+common project-config
+  default-language:     Haskell2010
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+
+  if (!flag(development))
+    ghc-options:        -Werror
+
+library
+  import:               base, project-config
+  hs-source-dirs:       src
+  exposed-modules:      Cardano.Crypto.VRF.Praos
+                 -- Disabled until the full audit is complete:
+                 -- ,      Cardano.Crypto.VRF.PraosBatchCompat
+                 ,      Cardano.Crypto.RandomBytes
+
+  build-depends:        base
+                      , bytestring
+                      , cardano-binary
+                      , cardano-crypto-class <2.2
+                      , cardano-prelude
+                      , nothunks
+
+  pkgconfig-depends: libsodium
+
+  if !flag(external-libsodium-vrf)
+    c-sources:          cbits/crypto_vrf.c
+                        cbits/vrf03/convert.c
+                        cbits/vrf03/keypair.c
+                        cbits/vrf03/prove.c
+                        cbits/vrf03/verify.c
+                        cbits/vrf03/vrf.c
+
+                        -- cbits/vrf10_batchcompat/convert.c
+                        -- cbits/vrf10_batchcompat/verify.c
+                        -- cbits/vrf10_batchcompat/keypair.c
+                        -- cbits/vrf10_batchcompat/prove.c
+                        -- cbits/vrf10_batchcompat/vrf.c
+
+                        -- cbits/private/hash_to_curve.c
+                        cbits/private/ed25519_ref10.c

--- a/_sources/cardano-crypto-praos/2.1.0.0/meta.toml
+++ b/_sources/cardano-crypto-praos/2.1.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-10-17T00:00:00Z
 github = { repo = "input-output-hk/cardano-base", rev = "2c5285e40f9076d15a86c53254777601c1077cc9" }
 subdir = 'cardano-crypto-praos'
+
+[[revisions]]
+number = 1
+timestamp = 2025-01-29T20:54:25Z

--- a/_sources/cardano-crypto-praos/2.1.0.0/revisions/1.cabal
+++ b/_sources/cardano-crypto-praos/2.1.0.0/revisions/1.cabal
@@ -1,0 +1,103 @@
+cabal-version: 2.2
+
+name:                cardano-crypto-praos
+version:             2.1.0.0
+synopsis:            Crypto primitives from libsodium
+description:         VRF (and KES, tba) primitives from libsodium.
+license:             Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2019-2021 IOHK
+category:            Currency
+build-type:          Simple
+extra-source-files:  README.md
+                     CHANGELOG.md
+
+extra-source-files:    cbits/crypto_vrf.h
+
+                       cbits/vrf03/crypto_vrf_ietfdraft03.h
+                       cbits/vrf03/vrf_ietfdraft03.h
+
+                       -- cbits/vrf10_batchcompat/crypto_vrf_ietfdraft10.h
+                       -- cbits/vrf10_batchcompat/vrf_ietfdraft10.h
+
+                       cbits/private/common.h
+                       cbits/private/quirks.h
+                       cbits/private/ed25519_ref10.h
+                       --cbits/private/hash_to_curve.h
+                       cbits/private/ed25519_ref10_fe_25_5.h
+                       cbits/private/ed25519_ref10_fe_51.h
+
+                       cbits/private/fe_25_5/constants.h
+                       cbits/private/fe_25_5/base.h
+                       cbits/private/fe_25_5/base2.h
+                       cbits/private/fe_25_5/fe.h
+                       cbits/private/fe_51/constants.h
+                       cbits/private/fe_51/base.h
+                       cbits/private/fe_51/base2.h
+                       cbits/private/fe_51/fe.h
+
+flag development
+    description: Disable `-Werror`
+    default: False
+    manual: True
+
+flag external-libsodium-vrf
+    description: Rely on a special libsodium fork containing the VRF code.
+                 Otherwise expect a normal unaltered system libsodium, and
+                 bundle the VRF code.
+    default: True
+    manual: True
+
+common base                         { build-depends: base >= 4.14 && < 4.17 }
+
+common project-config
+  default-language:     Haskell2010
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+
+  if (!flag(development))
+    ghc-options:        -Werror
+
+library
+  import:               base, project-config
+  hs-source-dirs:       src
+  exposed-modules:      Cardano.Crypto.VRF.Praos
+                 -- Disabled until the full audit is complete:
+                 -- ,      Cardano.Crypto.VRF.PraosBatchCompat
+                 ,      Cardano.Crypto.RandomBytes
+
+  build-depends:        base
+                      , bytestring
+                      , cardano-binary
+                      , cardano-crypto-class <2.2
+                      , deepseq
+                      , nothunks
+
+  pkgconfig-depends: libsodium
+
+  if !flag(external-libsodium-vrf)
+    c-sources:          cbits/crypto_vrf.c
+                        cbits/vrf03/convert.c
+                        cbits/vrf03/keypair.c
+                        cbits/vrf03/prove.c
+                        cbits/vrf03/verify.c
+                        cbits/vrf03/vrf.c
+
+                        -- cbits/vrf10_batchcompat/convert.c
+                        -- cbits/vrf10_batchcompat/verify.c
+                        -- cbits/vrf10_batchcompat/keypair.c
+                        -- cbits/vrf10_batchcompat/prove.c
+                        -- cbits/vrf10_batchcompat/vrf.c
+
+                        -- cbits/private/hash_to_curve.c
+                        cbits/private/ed25519_ref10.c

--- a/_sources/cardano-crypto-praos/2.1.1.0/meta.toml
+++ b/_sources/cardano-crypto-praos/2.1.1.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-02-21T23:26:04Z
 github = { repo = "input-output-hk/cardano-base", rev = "7e64caa79e0f751f1333ccbce4a64cb48752ae69" }
 subdir = 'cardano-crypto-praos'
+
+[[revisions]]
+number = 1
+timestamp = 2025-01-29T20:54:25Z

--- a/_sources/cardano-crypto-praos/2.1.1.0/revisions/1.cabal
+++ b/_sources/cardano-crypto-praos/2.1.1.0/revisions/1.cabal
@@ -1,0 +1,95 @@
+cabal-version: 2.2
+
+name:                cardano-crypto-praos
+version:             2.1.1.0
+synopsis:            Crypto primitives from libsodium
+description:         VRF (and KES, tba) primitives from libsodium.
+license:             Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2019-2021 IOHK
+category:            Currency
+build-type:          Simple
+extra-source-files:  README.md
+                     CHANGELOG.md
+
+extra-source-files:    cbits/crypto_vrf.h
+
+                       cbits/vrf03/crypto_vrf_ietfdraft03.h
+
+                       cbits/vrf13_batchcompat/crypto_vrf_ietfdraft13.h
+
+                       cbits/private/common.h
+                       cbits/private/ed25519_ref10.h
+                       cbits/private/core_h2c.h
+                       cbits/private/ed25519_ref10_fe_25_5.h
+                       cbits/private/ed25519_ref10_fe_51.h
+
+                       cbits/private/fe_25_5/constants.h
+                       cbits/private/fe_25_5/base.h
+                       cbits/private/fe_25_5/base2.h
+                       cbits/private/fe_25_5/fe.h
+                       cbits/private/fe_51/constants.h
+                       cbits/private/fe_51/base.h
+                       cbits/private/fe_51/base2.h
+                       cbits/private/fe_51/fe.h
+
+flag development
+    description: Disable `-Werror`
+    default: False
+    manual: True
+
+flag external-libsodium-vrf
+    description: Rely on a special libsodium fork containing the VRF code.
+                 Otherwise expect a normal unaltered system libsodium, and
+                 bundle the VRF code.
+    default: True
+    manual: True
+
+common base                         { build-depends: base >= 4.14 && < 4.17 }
+
+common project-config
+  default-language:     Haskell2010
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+
+  if (!flag(development))
+    ghc-options:        -Werror
+
+library
+  import:               base, project-config
+  hs-source-dirs:       src
+  exposed-modules:      Cardano.Crypto.VRF.Praos
+                 ,      Cardano.Crypto.VRF.PraosBatchCompat
+                 ,      Cardano.Crypto.RandomBytes
+
+  build-depends:        base
+                      , bytestring
+                      , cardano-binary
+                      , cardano-crypto-class >= 2.1 && <2.2
+                      , deepseq
+                      , nothunks
+
+  pkgconfig-depends: libsodium
+
+  if !flag(external-libsodium-vrf)
+    c-sources:          cbits/crypto_vrf.c
+                        cbits/vrf03/prove.c
+                        cbits/vrf03/verify.c
+                        cbits/vrf03/vrf.c
+
+                        cbits/vrf13_batchcompat/verify.c
+                        cbits/vrf13_batchcompat/prove.c
+                        cbits/vrf13_batchcompat/vrf.c
+
+                        cbits/private/core_h2c.c
+                        cbits/private/ed25519_ref10.c

--- a/_sources/cardano-crypto-praos/2.1.1.1/meta.toml
+++ b/_sources/cardano-crypto-praos/2.1.1.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-04-03T21:22:00Z
 github = { repo = "input-output-hk/cardano-base", rev = "f954aec4fbe11ba96729ddcc5e22c13ab6320b5d" }
 subdir = 'cardano-crypto-praos'
+
+[[revisions]]
+number = 1
+timestamp = 2025-01-29T20:54:25Z

--- a/_sources/cardano-crypto-praos/2.1.1.1/revisions/1.cabal
+++ b/_sources/cardano-crypto-praos/2.1.1.1/revisions/1.cabal
@@ -1,0 +1,87 @@
+cabal-version: 2.2
+
+name:                cardano-crypto-praos
+version:             2.1.1.1
+synopsis:            Crypto primitives from libsodium
+description:         VRF (and KES, tba) primitives from libsodium.
+license:             Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2019-2021 IOHK
+category:            Currency
+build-type:          Simple
+extra-source-files:  README.md
+                     CHANGELOG.md
+
+extra-source-files:    cbits/crypto_vrf.h
+
+                       cbits/vrf03/crypto_vrf_ietfdraft03.h
+
+                       cbits/vrf13_batchcompat/crypto_vrf_ietfdraft13.h
+
+                       cbits/private/common.h
+                       cbits/private/ed25519_ref10.h
+                       cbits/private/core_h2c.h
+                       cbits/private/ed25519_ref10_fe_25_5.h
+                       cbits/private/ed25519_ref10_fe_51.h
+
+                       cbits/private/fe_25_5/constants.h
+                       cbits/private/fe_25_5/base.h
+                       cbits/private/fe_25_5/base2.h
+                       cbits/private/fe_25_5/fe.h
+                       cbits/private/fe_51/constants.h
+                       cbits/private/fe_51/base.h
+                       cbits/private/fe_51/base2.h
+                       cbits/private/fe_51/fe.h
+
+flag external-libsodium-vrf
+    description: Rely on a special libsodium fork containing the VRF code.
+                 Otherwise expect a normal unaltered system libsodium, and
+                 bundle the VRF code.
+    default: True
+    manual: True
+
+common base                         { build-depends: base >= 4.14 && < 4.17 }
+
+common project-config
+  default-language:     Haskell2010
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+
+library
+  import:               base, project-config
+  hs-source-dirs:       src
+  exposed-modules:      Cardano.Crypto.VRF.Praos
+                 ,      Cardano.Crypto.VRF.PraosBatchCompat
+                 ,      Cardano.Crypto.RandomBytes
+
+  build-depends:        base
+                      , bytestring
+                      , cardano-binary
+                      , cardano-crypto-class >= 2.1 && <2.2
+                      , deepseq
+                      , nothunks
+
+  pkgconfig-depends: libsodium
+
+  if !flag(external-libsodium-vrf)
+    c-sources:          cbits/crypto_vrf.c
+                        cbits/vrf03/prove.c
+                        cbits/vrf03/verify.c
+                        cbits/vrf03/vrf.c
+
+                        cbits/vrf13_batchcompat/verify.c
+                        cbits/vrf13_batchcompat/prove.c
+                        cbits/vrf13_batchcompat/vrf.c
+
+                        cbits/private/core_h2c.c
+                        cbits/private/ed25519_ref10.c

--- a/_sources/cardano-crypto-praos/2.1.1.2/meta.toml
+++ b/_sources/cardano-crypto-praos/2.1.1.2/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-04-26T21:43:05Z
 github = { repo = "input-output-hk/cardano-base", rev = "ff892bfd88f030144b2ec60e1ef372476069c5f1" }
 subdir = 'cardano-crypto-praos'
+
+[[revisions]]
+number = 1
+timestamp = 2025-01-29T20:54:25Z

--- a/_sources/cardano-crypto-praos/2.1.1.2/revisions/1.cabal
+++ b/_sources/cardano-crypto-praos/2.1.1.2/revisions/1.cabal
@@ -1,0 +1,87 @@
+cabal-version: 2.2
+
+name:                cardano-crypto-praos
+version:             2.1.1.2
+synopsis:            Crypto primitives from libsodium
+description:         VRF (and KES, tba) primitives from libsodium.
+license:             Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2019-2021 IOHK
+category:            Currency
+build-type:          Simple
+extra-source-files:  README.md
+                     CHANGELOG.md
+
+extra-source-files:    cbits/crypto_vrf.h
+
+                       cbits/vrf03/crypto_vrf_ietfdraft03.h
+
+                       cbits/vrf13_batchcompat/crypto_vrf_ietfdraft13.h
+
+                       cbits/private/common.h
+                       cbits/private/ed25519_ref10.h
+                       cbits/private/core_h2c.h
+                       cbits/private/ed25519_ref10_fe_25_5.h
+                       cbits/private/ed25519_ref10_fe_51.h
+
+                       cbits/private/fe_25_5/constants.h
+                       cbits/private/fe_25_5/base.h
+                       cbits/private/fe_25_5/base2.h
+                       cbits/private/fe_25_5/fe.h
+                       cbits/private/fe_51/constants.h
+                       cbits/private/fe_51/base.h
+                       cbits/private/fe_51/base2.h
+                       cbits/private/fe_51/fe.h
+
+flag external-libsodium-vrf
+    description: Rely on a special libsodium fork containing the VRF code.
+                 Otherwise expect a normal unaltered system libsodium, and
+                 bundle the VRF code.
+    default: True
+    manual: True
+
+common base                         { build-depends: base >= 4.14 && < 4.19 }
+
+common project-config
+  default-language:     Haskell2010
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+
+library
+  import:               base, project-config
+  hs-source-dirs:       src
+  exposed-modules:      Cardano.Crypto.VRF.Praos
+                 ,      Cardano.Crypto.VRF.PraosBatchCompat
+                 ,      Cardano.Crypto.RandomBytes
+
+  build-depends:        base
+                      , bytestring
+                      , cardano-binary
+                      , cardano-crypto-class >= 2.1 && <2.2
+                      , deepseq
+                      , nothunks
+
+  pkgconfig-depends: libsodium
+
+  if !flag(external-libsodium-vrf)
+    c-sources:          cbits/crypto_vrf.c
+                        cbits/vrf03/prove.c
+                        cbits/vrf03/verify.c
+                        cbits/vrf03/vrf.c
+
+                        cbits/vrf13_batchcompat/verify.c
+                        cbits/vrf13_batchcompat/prove.c
+                        cbits/vrf13_batchcompat/vrf.c
+
+                        cbits/private/core_h2c.c
+                        cbits/private/ed25519_ref10.c

--- a/_sources/cardano-crypto-praos/2.1.2.0/meta.toml
+++ b/_sources/cardano-crypto-praos/2.1.2.0/meta.toml
@@ -9,3 +9,7 @@ timestamp = 2023-11-22T22:19:16Z
 [[revisions]]
 number = 2
 timestamp = 2024-06-19T21:42:15Z
+
+[[revisions]]
+number = 3
+timestamp = 2025-01-29T20:54:25Z

--- a/_sources/cardano-crypto-praos/2.1.2.0/revisions/3.cabal
+++ b/_sources/cardano-crypto-praos/2.1.2.0/revisions/3.cabal
@@ -1,0 +1,87 @@
+cabal-version: 2.2
+
+name:                cardano-crypto-praos
+version:             2.1.2.0
+synopsis:            Crypto primitives from libsodium
+description:         VRF (and KES, tba) primitives from libsodium.
+license:             Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2019-2021 IOHK
+category:            Currency
+build-type:          Simple
+extra-source-files:  README.md
+                     CHANGELOG.md
+
+extra-source-files:    cbits/crypto_vrf.h
+
+                       cbits/vrf03/crypto_vrf_ietfdraft03.h
+
+                       cbits/vrf13_batchcompat/crypto_vrf_ietfdraft13.h
+
+                       cbits/private/common.h
+                       cbits/private/ed25519_ref10.h
+                       cbits/private/core_h2c.h
+                       cbits/private/ed25519_ref10_fe_25_5.h
+                       cbits/private/ed25519_ref10_fe_51.h
+
+                       cbits/private/fe_25_5/constants.h
+                       cbits/private/fe_25_5/base.h
+                       cbits/private/fe_25_5/base2.h
+                       cbits/private/fe_25_5/fe.h
+                       cbits/private/fe_51/constants.h
+                       cbits/private/fe_51/base.h
+                       cbits/private/fe_51/base2.h
+                       cbits/private/fe_51/fe.h
+
+flag external-libsodium-vrf
+    description: Rely on a special libsodium fork containing the VRF code.
+                 Otherwise expect a normal unaltered system libsodium, and
+                 bundle the VRF code.
+    default: True
+    manual: True
+
+common base                         { build-depends: base >= 4.14 && < 5 }
+
+common project-config
+  default-language:     Haskell2010
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+
+library
+  import:               base, project-config
+  hs-source-dirs:       src
+  exposed-modules:      Cardano.Crypto.VRF.Praos
+                 ,      Cardano.Crypto.VRF.PraosBatchCompat
+                 ,      Cardano.Crypto.RandomBytes
+
+  build-depends:        base
+                      , bytestring
+                      , cardano-binary
+                      , cardano-crypto-class >= 2.1.1 && <2.2
+                      , deepseq
+                      , nothunks
+
+  pkgconfig-depends: libsodium
+
+  if !flag(external-libsodium-vrf)
+    c-sources:          cbits/crypto_vrf.c
+                        cbits/vrf03/prove.c
+                        cbits/vrf03/verify.c
+                        cbits/vrf03/vrf.c
+
+                        cbits/vrf13_batchcompat/verify.c
+                        cbits/vrf13_batchcompat/prove.c
+                        cbits/vrf13_batchcompat/vrf.c
+
+                        cbits/private/core_h2c.c
+                        cbits/private/ed25519_ref10.c

--- a/_sources/cardano-crypto-tests/2.0.0.0.1/meta.toml
+++ b/_sources/cardano-crypto-tests/2.0.0.0.1/meta.toml
@@ -2,3 +2,7 @@ timestamp = 2022-10-25T16:40:49Z
 github = { repo = "input-output-hk/cardano-base", rev = "cc049d7c9b9a0129c15b1355fd1dff9e1a1a551c" }
 subdir = 'cardano-crypto-tests'
 force-version = true
+
+[[revisions]]
+number = 1
+timestamp = 2025-01-29T20:54:25Z

--- a/_sources/cardano-crypto-tests/2.0.0.0.1/revisions/1.cabal
+++ b/_sources/cardano-crypto-tests/2.0.0.0.1/revisions/1.cabal
@@ -1,0 +1,111 @@
+cabal-version:      2.2
+name:               cardano-crypto-tests
+version:            2.0.0.0.1
+license:            Apache-2.0
+license-file:       LICENSE NOTICE
+copyright:          2020-2021 IOHK
+maintainer:         operations@iohk.io
+author:             IOHK
+synopsis:           Tests for cardano-crypto-class and -praos
+description:        Tests for cardano-crypto-class and -praos
+category:           Currency
+build-type:         Simple
+extra-source-files: README.md
+
+flag development
+    description: Disable `-Werror`
+    default:     False
+    manual:      True
+
+flag secp256k1-support
+    description:
+        Enable support for functions from libsecp256k1. Requires
+        a recent libsecp256k1 with support for Schnorr signatures.
+
+    manual:      True
+
+library
+    exposed-modules:
+        Test.Crypto.DSIGN
+        Test.Crypto.Hash
+        Test.Crypto.KES
+        Test.Crypto.Util
+        Test.Crypto.VRF
+        Test.Crypto.Regressions
+        Test.Crypto.Instances
+        Bench.Crypto.VRF
+        Bench.Crypto.KES
+
+    hs-source-dirs:   src
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.15,
+        base,
+        bytestring,
+        cardano-binary,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-prelude,
+        cborg,
+        cryptonite,
+        formatting,
+        nothunks,
+        pretty-show,
+        QuickCheck,
+        quickcheck-instances,
+        tasty,
+        tasty-hunit,
+        tasty-quickcheck,
+        criterion
+
+    if !flag(development)
+        ghc-options: -Werror
+
+    if flag(secp256k1-support)
+        cpp-options: -DSECP256K1_ENABLED
+
+test-suite test-crypto
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base >=4.14 && <4.15,
+        base,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        tasty,
+        tasty-quickcheck
+
+    if !flag(development)
+        ghc-options: -Werror
+
+benchmark bench-crypto
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
+        -Wunused-packages -threaded
+
+    build-depends:
+        base >=4.14 && <4.15,
+        base,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        criterion
+
+    if !flag(development)
+        ghc-options: -Werror

--- a/_sources/cardano-crypto-tests/2.0.0.1/meta.toml
+++ b/_sources/cardano-crypto-tests/2.0.0.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-10-17T00:00:00Z
 github = { repo = "input-output-hk/cardano-base", rev = "4ef911eb7a4d628c938312ff4c92e7c0bb8c83a1" }
 subdir = 'cardano-crypto-tests'
+
+[[revisions]]
+number = 1
+timestamp = 2025-01-29T20:54:25Z

--- a/_sources/cardano-crypto-tests/2.0.0.1/revisions/1.cabal
+++ b/_sources/cardano-crypto-tests/2.0.0.1/revisions/1.cabal
@@ -1,0 +1,103 @@
+cabal-version: 2.2
+
+name:                cardano-crypto-tests
+version:             2.0.0.1
+synopsis:            Tests for cardano-crypto-class and -praos
+description:         Tests for cardano-crypto-class and -praos
+license:             Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2020-2021 IOHK
+category:            Currency
+build-type:          Simple
+extra-source-files:  README.md
+
+flag development
+    description: Disable `-Werror`
+    default: False
+    manual: True
+
+flag secp256k1-support
+    description: Enable support for functions from libsecp256k1. Requires
+                 a recent libsecp256k1 with support for Schnorr signatures.
+    default: True
+    manual: True
+
+common base                         { build-depends: base >= 4.14 && < 4.17 }
+
+common project-config
+  default-language:     Haskell2010
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+
+  if (!flag(development))
+    ghc-options:        -Werror
+
+library
+  import:               base, project-config
+  hs-source-dirs:       src
+
+  exposed-modules:      Test.Crypto.DSIGN
+                        Test.Crypto.Hash
+                        Test.Crypto.KES
+                        Test.Crypto.Util
+                        Test.Crypto.VRF
+                        Test.Crypto.Regressions
+                        Test.Crypto.Instances
+                        Bench.Crypto.VRF
+                        Bench.Crypto.KES
+
+  build-depends:        base
+                      , bytestring
+                      , cardano-binary
+                      , cardano-crypto-class <2.2
+                      , cardano-crypto-praos
+                      , cborg
+                      , cryptonite
+                      , deepseq
+                      , formatting
+                      , nothunks
+                      , pretty-show
+                      , QuickCheck
+                      , quickcheck-instances
+                      , tasty
+                      , tasty-hunit
+                      , tasty-quickcheck
+                      , criterion
+
+  if flag(secp256k1-support)
+    cpp-options: -DSECP256K1_ENABLED
+
+test-suite test-crypto
+  import:               base, project-config
+  type:                 exitcode-stdio-1.0
+  hs-source-dirs:       test
+  main-is:              Main.hs
+  build-depends:        base
+                      , cardano-crypto-class
+                      , cardano-crypto-tests
+                      , tasty
+                      , tasty-quickcheck
+
+  ghc-options:          -threaded -rtsopts -with-rtsopts=-N
+
+benchmark bench-crypto
+  import:               base, project-config
+  type:                 exitcode-stdio-1.0
+  hs-source-dirs:       bench
+  main-is:              Main.hs
+  build-depends:        base
+                      , cardano-crypto-class
+                      , cardano-crypto-tests
+                      , criterion
+
+  ghc-options:          -threaded

--- a/_sources/cardano-crypto-tests/2.0.0/meta.toml
+++ b/_sources/cardano-crypto-tests/2.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-10-17T00:00:00Z
 github = { repo = "input-output-hk/cardano-base", rev = "0f3a867493059e650cda69e20a5cbf1ace289a57" }
 subdir = 'cardano-crypto-tests'
+
+[[revisions]]
+number = 1
+timestamp = 2025-01-29T20:54:25Z

--- a/_sources/cardano-crypto-tests/2.0.0/revisions/1.cabal
+++ b/_sources/cardano-crypto-tests/2.0.0/revisions/1.cabal
@@ -1,0 +1,102 @@
+cabal-version: 2.2
+
+name:                cardano-crypto-tests
+version:             2.0.0
+synopsis:            Tests for cardano-crypto-class and -praos
+description:         Tests for cardano-crypto-class and -praos
+license:             Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2020-2021 IOHK
+category:            Currency
+build-type:          Simple
+extra-source-files:  README.md
+
+flag development
+    description: Disable `-Werror`
+    default: False
+    manual: True
+
+flag secp256k1-support
+    description: Enable support for functions from libsecp256k1. Requires
+                 a recent libsecp256k1 with support for Schnorr signatures.
+    default: True
+    manual: True
+
+common base                         { build-depends: base                             >= 4.14       && < 4.15     }
+
+common project-config
+  default-language:     Haskell2010
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+
+  if (!flag(development))
+    ghc-options:        -Werror
+
+library
+  import:               base, project-config
+  hs-source-dirs:       src
+
+  exposed-modules:      Test.Crypto.DSIGN
+                        Test.Crypto.Hash
+                        Test.Crypto.KES
+                        Test.Crypto.Util
+                        Test.Crypto.VRF
+                        Test.Crypto.Instances
+                        Bench.Crypto.VRF
+                        Bench.Crypto.KES
+
+  build-depends:        base
+                      , bytestring
+                      , cardano-binary
+                      , cardano-crypto-class <2.2
+                      , cardano-crypto-praos
+                      , cardano-prelude
+                      , cborg
+                      , cryptonite
+                      , formatting
+                      , nothunks
+                      , pretty-show
+                      , QuickCheck
+                      , quickcheck-instances
+                      , tasty
+                      , tasty-quickcheck
+                      , criterion
+
+  if flag(secp256k1-support)
+    build-depends: secp256k1-haskell
+    cpp-options: -DSECP256K1
+
+test-suite test-crypto
+  import:               base, project-config
+  type:                 exitcode-stdio-1.0
+  hs-source-dirs:       test
+  main-is:              Main.hs
+  build-depends:        base
+                      , cardano-crypto-class
+                      , cardano-crypto-tests
+                      , tasty
+                      , tasty-quickcheck
+
+  ghc-options:          -threaded -rtsopts -with-rtsopts=-N
+
+benchmark bench-crypto
+  import:               base, project-config
+  type:                 exitcode-stdio-1.0
+  hs-source-dirs:       bench
+  main-is:              Main.hs
+  build-depends:        base
+                      , cardano-crypto-class
+                      , cardano-crypto-tests
+                      , criterion
+
+  ghc-options:          -threaded

--- a/_sources/cardano-crypto-tests/2.1.0.0/meta.toml
+++ b/_sources/cardano-crypto-tests/2.1.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-02-21T23:26:04Z
 github = { repo = "input-output-hk/cardano-base", rev = "7e64caa79e0f751f1333ccbce4a64cb48752ae69" }
 subdir = 'cardano-crypto-tests'
+
+[[revisions]]
+number = 1
+timestamp = 2025-01-29T20:54:25Z

--- a/_sources/cardano-crypto-tests/2.1.0.0/revisions/1.cabal
+++ b/_sources/cardano-crypto-tests/2.1.0.0/revisions/1.cabal
@@ -1,0 +1,111 @@
+cabal-version: 2.2
+
+name:                cardano-crypto-tests
+version:             2.1.0.0
+synopsis:            Tests for cardano-crypto-class and -praos
+description:         Tests for cardano-crypto-class and -praos
+license:             Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2020-2021 IOHK
+category:            Currency
+build-type:          Simple
+extra-source-files:  README.md
+                     CHANGELOG.md
+
+flag development
+    description: Disable `-Werror`
+    default: False
+    manual: True
+
+flag secp256k1-support
+    description: Enable support for functions from libsecp256k1. Requires
+                 a recent libsecp256k1 with support for Schnorr signatures.
+    default: True
+    manual: True
+
+common base                         { build-depends: base >= 4.14 && < 4.17 }
+
+common project-config
+  default-language:     Haskell2010
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+
+  if (!flag(development))
+    ghc-options:        -Werror
+
+library
+  import:               base, project-config
+  hs-source-dirs:       src
+
+  exposed-modules:      Test.Crypto.DSIGN
+                        Test.Crypto.Hash
+                        Test.Crypto.KES
+                        Test.Crypto.Util
+                        Test.Crypto.VRF
+                        Test.Crypto.Regressions
+                        Test.Crypto.Instances
+                        Bench.Crypto.DSIGN
+                        Bench.Crypto.VRF
+                        Bench.Crypto.KES
+                        Bench.Crypto.BenchData
+                        Test.Crypto.Vector.Secp256k1DSIGN
+                        Test.Crypto.Vector.Vectors
+                        Test.Crypto.Vector.StringConstants
+                        Test.Crypto.Vector.SerializationUtils
+
+  build-depends:        base
+                      , bytestring
+                      , cardano-binary
+                      , cardano-crypto-class >= 2.1 && <2.2
+                      , cardano-crypto-praos
+                      , cborg
+                      , cryptonite
+                      , deepseq
+                      , formatting
+                      , nothunks
+                      , pretty-show
+                      , QuickCheck
+                      , quickcheck-instances
+                      , tasty
+                      , tasty-hunit
+                      , tasty-quickcheck
+                      , criterion
+                      , base16-bytestring
+
+  if flag(secp256k1-support)
+    cpp-options: -DSECP256K1_ENABLED
+
+test-suite test-crypto
+  import:               base, project-config
+  type:                 exitcode-stdio-1.0
+  hs-source-dirs:       test
+  main-is:              Main.hs
+  build-depends:        base
+                      , cardano-crypto-class
+                      , cardano-crypto-tests
+                      , tasty
+                      , tasty-quickcheck
+
+  ghc-options:          -threaded -rtsopts -with-rtsopts=-N
+
+benchmark bench-crypto
+  import:               base, project-config
+  type:                 exitcode-stdio-1.0
+  hs-source-dirs:       bench
+  main-is:              Main.hs
+  build-depends:        base
+                      , cardano-crypto-class
+                      , cardano-crypto-tests
+                      , criterion
+
+  ghc-options:          -threaded

--- a/_sources/cardano-crypto-tests/2.1.0.1/meta.toml
+++ b/_sources/cardano-crypto-tests/2.1.0.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-04-03T21:22:00Z
 github = { repo = "input-output-hk/cardano-base", rev = "f954aec4fbe11ba96729ddcc5e22c13ab6320b5d" }
 subdir = 'cardano-crypto-tests'
+
+[[revisions]]
+number = 1
+timestamp = 2025-01-29T20:54:25Z

--- a/_sources/cardano-crypto-tests/2.1.0.1/revisions/1.cabal
+++ b/_sources/cardano-crypto-tests/2.1.0.1/revisions/1.cabal
@@ -1,0 +1,103 @@
+cabal-version: 2.2
+
+name:                cardano-crypto-tests
+version:             2.1.0.1
+synopsis:            Tests for cardano-crypto-class and -praos
+description:         Tests for cardano-crypto-class and -praos
+license:             Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2020-2021 IOHK
+category:            Currency
+build-type:          Simple
+extra-source-files:  README.md
+                     CHANGELOG.md
+
+flag secp256k1-support
+    description: Enable support for functions from libsecp256k1. Requires
+                 a recent libsecp256k1 with support for Schnorr signatures.
+    default: True
+    manual: True
+
+common base                         { build-depends: base >= 4.14 && < 4.17 }
+
+common project-config
+  default-language:     Haskell2010
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+
+library
+  import:               base, project-config
+  hs-source-dirs:       src
+
+  exposed-modules:      Test.Crypto.DSIGN
+                        Test.Crypto.Hash
+                        Test.Crypto.KES
+                        Test.Crypto.Util
+                        Test.Crypto.VRF
+                        Test.Crypto.Regressions
+                        Test.Crypto.Instances
+                        Bench.Crypto.DSIGN
+                        Bench.Crypto.VRF
+                        Bench.Crypto.KES
+                        Bench.Crypto.BenchData
+                        Test.Crypto.Vector.Secp256k1DSIGN
+                        Test.Crypto.Vector.Vectors
+                        Test.Crypto.Vector.StringConstants
+                        Test.Crypto.Vector.SerializationUtils
+
+  build-depends:        base
+                      , bytestring
+                      , cardano-binary
+                      , cardano-crypto-class >= 2.1 && <2.2
+                      , cardano-crypto-praos
+                      , cborg
+                      , cryptonite
+                      , deepseq
+                      , formatting
+                      , nothunks
+                      , pretty-show
+                      , QuickCheck
+                      , quickcheck-instances
+                      , tasty
+                      , tasty-hunit
+                      , tasty-quickcheck
+                      , criterion
+                      , base16-bytestring
+
+  if flag(secp256k1-support)
+    cpp-options: -DSECP256K1_ENABLED
+
+test-suite test-crypto
+  import:               base, project-config
+  type:                 exitcode-stdio-1.0
+  hs-source-dirs:       test
+  main-is:              Main.hs
+  build-depends:        base
+                      , cardano-crypto-class
+                      , cardano-crypto-tests
+                      , tasty
+                      , tasty-quickcheck
+
+  ghc-options:          -threaded -rtsopts -with-rtsopts=-N
+
+benchmark bench-crypto
+  import:               base, project-config
+  type:                 exitcode-stdio-1.0
+  hs-source-dirs:       bench
+  main-is:              Main.hs
+  build-depends:        base
+                      , cardano-crypto-class
+                      , cardano-crypto-tests
+                      , criterion
+
+  ghc-options:          -threaded


### PR DESCRIPTION
Older versions of `cardano-crypto-tests` and `cardano-crypto-praos` are incompatible with `cardano-crypto-class-2.2`. This PR adds revisions with upper bounds for all older versions of those packages