### PR TITLE
Revise `cardano-api-8.33.0.0`

### DIFF
--- a/_sources/cardano-api/8.33.0.0/meta.toml
+++ b/_sources/cardano-api/8.33.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-11-17T15:33:21Z
 github = { repo = "input-output-hk/cardano-api", rev = "6767351e07a9d4ed331b8837482c88953e9f8a1b" }
 subdir = 'cardano-api'
+
+[[revisions]]
+number = 1
+timestamp = 2025-02-11T11:37:49Z

--- a/_sources/cardano-api/8.33.0.0/revisions/1.cabal
+++ b/_sources/cardano-api/8.33.0.0/revisions/1.cabal
@@ -1,0 +1,376 @@
+cabal-version: 3.4
+
+name:                   cardano-api
+version:                8.33.0.0
+synopsis:               The cardano api
+description:            The cardano api.
+category:               Cardano,
+                        API,
+copyright:              2020-2023 Input Output Global Inc (IOG).
+author:                 IOHK
+maintainer:             operations@iohk.io
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+build-type:             Simple
+extra-doc-files:        README.md, CHANGELOG.md
+
+common project-config
+  default-language:     Haskell2010
+  default-extensions:   OverloadedStrings
+  build-depends:        base >= 4.14 && < 4.19
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wno-unticked-promoted-constructors
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+
+  if impl(ghc < 9)
+    ghc-options:        -Wno-incomplete-patterns
+
+common maybe-unix
+  if !os(windows)
+     build-depends:    unix
+
+common maybe-Win32
+  if os(windows)
+    build-depends:      Win32
+
+library internal
+  import:               project-config, maybe-unix, maybe-Win32
+
+  visibility:           public
+
+  hs-source-dirs:       internal
+
+  -- Do not expose any additional modules. The correct way
+  -- to expose new functionality is via Cardano.Api or
+  -- Cardano.Api.Shelley
+  exposed-modules:      Cardano.Api.Address
+                        Cardano.Api.Anchor
+                        Cardano.Api.Block
+                        Cardano.Api.Certificate
+                        Cardano.Api.Convenience.Construction
+                        Cardano.Api.Convenience.Query
+                        Cardano.Api.DeserialiseAnyOf
+                        Cardano.Api.DRepMetadata
+                        Cardano.Api.Eon.AllegraEraOnwards
+                        Cardano.Api.Eon.AlonzoEraOnwards
+                        Cardano.Api.Eon.BabbageEraOnwards
+                        Cardano.Api.Eon.ByronEraOnly
+                        Cardano.Api.Eon.ByronToAlonzoEra
+                        Cardano.Api.Eon.ConwayEraOnwards
+                        Cardano.Api.Eon.MaryEraOnwards
+                        Cardano.Api.Eon.ShelleyBasedEra
+                        Cardano.Api.Eon.ShelleyEraOnly
+                        Cardano.Api.Eon.ShelleyToAllegraEra
+                        Cardano.Api.Eon.ShelleyToAlonzoEra
+                        Cardano.Api.Eon.ShelleyToBabbageEra
+                        Cardano.Api.Eon.ShelleyToMaryEra
+                        Cardano.Api.Eras
+                        Cardano.Api.Eras.Case
+                        Cardano.Api.Eras.Core
+                        Cardano.Api.Error
+                        Cardano.Api.Feature
+                        Cardano.Api.Fees
+                        Cardano.Api.Genesis
+                        Cardano.Api.GenesisParameters
+                        Cardano.Api.Governance.Actions.ProposalProcedure
+                        Cardano.Api.Governance.Actions.VotingProcedure
+                        Cardano.Api.Governance.Poll
+                        Cardano.Api.Hash
+                        Cardano.Api.HasTypeProxy
+                        Cardano.Api.InMode
+                        Cardano.Api.IO
+                        Cardano.Api.IO.Base
+                        Cardano.Api.IO.Compat
+                        Cardano.Api.IO.Compat.Posix
+                        Cardano.Api.IO.Compat.Win32
+                        Cardano.Api.IPC
+                        Cardano.Api.IPC.Monad
+                        Cardano.Api.IPC.Version
+                        Cardano.Api.Json
+                        Cardano.Api.Keys.Byron
+                        Cardano.Api.Keys.Class
+                        Cardano.Api.Keys.Praos
+                        Cardano.Api.Keys.Read
+                        Cardano.Api.Keys.Shelley
+                        Cardano.Api.Ledger.Lens
+                        Cardano.Api.LedgerEvent
+                        Cardano.Api.LedgerState
+                        Cardano.Api.Modes
+                        Cardano.Api.NetworkId
+                        Cardano.Api.OperationalCertificate
+                        Cardano.Api.Pretty
+                        Cardano.Api.Protocol
+                        Cardano.Api.ProtocolParameters
+                        Cardano.Api.Query
+                        Cardano.Api.Query.Expr
+                        Cardano.Api.Query.Types
+                        Cardano.Api.ReexposeLedger
+                        Cardano.Api.Rewards
+                        Cardano.Api.Script
+                        Cardano.Api.ScriptData
+                        Cardano.Api.SerialiseBech32
+                        Cardano.Api.SerialiseCBOR
+                        Cardano.Api.SerialiseJSON
+                        Cardano.Api.SerialiseLedgerCddl
+                        Cardano.Api.SerialiseRaw
+                        Cardano.Api.SerialiseTextEnvelope
+                        Cardano.Api.SerialiseUsing
+                        Cardano.Api.SpecialByron
+                        Cardano.Api.StakePoolMetadata
+                        Cardano.Api.Tx
+                        Cardano.Api.TxBody
+                        Cardano.Api.TxIn
+                        Cardano.Api.TxMetadata
+                        Cardano.Api.Utils
+                        Cardano.Api.Value
+                        Cardano.Api.ValueParser
+                        -- TODO: Eliminate in the future when
+                        -- we create wrapper types for the ledger types
+                        -- in this module
+                        Cardano.Api.Orphans
+
+  build-depends:        aeson             >= 1.5.6.0
+                      , aeson-pretty      >= 0.8.5
+                      , attoparsec
+                      , base16-bytestring >= 1.0
+                      , base58-bytestring
+                      , bech32 >= 1.1.0
+                      , bytestring
+                      , cardano-binary
+                      , cardano-crypto
+                      , cardano-crypto-class ^>= 2.1.2
+                      , cardano-crypto-wrapper ^>= 1.5
+                      , cardano-data >= 1.0
+                      , cardano-ledger-alonzo >= 1.5.0
+                      , cardano-ledger-allegra >= 1.2.3.1
+                      , cardano-ledger-api ^>= 1.7
+                      , cardano-ledger-babbage >= 1.5.0
+                      , cardano-ledger-binary
+                      , cardano-ledger-byron >= 1.0.0.2
+                      , cardano-ledger-conway >= 1.10.0
+                      , cardano-ledger-core >= 1.8.0
+                      , cardano-ledger-mary >= 1.3.0.2
+                      , cardano-ledger-shelley >= 1.7.0
+                      , cardano-protocol-tpraos >= 1.0.3.6
+                      , cardano-slotting >= 0.1
+                      , cardano-strict-containers >= 0.1
+                      , cborg
+                      , containers
+                      , contra-tracer
+                      , deepseq
+                      , directory
+                      , either
+                      , errors
+                      , filepath
+                      , formatting
+                      , groups
+                      , iproute
+                      , memory
+                      , microlens
+                      , mtl
+                      , network
+                      , optparse-applicative-fork
+                      , ouroboros-consensus ^>= 0.12
+                      , ouroboros-consensus-cardano ^>= 0.13
+                      , ouroboros-consensus-diffusion ^>= 0.9
+                      , ouroboros-consensus-protocol ^>= 0.6
+                      , ouroboros-network
+                      , ouroboros-network-api
+                      , ouroboros-network-framework
+                      , ouroboros-network-protocols
+                      , parsec
+                      , plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib} ^>= 1.15
+                      , prettyprinter
+                      , prettyprinter-ansi-terminal
+                      , prettyprinter-configurable ^>= 1.15
+                      , random
+                      , scientific
+                      , serialise
+                      , small-steps ^>= 1.0
+                      , sop-core
+                      , stm
+                      , strict-sop-core
+                      , text >= 2.0
+                      , time
+                      , transformers
+                      , transformers-except ^>= 0.1.3
+                      , typed-protocols ^>= 0.1.1
+                      , unordered-containers >= 0.2.11
+                      , vector
+                      , yaml
+
+library
+  import:               project-config
+
+  hs-source-dirs:       src
+
+  -- Do not expose any additional modules. The correct way
+  -- to expose new functionality is via Cardano.Api or
+  -- Cardano.Api.Shelley
+  exposed-modules:      Cardano.Api
+                        Cardano.Api.Byron
+                        Cardano.Api.ChainSync.Client
+                        Cardano.Api.ChainSync.ClientPipelined
+                        Cardano.Api.Crypto.Ed25519Bip32
+                        Cardano.Api.Shelley
+                        -- TODO: Eliminate Cardano.Api.Ledger when
+                        -- cardano-api only depends on modules
+                        -- exposed by cardano-api-ledger
+                        Cardano.Api.Ledger
+
+  reexported-modules:   Cardano.Api.Ledger.Lens
+                      , Cardano.Api.Pretty
+
+  build-depends:        bytestring
+                      , cardano-api:internal
+                      , cardano-binary
+                      , cardano-crypto
+                      , cardano-crypto-class ^>= 2.1.2
+                      , cryptonite
+                      , deepseq
+                      , memory
+                      , nothunks
+                      , ouroboros-network-protocols
+                      , typed-protocols ^>= 0.1.1
+
+library gen
+  import:               project-config
+
+  visibility:           public
+
+  hs-source-dirs:       gen
+
+  exposed-modules:      Test.Gen.Cardano.Api
+                        Test.Gen.Cardano.Api.Byron
+                        Test.Gen.Cardano.Api.Era
+                        Test.Gen.Cardano.Api.Metadata
+                        Test.Gen.Cardano.Api.Typed
+                        Test.Gen.Cardano.Api.ProtocolParameters
+                        Test.Gen.Cardano.Crypto.Seed
+                        Test.Hedgehog.Golden.ErrorMessage
+                        Test.Hedgehog.Roundtrip.Bech32
+                        Test.Hedgehog.Roundtrip.CBOR
+
+  build-depends:        aeson             >= 1.5.6.0
+                      , base16-bytestring
+                      , bytestring
+                      , cardano-api
+                      , cardano-api:internal
+                      , cardano-binary >= 1.6 && < 1.8
+                      , cardano-crypto-class ^>= 2.1.2
+                      , cardano-crypto-test ^>= 1.5
+                      , cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib} >= 1.5.0
+                      , cardano-ledger-byron-test >= 1.5
+                      , cardano-ledger-core:{cardano-ledger-core, testlib} >= 1.8.0
+                      , cardano-ledger-shelley >= 1.7.0
+                      , cardano-ledger-conway:testlib >= 1.10.0
+                      , containers
+                      , filepath
+                      , hedgehog >= 1.1
+                      , hedgehog-extras
+                      , hedgehog-quickcheck
+                      , QuickCheck
+                      , tasty
+                      , tasty-hedgehog
+                      , text
+
+test-suite cardano-api-test
+  import:               project-config
+  hs-source-dirs:       test/cardano-api-test
+  main-is:              cardano-api-test.hs
+  type:                 exitcode-stdio-1.0
+
+  build-depends:        aeson             >= 1.5.6.0
+                      , bytestring
+                      , cardano-api
+                      , cardano-api:gen
+                      , cardano-api:internal
+                      , cardano-crypto
+                      , cardano-crypto-class ^>= 2.1.2
+                      , cardano-crypto-test ^>= 1.5
+                      , cardano-crypto-tests ^>= 2.1
+                      , cardano-ledger-api ^>= 1.7
+                      , cardano-ledger-core:{cardano-ledger-core, testlib} >= 1.8
+                      , containers
+                      , directory
+                      , hedgehog >= 1.1
+                      , hedgehog-extras
+                      , hedgehog-quickcheck
+                      , mtl
+                      , QuickCheck
+                      , tasty
+                      , tasty-hedgehog
+                      , tasty-quickcheck
+
+  other-modules:        Test.Cardano.Api.Crypto
+                        Test.Cardano.Api.Eras
+                        Test.Cardano.Api.IO
+                        Test.Cardano.Api.Json
+                        Test.Cardano.Api.KeysByron
+                        Test.Cardano.Api.Ledger
+                        Test.Cardano.Api.Metadata
+                        Test.Cardano.Api.Typed.Address
+                        Test.Cardano.Api.Typed.Bech32
+                        Test.Cardano.Api.Typed.CBOR
+                        Test.Cardano.Api.Typed.Envelope
+                        Test.Cardano.Api.Typed.JSON
+                        Test.Cardano.Api.Typed.Ord
+                        Test.Cardano.Api.Typed.Orphans
+                        Test.Cardano.Api.Typed.RawBytes
+                        Test.Cardano.Api.Typed.TxBody
+                        Test.Cardano.Api.Typed.Value
+
+  ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
+
+test-suite cardano-api-golden
+  import:               project-config
+
+  hs-source-dirs:       test/cardano-api-golden
+  main-is:              cardano-api-golden.hs
+  type:                 exitcode-stdio-1.0
+
+  build-depends:        aeson
+                      , bech32 >= 1.1.0
+                      , bytestring
+                      , cardano-api
+                      , cardano-api:gen
+                      , cardano-binary
+                      , cardano-crypto-class ^>= 2.1.2
+                      , cardano-data >= 1.0
+                      , cardano-ledger-alonzo
+                      , cardano-ledger-api ^>= 1.7
+                      , cardano-ledger-core:{cardano-ledger-core, testlib} >= 1.8
+                      , cardano-ledger-shelley
+                      , cardano-ledger-shelley-test >= 1.2.0.1
+                      , cardano-slotting ^>= 0.1
+                      , containers
+                      , errors
+                      , filepath
+                      , hedgehog >= 1.1
+                      , hedgehog-extras ^>= 0.4.7.0
+                      , microlens
+                      , parsec
+                      , plutus-core ^>= 1.15
+                      , plutus-ledger-api ^>= 1.15
+                      , tasty
+                      , tasty-hedgehog
+                      , time
+                      , text
+
+  ghc-options:          -threaded -rtsopts -with-rtsopts=-N -with-rtsopts=-T
+
+  build-tool-depends:   tasty-discover:tasty-discover
+
+  other-modules:        Test.Golden.Cardano.Api.Genesis
+                      , Test.Golden.Cardano.Api.Ledger
+                      , Test.Golden.Cardano.Api.Typed.Script
+                      , Test.Golden.Cardano.Api.Value
+                      , Test.Golden.ErrorsSpec
+


### PR DESCRIPTION
This pull request fixes an issue with the `cardano-api-8.33.0.0` package where the version constraints on `ouroboros-consensus` and `ouroboros-consensus-cardano` have been flipped accidentally.