### PR TITLE
Update hackage-nix flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -201,11 +201,11 @@
     "hackage-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1737419274,
-        "narHash": "sha256-f8iGwOQ+4WLF+O2FopjhImtLJOH7nuC66Mqe/6SZiqU=",
+        "lastModified": 1742257475,
+        "narHash": "sha256-6P9Ky9YK9e3RO/fkzY4cAuVfRkdwiLKe5G5u64gOLYQ=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "abf7fd7615e82e6377c3c9b46f66ffca83d7ce29",
+        "rev": "010ce4ab9b6cc545811d7bbabe2a94ec3f9bad40",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -198,6 +198,23 @@
         "type": "github"
       }
     },
+    "hackage-for-stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1742257465,
+        "narHash": "sha256-+TFf3A0YGCp84ySQtOyf7NnFUhygbYDg+xrZDw/OQ8g=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "d64feaae2cc7d84e3886fdb0901986606f9aa2a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
     "hackage-nix": {
       "flake": false,
       "locked": {
@@ -226,6 +243,8 @@
         "hackage": [
           "hackage-nix"
         ],
+        "hackage-for-stackage": "hackage-for-stackage",
+        "hls": "hls",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
         "hls-2.2": "hls-2.2",
@@ -237,35 +256,46 @@
         "hls-2.8": "hls-2.8",
         "hls-2.9": "hls-2.9",
         "hpc-coveralls": "hpc-coveralls",
-        "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
         "nixpkgs": [
           "haskell-nix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-2003": "nixpkgs-2003",
-        "nixpkgs-2105": "nixpkgs-2105",
-        "nixpkgs-2111": "nixpkgs-2111",
-        "nixpkgs-2205": "nixpkgs-2205",
-        "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
         "nixpkgs-2311": "nixpkgs-2311",
         "nixpkgs-2405": "nixpkgs-2405",
+        "nixpkgs-2411": "nixpkgs-2411",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1733956415,
-        "narHash": "sha256-QECLKb+pGFqfZBujt8XwZ/DgwVhw0WRwXBhoKR5LbN4=",
+        "lastModified": 1742259110,
+        "narHash": "sha256-HywkFnFtiujE9HfU2yZfjsT1+nGmsKLUJGW03kR7mow=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "6aeb986c46b6c854408d4cbf733f591190f53c5f",
+        "rev": "605a567596c1572a9b4488741a86ba16584d3052",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741604408,
+        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "682d6894c94087da5e566771f25311c47e145359",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
         "type": "github"
       }
     },
@@ -425,11 +455,11 @@
     "hls-2.9": {
       "flake": false,
       "locked": {
-        "lastModified": 1720003792,
-        "narHash": "sha256-qnDx8Pk0UxtoPr7BimEsAZh9g2WuTuMB/kGqnmdryKs=",
+        "lastModified": 1719993701,
+        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "0c1817cb2babef0765e4e72dd297c013e8e3d12b",
+        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
         "type": "github"
       },
       "original": {
@@ -453,29 +483,6 @@
         "owner": "sevanspowell",
         "repo": "hpc-coveralls",
         "type": "github"
-      }
-    },
-    "hydra": {
-      "inputs": {
-        "nix": "nix",
-        "nixpkgs": [
-          "haskell-nix",
-          "hydra",
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1671755331,
-        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
-        "owner": "NixOS",
-        "repo": "hydra",
-        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
-        "type": "github"
-      },
-      "original": {
-        "id": "hydra",
-        "type": "indirect"
       }
     },
     "iohk-nix": {
@@ -504,150 +511,17 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1717479972,
-        "narHash": "sha256-7vE3RQycHI1YT9LHJ1/fUaeln2vIpYm6Mmn8FTpYeVo=",
+        "lastModified": 1742121966,
+        "narHash": "sha256-x4bg4OoKAPnayom0nWc0BmlxgRMMHk6lEPvbiyFBq1s=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "2ed34002247213fc435d0062350b91bab920626e",
+        "rev": "e9dc86ed6ad71f0368c16672081c8f26406c3a7e",
         "type": "github"
       },
       "original": {
         "owner": "stable-haskell",
         "ref": "iserv-syms",
         "repo": "iserv-proxy",
-        "type": "github"
-      }
-    },
-    "lowdown-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "type": "github"
-      }
-    },
-    "nix": {
-      "inputs": {
-        "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-regression": "nixpkgs-regression"
-      },
-      "locked": {
-        "lastModified": 1661606874,
-        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "2.11.0",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.05-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2003": {
-      "locked": {
-        "lastModified": 1620055814,
-        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-20.03-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2105": {
-      "locked": {
-        "lastModified": 1659914493,
-        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2111": {
-      "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2205": {
-      "locked": {
-        "lastModified": 1685573264,
-        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2211": {
-      "locked": {
-        "lastModified": 1688392541,
-        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.11-darwin",
-        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -685,11 +559,11 @@
     },
     "nixpkgs-2405": {
       "locked": {
-        "lastModified": 1729242558,
-        "narHash": "sha256-VgcLDu4igNT0eYua6OAl9pWCI0cYXhDbR+pWP44tte0=",
+        "lastModified": 1735564410,
+        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4a3f2d3195b60d07530574988df92e049372c10e",
+        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
         "type": "github"
       },
       "original": {
@@ -699,29 +573,29 @@
         "type": "github"
       }
     },
-    "nixpkgs-regression": {
+    "nixpkgs-2411": {
       "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "lastModified": 1739151041,
+        "narHash": "sha256-uNszcul7y++oBiyYXjHEDw/AHeLNp8B6pyWOB+RLA/4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "rev": "94792ab2a6beaec81424445bf917ca2556fbeade",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
         "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1729980323,
-        "narHash": "sha256-eWPRZAlhf446bKSmzw6x7RWEE4IuZgAp8NW3eXZwRAY=",
+        "lastModified": 1737110817,
+        "narHash": "sha256-DSenga8XjPaUV5KUFW/i3rNkN7jm9XmguW+qQ1ZJTR4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "86e78d3d2084ff87688da662cf78c2af085d8e73",
+        "rev": "041c867bad68dfe34b78b2813028a2e2ea70a23c",
         "type": "github"
       },
       "original": {
@@ -799,11 +673,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1733789551,
-        "narHash": "sha256-0tSxhYw3RqNEHYFYIwJZ99mFDpGr8Dekf+p2ZCEygYY=",
+        "lastModified": 1742256713,
+        "narHash": "sha256-uOcYxLNixdsZivcz9hhOlVWO7nogwIFsWJxlRvDSgyk=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "db7b3e7ae59867ce0ba21df45f57ea38f57710ab",
+        "rev": "27c2471ebf3c5b77ee2f817a51a31c4ee5ef9a82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
```
• Updated input 'hackage-nix':
    'github:input-output-hk/hackage.nix/abf7fd7615e82e6377c3c9b46f66ffca83d7ce29?narHash=sha256-f8iGwOQ%2B4WLF%2BO2FopjhImtLJOH7nuC66Mqe/6SZiqU%3D' (2025-01-21)
  → 'github:input-output-hk/hackage.nix/010ce4ab9b6cc545811d7bbabe2a94ec3f9bad40?narHash=sha256-6P9Ky9YK9e3RO/fkzY4cAuVfRkdwiLKe5G5u64gOLYQ%3D' (2025-03-18)
• Updated input 'haskell-nix':
    'github:input-output-hk/haskell.nix/6aeb986c46b6c854408d4cbf733f591190f53c5f?narHash=sha256-QECLKb%2BpGFqfZBujt8XwZ/DgwVhw0WRwXBhoKR5LbN4%3D' (2024-12-11)
  → 'github:input-output-hk/haskell.nix/605a567596c1572a9b4488741a86ba16584d3052?narHash=sha256-HywkFnFtiujE9HfU2yZfjsT1%2BnGmsKLUJGW03kR7mow%3D' (2025-03-18)
• Added input 'haskell-nix/hackage-for-stackage':
    'github:input-output-hk/hackage.nix/d64feaae2cc7d84e3886fdb0901986606f9aa2a2?narHash=sha256-%2BTFf3A0YGCp84ySQtOyf7NnFUhygbYDg%2BxrZDw/OQ8g%3D' (2025-03-18)
• Added input 'haskell-nix/hls':
    'github:haskell/haskell-language-server/682d6894c94087da5e566771f25311c47e145359?narHash=sha256-tuq3%2BIp70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc%3D' (2025-03-10)
• Updated input 'haskell-nix/hls-2.9':
    'github:haskell/haskell-language-server/0c1817cb2babef0765e4e72dd297c013e8e3d12b?narHash=sha256-qnDx8Pk0UxtoPr7BimEsAZh9g2WuTuMB/kGqnmdryKs%3D' (2024-07-03)
  → 'github:haskell/haskell-language-server/90319a7e62ab93ab65a95f8f2bcf537e34dae76a?narHash=sha256-wy348%2B%2BMiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA%3D' (2024-07-03)
• Removed input 'haskell-nix/hydra'
• Removed input 'haskell-nix/hydra/nix'
• Removed input 'haskell-nix/hydra/nix/lowdown-src'
• Removed input 'haskell-nix/hydra/nix/nixpkgs'
• Removed input 'haskell-nix/hydra/nix/nixpkgs-regression'
• Removed input 'haskell-nix/hydra/nixpkgs'
• Updated input 'haskell-nix/iserv-proxy':
    'github:stable-haskell/iserv-proxy/2ed34002247213fc435d0062350b91bab920626e?narHash=sha256-7vE3RQycHI1YT9LHJ1/fUaeln2vIpYm6Mmn8FTpYeVo%3D' (2024-06-04)
  → 'github:stable-haskell/iserv-proxy/e9dc86ed6ad71f0368c16672081c8f26406c3a7e?narHash=sha256-x4bg4OoKAPnayom0nWc0BmlxgRMMHk6lEPvbiyFBq1s%3D' (2025-03-16)
• Removed input 'haskell-nix/nixpkgs-2003'
• Removed input 'haskell-nix/nixpkgs-2105'
• Removed input 'haskell-nix/nixpkgs-2111'
• Removed input 'haskell-nix/nixpkgs-2205'
• Removed input 'haskell-nix/nixpkgs-2211'
• Updated input 'haskell-nix/nixpkgs-2405':
    'github:NixOS/nixpkgs/4a3f2d3195b60d07530574988df92e049372c10e?narHash=sha256-VgcLDu4igNT0eYua6OAl9pWCI0cYXhDbR%2BpWP44tte0%3D' (2024-10-18)
  → 'github:NixOS/nixpkgs/1e7a8f391f1a490460760065fa0630b5520f9cf8?narHash=sha256-HB/FA0%2B1gpSs8%2B/boEavrGJH%2BEq08/R2wWNph1sM1Dg%3D' (2024-12-30)
• Added input 'haskell-nix/nixpkgs-2411':
    'github:NixOS/nixpkgs/94792ab2a6beaec81424445bf917ca2556fbeade?narHash=sha256-uNszcul7y%2B%2BoBiyYXjHEDw/AHeLNp8B6pyWOB%2BRLA/4%3D' (2025-02-10)
• Updated input 'haskell-nix/nixpkgs-unstable':
    'github:NixOS/nixpkgs/86e78d3d2084ff87688da662cf78c2af085d8e73?narHash=sha256-eWPRZAlhf446bKSmzw6x7RWEE4IuZgAp8NW3eXZwRAY%3D' (2024-10-26)
  → 'github:NixOS/nixpkgs/041c867bad68dfe34b78b2813028a2e2ea70a23c?narHash=sha256-DSenga8XjPaUV5KUFW/i3rNkN7jm9XmguW%2BqQ1ZJTR4%3D' (2025-01-17)
• Updated input 'haskell-nix/stackage':
    'github:input-output-hk/stackage.nix/db7b3e7ae59867ce0ba21df45f57ea38f57710ab?narHash=sha256-0tSxhYw3RqNEHYFYIwJZ99mFDpGr8Dekf%2Bp2ZCEygYY%3D' (2024-12-10)
  → 'github:input-output-hk/stackage.nix/27c2471ebf3c5b77ee2f817a51a31c4ee5ef9a82?narHash=sha256-uOcYxLNixdsZivcz9hhOlVWO7nogwIFsWJxlRvDSgyk%3D' (2025-03-18)

```