### PR TITLE
Bump upper dependency bounds on base and io-classes

### DIFF
--- a/_sources/typed-protocols-cborg/0.3.0.0/meta.toml
+++ b/_sources/typed-protocols-cborg/0.3.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-09-26T15:16:07Z
 github = { repo = "input-output-hk/typed-protocols", rev = "d127d3ebd1850b7d1aa6eb75c0b040b1f94d0e24" }
 subdir = 'typed-protocols-cborg'
+
+[[revisions]]
+number = 1
+timestamp = 2025-01-30T23:36:17Z

--- a/_sources/typed-protocols-cborg/0.3.0.0/revisions/1.cabal
+++ b/_sources/typed-protocols-cborg/0.3.0.0/revisions/1.cabal
@@ -1,0 +1,38 @@
+cabal-version:       3.4
+name:                typed-protocols-cborg
+version:             0.3.0.0
+synopsis:            CBOR codecs for typed-protocols
+-- description:
+license:             Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+copyright:           2019-2023 Input Output Global Inc (IOG)
+author:              Alexander Vieth, Duncan Coutts, Marcin Szamotulski
+maintainer:          alex@well-typed.com, duncan@well-typed.com, marcin.szamotulski@iohk.io
+category:            Control
+build-type:          Simple
+tested-with:         GHC == {8.10, 9.2, 9.4, 9.6}
+extra-source-files:  CHANGELOG.md, README.md
+
+library
+  exposed-modules:   Network.TypedProtocol.Codec.CBOR
+
+  build-depends:     base             >=4.12  && <4.22,
+                     bytestring       >=0.10  && <0.13,
+                     cborg            >=0.2.1 && <0.3,
+                     singletons,        
+
+                     io-classes      >=1.5    && <1.8,
+                     typed-protocols ^>=0.3
+
+  hs-source-dirs:    src
+  default-language:  Haskell2010
+  ghc-options:       -Wall
+                     -Wno-unticked-promoted-constructors
+                     -Wcompat
+                     -Wincomplete-uni-patterns
+                     -Wincomplete-record-updates
+                     -Wpartial-fields
+                     -Widentities
+                     -Wredundant-constraints

--- a/_sources/typed-protocols-stateful-cborg/0.3.0.0/meta.toml
+++ b/_sources/typed-protocols-stateful-cborg/0.3.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-09-26T15:16:07Z
 github = { repo = "input-output-hk/typed-protocols", rev = "d127d3ebd1850b7d1aa6eb75c0b040b1f94d0e24" }
 subdir = 'typed-protocols-stateful-cborg'
+
+[[revisions]]
+number = 1
+timestamp = 2025-01-30T23:36:06Z

--- a/_sources/typed-protocols-stateful-cborg/0.3.0.0/revisions/1.cabal
+++ b/_sources/typed-protocols-stateful-cborg/0.3.0.0/revisions/1.cabal
@@ -1,0 +1,42 @@
+cabal-version:       3.4
+name:                typed-protocols-stateful-cborg
+version:             0.3.0.0
+synopsis:            CBOR codecs for typed-protocols
+-- description:
+license:             Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+copyright:           2022-2024 Input Output Global Inc (IOG)
+author:              Marcin Szamotulski
+maintainer:          marcin.szamotulski@iohk.io
+category:            Control
+build-type:          Simple
+
+-- These should probably be added at some point.
+extra-source-files:  ChangeLog.md, README.md
+
+library
+  exposed-modules:   Network.TypedProtocol.Stateful.Codec.CBOR
+
+  build-depends:     base            >=4.12  && <4.22,
+                     bytestring      >=0.10  && <0.13,
+                     cborg           >=0.2.1 && <0.3,
+                     singletons,       
+
+                     io-classes,
+                     typed-protocols ^>= 0.3,
+                     typed-protocols-cborg,
+                     typed-protocols-stateful
+
+  hs-source-dirs:    src
+  default-language:  Haskell2010
+  default-extensions: ImportQualifiedPost
+  ghc-options:       -Wall
+                     -Wno-unticked-promoted-constructors
+                     -Wcompat
+                     -Wincomplete-uni-patterns
+                     -Wincomplete-record-updates
+                     -Wpartial-fields
+                     -Widentities
+                     -Wredundant-constraints

--- a/_sources/typed-protocols/0.3.0.0/meta.toml
+++ b/_sources/typed-protocols/0.3.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-09-26T15:16:07Z
 github = { repo = "input-output-hk/typed-protocols", rev = "d127d3ebd1850b7d1aa6eb75c0b040b1f94d0e24" }
 subdir = 'typed-protocols'
+
+[[revisions]]
+number = 1
+timestamp = 2025-01-30T23:35:23Z

--- a/_sources/typed-protocols/0.3.0.0/revisions/1.cabal
+++ b/_sources/typed-protocols/0.3.0.0/revisions/1.cabal
@@ -1,0 +1,50 @@
+cabal-version:       3.4
+name:                typed-protocols
+version:             0.3.0.0
+synopsis:            A framework for strongly typed protocols
+-- description:
+license:             Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+copyright:           2019-2023 Input Output Global Inc (IOG)
+author:              Alexander Vieth, Duncan Coutts, Marcin Szamotulski
+maintainer:          alex@well-typed.com, duncan@well-typed.com, marcin.szamotulski@iohk.io
+category:            Control
+build-type:          Simple
+tested-with:         GHC == {8.10, 9.2, 9.4, 9.6}
+extra-source-files:  CHANGELOG.md
+
+library
+  exposed-modules:   Network.TypedProtocol
+                   , Network.TypedProtocol.Core
+                   , Network.TypedProtocol.Peer
+                   , Network.TypedProtocol.Peer.Client
+                   , Network.TypedProtocol.Peer.Server
+                   , Network.TypedProtocol.Codec
+                   , Network.TypedProtocol.Driver
+                   , Network.TypedProtocol.Proofs
+  other-modules:     Network.TypedProtocol.Lemmas
+
+  other-extensions:  GADTs
+                   , RankNTypes
+                   , PolyKinds
+                   , DataKinds
+                   , ScopedTypeVariables
+                   , TypeFamilies
+                   , TypeOperators
+                   , BangPatterns
+  build-depends:     base,
+                     io-classes >= 1.0 && < 1.8,
+                     singletons >= 3.0
+
+  hs-source-dirs:    src
+  default-language:  Haskell2010
+  ghc-options:       -Wall
+                     -Wno-unticked-promoted-constructors
+                     -Wcompat
+                     -Wincomplete-uni-patterns
+                     -Wincomplete-record-updates
+                     -Wpartial-fields
+                     -Widentities
+                     -Wredundant-constraints

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1737030073,
-        "narHash": "sha256-Mdf9GfcJG2ehJM4yFkZKjTnOWCbutjAe7s+Z27fusA8=",
+        "lastModified": 1738202224,
+        "narHash": "sha256-JGMCfnJjBYafFhbGBW1PBYABaIJfBLkXk4zCrk4EfFc=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "1013daa305ed2a6e5f50edf8141d4edce94c06bc",
+        "rev": "557c7d252376fda1d22d45fd6e5a8a1b78a66585",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Tested by successfully compiling `ouroboros-network` with:
```
if impl (ghc >= 9.12)
  allow-newer:
    , typed-protocols:io-classes
    , typed-protocols-cborg:base
    , typed-protocols-cborg:io-classes
    , typed-protocols-stateful-cborg:base
    , typed-protocols-stateful-cborg:base
    , typed-protocols-stateful-cborg:base
```
