### PR TITLE
Added cardano-wallet-read-1.0.0.1

### DIFF
--- a/_sources/cardano-wallet-read/1.0.0.1/meta.toml
+++ b/_sources/cardano-wallet-read/1.0.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-03-20T13:25:36Z
+github = { repo = "cardano-foundation/cardano-wallet-agda", rev = "cfcf563f3455d104bda373c4416518d4fb342e95" }
+subdir = 'lib/cardano-wallet-read'

--- a/_sources/plutus-core/1.40.0.0/meta.toml
+++ b/_sources/plutus-core/1.40.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2025-01-29T08:56:13Z
 github = { repo = "IntersectMBO/plutus", rev = "9377feefe25d145280b1571ba1d796b4269cc19f" }
 subdir = 'plutus-core'
+
+[[revisions]]
+number = 1
+timestamp = 2025-03-20T12:42:38Z

--- a/_sources/plutus-core/1.40.0.0/revisions/1.cabal
+++ b/_sources/plutus-core/1.40.0.0/revisions/1.cabal
@@ -1,0 +1,1107 @@
+cabal-version:   3.0
+name:            plutus-core
+version:         1.40.0.0
+license:         Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+maintainer:      michael.peyton-jones@iohk.io
+author:          Plutus Core Team
+synopsis:        Language library for Plutus Core
+description:     Pretty-printer, parser, and typechecker for Plutus Core.
+category:        Language, Plutus
+build-type:      Simple
+extra-doc-files:
+  CHANGELOG.md
+  README.md
+
+data-files:
+  cost-model/data/*.R
+  cost-model/data/builtinCostModelA.json
+  cost-model/data/builtinCostModelB.json
+  cost-model/data/builtinCostModelC.json
+  cost-model/data/cekMachineCostsA.json
+  cost-model/data/cekMachineCostsB.json
+  cost-model/data/cekMachineCostsC.json
+  plutus-core/test/CostModelInterface/defaultCostModelParams.json
+
+source-repository head
+  type:     git
+  location: https://github.com/IntersectMBO/plutus
+
+-- inline-r is a problematic dependency. It doesn't build with newer
+-- versions of R, so if we depend on it then people need to install
+-- an old R. This is not so bad for people working on plutus itself
+-- (use Nix or work it out), although we may want to eventually
+-- purge it. However, due to a cabal bug (https://github.com/haskell/cabal/issues/4087),
+-- in some cases cabal will require R to be installed _at solving time_,
+-- even though it never wants to build it. This means that the problem
+-- leaks into our downstream dependencies. So our solution is to guard
+-- the dependency behind a flag, off by default, and turn it on for
+-- ourselves locally.
+flag with-inline-r
+  description: Enable build of packages that use `inline-r`.
+  manual:      True
+  default:     False
+
+flag with-cert
+  description: Enable build of packages that use `plutus-cert`.
+  manual:      True
+  default:     False
+
+common lang
+  default-language:   Haskell2010
+  default-extensions:
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveLift
+    DeriveTraversable
+    DerivingStrategies
+    DerivingVia
+    ExplicitForAll
+    FlexibleContexts
+    GeneralizedNewtypeDeriving
+    ImportQualifiedPost
+    ScopedTypeVariables
+    StandaloneDeriving
+
+  ghc-options:
+    -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wredundant-constraints -Widentities
+    -Wunused-packages -Wmissing-deriving-strategies
+
+  if impl(ghc >=9.8)
+    ghc-options: -Wno-x-partial
+
+-- This contains UPLC+TPLC, PIR must be explicitly included by depending
+-- on the public sub-library.
+-- In due course UPLC and TPLC should be split, with the main library
+-- containing UPLC.
+library
+  import:             lang
+  exposed-modules:
+    Codec.Extras.FlatViaSerialise
+    Codec.Extras.SerialiseViaFlat
+    Data.Aeson.THReader
+    Data.Either.Extras
+    Data.List.Extras
+    Data.MultiSet.Lens
+    PlutusCore
+    PlutusCore.Analysis.Definitions
+    PlutusCore.Annotation
+    PlutusCore.Arity
+    PlutusCore.Bitwise
+    PlutusCore.Builtin
+    PlutusCore.Builtin.Debug
+    PlutusCore.Builtin.Elaborate
+    PlutusCore.Check.Normal
+    PlutusCore.Check.Scoping
+    PlutusCore.Check.Uniques
+    PlutusCore.Check.Value
+    PlutusCore.Compiler
+    PlutusCore.Compiler.Erase
+    PlutusCore.Compiler.Opts
+    PlutusCore.Compiler.Types
+    PlutusCore.Core
+    PlutusCore.Core.Plated
+    PlutusCore.Crypto.BLS12_381.Error
+    PlutusCore.Crypto.BLS12_381.G1
+    PlutusCore.Crypto.BLS12_381.G2
+    PlutusCore.Crypto.BLS12_381.Pairing
+    PlutusCore.Crypto.Ed25519
+    PlutusCore.Crypto.ExpMod
+    PlutusCore.Crypto.Hash
+    PlutusCore.Crypto.Secp256k1
+    PlutusCore.Data
+    PlutusCore.DataFilePaths
+    PlutusCore.DeBruijn
+    PlutusCore.DeBruijn.Internal
+    PlutusCore.Default
+    PlutusCore.Default.Builtins
+    PlutusCore.Error
+    PlutusCore.Evaluation.Error
+    PlutusCore.Evaluation.ErrorWithCause
+    PlutusCore.Evaluation.Machine.BuiltinCostModel
+    PlutusCore.Evaluation.Machine.Ck
+    PlutusCore.Evaluation.Machine.CostingFun.Core
+    PlutusCore.Evaluation.Machine.CostingFun.JSON
+    PlutusCore.Evaluation.Machine.CostingFun.SimpleJSON
+    PlutusCore.Evaluation.Machine.CostModelInterface
+    PlutusCore.Evaluation.Machine.CostStream
+    PlutusCore.Evaluation.Machine.ExBudget
+    PlutusCore.Evaluation.Machine.ExBudgetingDefaults
+    PlutusCore.Evaluation.Machine.ExBudgetStream
+    PlutusCore.Evaluation.Machine.Exception
+    PlutusCore.Evaluation.Machine.ExMemory
+    PlutusCore.Evaluation.Machine.ExMemoryUsage
+    PlutusCore.Evaluation.Machine.MachineParameters
+    PlutusCore.Evaluation.Machine.MachineParameters.Default
+    PlutusCore.Evaluation.Machine.SimpleBuiltinCostModel
+    PlutusCore.Evaluation.Result
+    PlutusCore.Examples.Builtins
+    PlutusCore.Examples.Data.Data
+    PlutusCore.Examples.Data.Function
+    PlutusCore.Examples.Data.InterList
+    PlutusCore.Examples.Data.List
+    PlutusCore.Examples.Data.Pair
+    PlutusCore.Examples.Data.Shad
+    PlutusCore.Examples.Data.TreeForest
+    PlutusCore.Examples.Data.Vec
+    PlutusCore.Examples.Everything
+    PlutusCore.Flat
+    PlutusCore.FsTree
+    PlutusCore.Mark
+    PlutusCore.MkPlc
+    PlutusCore.Name.Unique
+    PlutusCore.Name.UniqueMap
+    PlutusCore.Name.UniqueSet
+    PlutusCore.Normalize
+    PlutusCore.Normalize.Internal
+    PlutusCore.Parser
+    PlutusCore.Pretty
+    PlutusCore.Quote
+    PlutusCore.Rename
+    PlutusCore.Rename.Internal
+    PlutusCore.Rename.Monad
+    PlutusCore.Size
+    PlutusCore.StdLib.Data.Bool
+    PlutusCore.StdLib.Data.ChurchNat
+    PlutusCore.StdLib.Data.Data
+    PlutusCore.StdLib.Data.Function
+    PlutusCore.StdLib.Data.Integer
+    PlutusCore.StdLib.Data.List
+    PlutusCore.StdLib.Data.MatchOption
+    PlutusCore.StdLib.Data.Nat
+    PlutusCore.StdLib.Data.Pair
+    PlutusCore.StdLib.Data.ScottList
+    PlutusCore.StdLib.Data.ScottUnit
+    PlutusCore.StdLib.Data.Sum
+    PlutusCore.StdLib.Data.Unit
+    PlutusCore.StdLib.Everything
+    PlutusCore.StdLib.Meta
+    PlutusCore.StdLib.Meta.Data.Function
+    PlutusCore.StdLib.Meta.Data.Tuple
+    PlutusCore.StdLib.Type
+    PlutusCore.Subst
+    PlutusCore.TypeCheck
+    PlutusCore.TypeCheck.Internal
+    PlutusCore.Version
+    PlutusPrelude
+    Prettyprinter.Custom
+    Universe
+    UntypedPlutusCore
+    UntypedPlutusCore.Check.Scope
+    UntypedPlutusCore.Check.Uniques
+    UntypedPlutusCore.Core
+    UntypedPlutusCore.Core.Instance.Scoping
+    UntypedPlutusCore.Core.Plated
+    UntypedPlutusCore.Core.Type
+    UntypedPlutusCore.Core.Zip
+    UntypedPlutusCore.DeBruijn
+    UntypedPlutusCore.Evaluation.Machine.Cek
+    UntypedPlutusCore.Evaluation.Machine.Cek.CekMachineCosts
+    UntypedPlutusCore.Evaluation.Machine.Cek.Internal
+    UntypedPlutusCore.Evaluation.Machine.Cek.StepCounter
+    UntypedPlutusCore.Evaluation.Machine.SteppableCek
+    UntypedPlutusCore.Evaluation.Machine.SteppableCek.DebugDriver
+    UntypedPlutusCore.Evaluation.Machine.SteppableCek.Internal
+    UntypedPlutusCore.Mark
+    UntypedPlutusCore.MkUPlc
+    UntypedPlutusCore.Parser
+    UntypedPlutusCore.Purity
+    UntypedPlutusCore.Rename
+    UntypedPlutusCore.Rename.Internal
+    UntypedPlutusCore.Size
+    UntypedPlutusCore.Transform.CaseOfCase
+    UntypedPlutusCore.Transform.CaseReduce
+    UntypedPlutusCore.Transform.Cse
+    UntypedPlutusCore.Transform.FloatDelay
+    UntypedPlutusCore.Transform.ForceDelay
+    UntypedPlutusCore.Transform.Inline
+    UntypedPlutusCore.Transform.Simplifier
+
+  other-modules:
+    Data.Aeson.Flatten
+    Data.Functor.Foldable.Monadic
+    PlutusCore.Builtin.HasConstant
+    PlutusCore.Builtin.KnownKind
+    PlutusCore.Builtin.KnownType
+    PlutusCore.Builtin.KnownTypeAst
+    PlutusCore.Builtin.Meaning
+    PlutusCore.Builtin.Polymorphism
+    PlutusCore.Builtin.Result
+    PlutusCore.Builtin.Runtime
+    PlutusCore.Builtin.TestKnown
+    PlutusCore.Builtin.TypeScheme
+    PlutusCore.Core.Instance
+    PlutusCore.Core.Instance.Eq
+    PlutusCore.Core.Instance.Pretty
+    PlutusCore.Core.Instance.Pretty.Classic
+    PlutusCore.Core.Instance.Pretty.Default
+    PlutusCore.Core.Instance.Pretty.Plc
+    PlutusCore.Core.Instance.Pretty.Readable
+    PlutusCore.Core.Instance.Scoping
+    PlutusCore.Core.Type
+    PlutusCore.Crypto.Utils
+    PlutusCore.Default.Universe
+    PlutusCore.Eq
+    PlutusCore.Parser.Builtin
+    PlutusCore.Parser.ParserCommon
+    PlutusCore.Parser.Type
+    PlutusCore.Pretty.Classic
+    PlutusCore.Pretty.ConfigName
+    PlutusCore.Pretty.Default
+    PlutusCore.Pretty.Extra
+    PlutusCore.Pretty.Plc
+    PlutusCore.Pretty.PrettyConst
+    PlutusCore.Pretty.Readable
+    PlutusCore.Pretty.Utils
+    Universe.Core
+    UntypedPlutusCore.Analysis.Definitions
+    UntypedPlutusCore.Analysis.Usages
+    UntypedPlutusCore.Core.Instance
+    UntypedPlutusCore.Core.Instance.Eq
+    UntypedPlutusCore.Core.Instance.Flat
+    UntypedPlutusCore.Core.Instance.Pretty
+    UntypedPlutusCore.Core.Instance.Pretty.Classic
+    UntypedPlutusCore.Core.Instance.Pretty.Default
+    UntypedPlutusCore.Core.Instance.Pretty.Plc
+    UntypedPlutusCore.Core.Instance.Pretty.Readable
+    UntypedPlutusCore.Evaluation.Machine.Cek.EmitterMode
+    UntypedPlutusCore.Evaluation.Machine.Cek.ExBudgetMode
+    UntypedPlutusCore.Evaluation.Machine.CommonAPI
+    UntypedPlutusCore.Simplify
+    UntypedPlutusCore.Simplify.Opts
+    UntypedPlutusCore.Subst
+
+  reexported-modules: Data.SatInt
+  hs-source-dirs:
+    plutus-core/src plutus-core/stdlib plutus-core/examples
+    untyped-plutus-core/src prelude
+
+  -- Notes on dependencies:
+  -- * Bound on cardano-crypto-class for the fixed SECP primitives and 9.6 support
+  -- * The bound on 'dependent-sum' is needed to avoid https://github.com/obsidiansystems/dependent-sum/issues/72
+  build-depends:
+    , aeson
+    , array
+    , barbies
+    , base                        >=4.9     && <5
+    , base64-bytestring
+    , bimap
+    , bytestring
+    , bytestring-strict-builder
+    , cardano-crypto              >=1.2
+    , cardano-crypto-class        ^>=2.1.5
+    , cassava
+    , cborg
+    , composition-prelude         >=1.1.0.1
+    , containers
+    , crypton
+    , data-default-class
+    , deepseq
+    , dependent-sum               >=0.7.1.0
+    , deriving-aeson              >=0.2.3
+    , deriving-compat
+    , dlist
+    , exceptions
+    , extra
+    , filepath
+    , flat                        ^>=0.6
+    , free
+    , ghc-prim
+    , hashable                    >=1.4
+    , hedgehog                    >=1.0
+    , index-envs
+    , lens
+    , megaparsec
+    , mmorph
+    , mono-traversable
+    , monoidal-containers
+    , mtl
+    , multiset
+    , nothunks                    ^>=0.2
+    , parser-combinators          >=0.4.0
+    , prettyprinter               >=1.1.0.1
+    , prettyprinter-configurable
+    , primitive
+    , profunctors
+    , recursion-schemes
+    , satint
+    , semigroups                  >=0.19.1
+    , serialise
+    , some
+    , template-haskell
+    , text
+    , th-compat
+    , th-lift
+    , th-lift-instances
+    , th-utilities
+    , time
+    , transformers
+    , unordered-containers
+    , vector
+    , witherable
+
+  if impl(ghc <9.0)
+    build-depends: integer-gmp
+
+test-suite plutus-core-test
+  import:           lang
+
+  -- needs linux 'diff' available
+  if os(windows)
+    buildable: False
+
+  type:             exitcode-stdio-1.0
+  main-is:          Spec.hs
+  hs-source-dirs:   plutus-core/test
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
+  other-modules:
+    CBOR.DataStability
+    Check.Spec
+    CostModelInterface.Spec
+    CostModelSafety.Spec
+    Evaluation.Machines
+    Evaluation.Spec
+    Generators.QuickCheck.Utils
+    Names.Spec
+    Normalization.Check
+    Normalization.Type
+    Parser.Spec
+    Pretty.Readable
+    TypeSynthesis.Spec
+
+  default-language: Haskell2010
+  build-depends:
+    , aeson
+    , base                             >=4.9   && <5
+    , bytestring
+    , containers
+    , data-default-class
+    , extra
+    , filepath
+    , flat                             ^>=0.6
+    , hedgehog
+    , hex-text
+    , mmorph
+    , mtl
+    , plutus-core                      ^>=1.40
+    , plutus-core:plutus-core-testlib
+    , prettyprinter
+    , serialise
+    , tasty
+    , tasty-golden
+    , tasty-hedgehog
+    , tasty-hunit
+    , tasty-quickcheck
+    , template-haskell
+    , text
+    , th-lift-instances
+    , th-utilities
+
+test-suite untyped-plutus-core-test
+  import:         lang
+
+  -- needs linux 'diff' available
+  if os(windows)
+    buildable: False
+
+  type:           exitcode-stdio-1.0
+  main-is:        Spec.hs
+  hs-source-dirs: untyped-plutus-core/test
+  ghc-options:    -O2 -threaded -rtsopts -with-rtsopts=-N
+  other-modules:
+    Analysis.Spec
+    DeBruijn.FlatNatWord
+    DeBruijn.Scope
+    DeBruijn.Spec
+    DeBruijn.UnDeBruijnify
+    Evaluation.Builtins
+    Evaluation.Builtins.Bitwise
+    Evaluation.Builtins.BLS12_381
+    Evaluation.Builtins.BLS12_381.TestClasses
+    Evaluation.Builtins.BLS12_381.Utils
+    Evaluation.Builtins.Common
+    Evaluation.Builtins.Conversion
+    Evaluation.Builtins.Costing
+    Evaluation.Builtins.Definition
+    Evaluation.Builtins.Laws
+    Evaluation.Builtins.MakeRead
+    Evaluation.Builtins.SignatureVerification
+    Evaluation.Debug
+    Evaluation.FreeVars
+    Evaluation.Golden
+    Evaluation.Helpers
+    Evaluation.Machines
+    Evaluation.Regressions
+    Flat.Spec
+    Generators
+    Scoping.Spec
+    Transform.CaseOfCase.Test
+    Transform.Simplify
+    Transform.Simplify.Lib
+
+  build-depends:
+    , base                             >=4.9   && <5
+    , base16-bytestring
+    , bytestring
+    , cardano-crypto-class
+    , dlist
+    , flat                             ^>=0.6
+    , hedgehog
+    , lens
+    , mtl
+    , plutus-core                      ^>=1.40
+    , plutus-core:plutus-core-testlib
+    , pretty-show
+    , prettyprinter
+    , QuickCheck
+    , serialise
+    , split
+    , tasty
+    , tasty-golden
+    , tasty-hedgehog
+    , tasty-hunit
+    , tasty-quickcheck
+    , text
+    , vector
+
+----------------------------------------------
+-- plutus-ir
+----------------------------------------------
+
+library plutus-ir
+  import:          lang
+  visibility:      public
+  hs-source-dirs:  plutus-ir/src
+  exposed-modules:
+    PlutusIR
+    PlutusIR.Analysis.Builtins
+    PlutusIR.Analysis.Dependencies
+    PlutusIR.Analysis.RetainedSize
+    PlutusIR.Analysis.Size
+    PlutusIR.Analysis.VarInfo
+    PlutusIR.Check.Uniques
+    PlutusIR.Compiler
+    PlutusIR.Compiler.Datatype
+    PlutusIR.Compiler.Definitions
+    PlutusIR.Compiler.Let
+    PlutusIR.Compiler.Names
+    PlutusIR.Compiler.Provenance
+    PlutusIR.Compiler.Types
+    PlutusIR.Contexts
+    PlutusIR.Core
+    PlutusIR.Core.Instance
+    PlutusIR.Core.Instance.Flat
+    PlutusIR.Core.Instance.Pretty
+    PlutusIR.Core.Instance.Pretty.Readable
+    PlutusIR.Core.Instance.Scoping
+    PlutusIR.Core.Plated
+    PlutusIR.Core.Type
+    PlutusIR.Error
+    PlutusIR.Mark
+    PlutusIR.MkPir
+    PlutusIR.Parser
+    PlutusIR.Pass
+    PlutusIR.Purity
+    PlutusIR.Subst
+    PlutusIR.Transform.Beta
+    PlutusIR.Transform.CaseOfCase
+    PlutusIR.Transform.CaseReduce
+    PlutusIR.Transform.DeadCode
+    PlutusIR.Transform.EvaluateBuiltins
+    PlutusIR.Transform.Inline.CallSiteInline
+    PlutusIR.Transform.Inline.Inline
+    PlutusIR.Transform.Inline.Utils
+    PlutusIR.Transform.KnownCon
+    PlutusIR.Transform.LetFloatIn
+    PlutusIR.Transform.LetFloatOut
+    PlutusIR.Transform.LetMerge
+    PlutusIR.Transform.NonStrict
+    PlutusIR.Transform.RecSplit
+    PlutusIR.Transform.Rename
+    PlutusIR.Transform.RewriteRules
+    PlutusIR.Transform.RewriteRules.CommuteFnWithConst
+    PlutusIR.Transform.RewriteRules.RemoveTrace
+    PlutusIR.Transform.StrictifyBindings
+    PlutusIR.Transform.Substitute
+    PlutusIR.Transform.ThunkRecursions
+    PlutusIR.Transform.Unwrap
+    PlutusIR.TypeCheck
+    PlutusIR.TypeCheck.Internal
+
+  other-modules:
+    PlutusIR.Analysis.Definitions
+    PlutusIR.Analysis.Usages
+    PlutusIR.Compiler.Error
+    PlutusIR.Compiler.Lower
+    PlutusIR.Compiler.Recursion
+    PlutusIR.Normalize
+    PlutusIR.Transform.RewriteRules.Common
+    PlutusIR.Transform.RewriteRules.Internal
+    PlutusIR.Transform.RewriteRules.UnConstrConstrData
+
+  build-depends:
+    , algebraic-graphs     >=0.7
+    , base                 >=4.9     && <5
+    , containers
+    , dlist
+    , dom-lt
+    , extra
+    , flat                 ^>=0.6
+    , hashable
+    , lens
+    , megaparsec
+    , mmorph
+    , monoidal-containers
+    , mtl
+    , multiset
+    , parser-combinators   >=0.4.0
+    , plutus-core          ^>=1.40
+    , prettyprinter        >=1.1.0.1
+    , profunctors
+    , semigroupoids
+    , semigroups           >=0.19.1
+    , text
+    , transformers
+    , witherable
+
+  if impl(ghc <9.0)
+    build-depends: integer-gmp
+
+test-suite plutus-ir-test
+  import:             lang
+
+  -- needs linux 'diff' available
+  if os(windows)
+    buildable: False
+
+  type:               exitcode-stdio-1.0
+  main-is:            Driver.hs
+  hs-source-dirs:     plutus-ir/test
+  ghc-options:        -threaded -rtsopts -with-rtsopts=-N
+  other-modules:
+    PlutusCore.Generators.QuickCheck.BuiltinsTests
+    PlutusCore.Generators.QuickCheck.SubstitutionTests
+    PlutusCore.Generators.QuickCheck.TypesTests
+    PlutusIR.Analysis.RetainedSize.Tests
+    PlutusIR.Check.Uniques.Tests
+    PlutusIR.Compiler.Datatype.Tests
+    PlutusIR.Compiler.Error.Tests
+    PlutusIR.Compiler.Let.Tests
+    PlutusIR.Compiler.Recursion.Tests
+    PlutusIR.Contexts.Tests
+    PlutusIR.Core.Tests
+    PlutusIR.Generators.QuickCheck.Tests
+    PlutusIR.Parser.Tests
+    PlutusIR.Purity.Tests
+    PlutusIR.Scoping.Tests
+    PlutusIR.Transform.Beta.Tests
+    PlutusIR.Transform.CaseOfCase.Tests
+    PlutusIR.Transform.CaseReduce.Tests
+    PlutusIR.Transform.DeadCode.Tests
+    PlutusIR.Transform.EvaluateBuiltins.Tests
+    PlutusIR.Transform.Inline.Tests
+    PlutusIR.Transform.KnownCon.Tests
+    PlutusIR.Transform.LetFloatIn.Tests
+    PlutusIR.Transform.LetFloatOut.Tests
+    PlutusIR.Transform.NonStrict.Tests
+    PlutusIR.Transform.RecSplit.Tests
+    PlutusIR.Transform.Rename.Tests
+    PlutusIR.Transform.RewriteRules.Tests
+    PlutusIR.Transform.StrictifyBindings.Tests
+    PlutusIR.Transform.StrictLetRec.Tests
+    PlutusIR.Transform.StrictLetRec.Tests.Lib
+    PlutusIR.Transform.ThunkRecursions.Tests
+    PlutusIR.Transform.Unwrap.Tests
+    PlutusIR.TypeCheck.Tests
+
+  build-tool-depends: tasty-discover:tasty-discover
+  build-depends:
+    , base                             >=4.9   && <5
+    , containers
+    , filepath
+    , flat                             ^>=0.6
+    , hashable
+    , hedgehog
+    , lens
+    , mtl
+    , plutus-core                      ^>=1.40
+    , plutus-core:plutus-core-testlib
+    , plutus-core:plutus-ir
+    , QuickCheck
+    , serialise
+    , tasty
+    , tasty-expected-failure
+    , tasty-hedgehog
+    , tasty-hunit
+    , tasty-quickcheck
+    , text
+    , unordered-containers
+
+executable plutus
+  import:             lang
+  main-is:            Main.hs
+  hs-source-dirs:     executables/plutus
+
+  -- singletons-th does not support GHC<=8.10
+  if impl(ghc <9.6)
+    buildable: False
+
+  -- Hydra complains that this is not buildable on mingw32 because of brick.
+  -- Strange, because I thought vty added support for windows.
+  if os(windows)
+    buildable: False
+
+  other-modules:
+    AnyProgram.Apply
+    AnyProgram.Bench
+    AnyProgram.Compile
+    AnyProgram.Debug
+    AnyProgram.Example
+    AnyProgram.IO
+    AnyProgram.Parse
+    AnyProgram.Run
+    AnyProgram.With
+    Common
+    Debugger.TUI.Draw
+    Debugger.TUI.Event
+    Debugger.TUI.Main
+    Debugger.TUI.Types
+    GetOpt
+    Mode.Compile
+    Mode.HelpVersion
+    Mode.ListExamples
+    Mode.PrintBuiltins
+    Mode.PrintCostModel
+    Types
+
+  build-depends:
+    , aeson-pretty
+    , base                   >=4.9   && <5
+    , brick
+    , bytestring
+    , containers
+    , exceptions
+    , filepath
+    , flat
+    , lens
+    , megaparsec
+    , microlens
+    , microlens-th           ^>=0.4
+    , mono-traversable
+    , mtl
+    , plutus-core            ^>=1.40
+    , plutus-core:plutus-ir
+    , prettyprinter
+    , primitive
+    , serialise
+    , singletons
+    , singletons-th
+    , text
+    , text-zipper
+    , vty                    ^>=6
+    , vty-crossplatform      ^>=0.2
+
+  ghc-options:        -O2 -threaded -rtsopts -with-rtsopts=-N
+  default-extensions:
+    GADTs
+    TypeApplications
+
+----------------------------------------------
+-- support libs
+----------------------------------------------
+
+library plutus-core-execlib
+  import:          lang
+  visibility:      public
+  hs-source-dirs:  executables/src
+  exposed-modules:
+    PlutusCore.Executable.AstIO
+    PlutusCore.Executable.Common
+    PlutusCore.Executable.Parsers
+    PlutusCore.Executable.Types
+
+  build-depends:
+    , aeson
+    , base                             >=4.9   && <5
+    , bytestring
+    , flat                             ^>=0.6
+    , lens
+    , megaparsec
+    , monoidal-containers
+    , mtl
+    , optparse-applicative
+    , plutus-core                      ^>=1.40
+    , plutus-core:plutus-core-testlib
+    , plutus-core:plutus-ir
+    , prettyprinter
+    , text
+
+-- could split this up if we split up the main library for UPLC/PLC/PIR
+library plutus-core-testlib
+  import:          lang
+  visibility:      public
+  hs-source-dirs:  testlib
+  exposed-modules:
+    PlutusCore.Generators.Hedgehog
+    PlutusCore.Generators.Hedgehog.AST
+    PlutusCore.Generators.Hedgehog.Builtin
+    PlutusCore.Generators.Hedgehog.Denotation
+    PlutusCore.Generators.Hedgehog.Entity
+    PlutusCore.Generators.Hedgehog.Interesting
+    PlutusCore.Generators.Hedgehog.Test
+    PlutusCore.Generators.Hedgehog.TypedBuiltinGen
+    PlutusCore.Generators.Hedgehog.TypeEvalCheck
+    PlutusCore.Generators.Hedgehog.Utils
+    PlutusCore.Generators.NEAT.Common
+    PlutusCore.Generators.NEAT.Spec
+    PlutusCore.Generators.NEAT.Term
+    PlutusCore.Generators.NEAT.Type
+    PlutusCore.Generators.QuickCheck
+    PlutusCore.Generators.QuickCheck.Builtin
+    PlutusCore.Generators.QuickCheck.Common
+    PlutusCore.Generators.QuickCheck.GenerateKinds
+    PlutusCore.Generators.QuickCheck.GenerateTypes
+    PlutusCore.Generators.QuickCheck.GenTm
+    PlutusCore.Generators.QuickCheck.ShrinkTypes
+    PlutusCore.Generators.QuickCheck.Split
+    PlutusCore.Generators.QuickCheck.Substitutions
+    PlutusCore.Generators.QuickCheck.Unification
+    PlutusCore.Generators.QuickCheck.Utils
+    PlutusCore.Test
+    PlutusIR.Generators.AST
+    PlutusIR.Generators.QuickCheck
+    PlutusIR.Generators.QuickCheck.Common
+    PlutusIR.Generators.QuickCheck.GenerateTerms
+    PlutusIR.Generators.QuickCheck.ShrinkTerms
+    PlutusIR.Pass.Test
+    PlutusIR.Test
+    Test.Tasty.Extras
+    UntypedPlutusCore.Generators.Hedgehog
+    UntypedPlutusCore.Test.DeBruijn.Bad
+    UntypedPlutusCore.Test.DeBruijn.Good
+
+  build-depends:
+    , base                        >=4.9     && <5
+    , bifunctors
+    , bytestring
+    , containers
+    , data-default-class
+    , dependent-map               >=0.4.0.0
+    , filepath
+    , free
+    , hashable
+    , hedgehog                    >=1.0
+    , hedgehog-quickcheck
+    , lazy-search
+    , lens
+    , mmorph
+    , mtl
+    , multiset
+    , plutus-core                 ^>=1.40
+    , plutus-core:plutus-ir
+    , prettyprinter               >=1.1.0.1
+    , prettyprinter-configurable
+    , QuickCheck
+    , quickcheck-instances
+    , quickcheck-transformer
+    , size-based
+    , Stream
+    , tagged
+    , tasty
+    , tasty-golden
+    , tasty-hedgehog
+    , tasty-hunit
+    , text
+
+-- This wraps up the use of the certifier library
+-- so we can present a consistent inteface whether we
+-- are building with it or not. If we aren't building
+-- with it, we present a conservative stub implementation
+-- that just always says everything is fine.
+library plutus-ir-cert
+  import:           lang
+
+  if flag(with-cert)
+    hs-source-dirs: plutus-ir/cert
+    build-depends:  plutus-cert
+
+  else
+    hs-source-dirs: plutus-ir/cert-stub
+
+  default-language: Haskell2010
+  exposed-modules:  PlutusIR.Certifier
+  build-depends:
+    , base
+    , plutus-core            ^>=1.40
+    , plutus-core:plutus-ir
+
+----------------------------------------------
+-- profiling
+----------------------------------------------
+
+executable traceToStacks
+  import:         lang
+  main-is:        Main.hs
+  hs-source-dirs: executables/traceToStacks
+  other-modules:  Common
+  build-depends:
+    , base                  >=4.9 && <5
+    , bytestring
+    , cassava
+    , optparse-applicative
+    , text
+    , vector
+
+-- Tests for functions called by @traceToStacks@.
+test-suite traceToStacks-test
+  import:           lang
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   executables/traceToStacks
+  default-language: Haskell2010
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
+  main-is:          TestGetStacks.hs
+  other-modules:    Common
+  build-depends:
+    , base         >=4.9 && <5
+    , bytestring
+    , cassava
+    , tasty
+    , tasty-hunit
+    , text
+    , vector
+
+----------------------------------------------
+-- cost-model
+----------------------------------------------
+
+-- This runs the microbenchmarks used to generate the cost models for built-in
+-- functions, saving the results in a CSV file which must be specified on the
+-- commmand line.  It will take several hours.
+executable cost-model-budgeting-bench
+  import:         lang
+  main-is:        Main.hs
+  other-modules:
+    Benchmarks.Bitwise
+    Benchmarks.Bool
+    Benchmarks.ByteStrings
+    Benchmarks.Crypto
+    Benchmarks.Data
+    Benchmarks.Integers
+    Benchmarks.Lists
+    Benchmarks.Misc
+    Benchmarks.Nops
+    Benchmarks.Pairs
+    Benchmarks.Strings
+    Benchmarks.Tracing
+    Benchmarks.Unit
+    Common
+    CriterionExtensions
+    Generators
+
+  hs-source-dirs: cost-model/budgeting-bench
+  build-depends:
+    , base                   >=4.9   && <5
+    , bytestring
+    , cardano-crypto-class
+    , criterion
+    , criterion-measurement
+    , deepseq
+    , directory
+    , filepath
+    , hedgehog
+    , mtl
+    , optparse-applicative
+    , plutus-core            ^>=1.40
+    , QuickCheck
+    , quickcheck-instances
+    , random
+    , text
+    , time
+
+-- This reads CSV data generated by cost-model-budgeting-bench, uses R to build
+-- the cost models for built-in functions, and saves them in a specified
+-- JSON file (see the help).  The 'official' cost model should be checked in
+-- in plutus-core/cost-model/data/builtinCostModel.json.
+executable generate-cost-model
+  import:         lang
+  main-is:        Main.hs
+  hs-source-dirs: cost-model/create-cost-model
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
+
+  if !flag(with-inline-r)
+    buildable: False
+
+  -- This fails on Darwin with strange errors and I don't know why
+  -- > Error: C stack usage  17556409549320 is too close to the limit
+  -- > Fatal error: unable to initialize the JI
+  if os(osx)
+    buildable: False
+
+  -- Can't build on windows as it depends on R.
+  if os(windows)
+    buildable: False
+
+  build-depends:
+    , aeson-pretty
+    , barbies
+    , base                  >=4.9   && <5
+    , bytestring
+    , directory
+    , inline-r              >=1.0.1
+    , optparse-applicative
+    , plutus-core           ^>=1.40
+    , text
+
+  --    , exceptions
+  other-modules:
+    BuiltinMemoryModels
+    CreateBuiltinCostModel
+
+-- The cost models for builtins are generated using R and converted into a JSON
+-- form that can later be used to construct Haskell functions.  This tests that
+-- the predictions of the Haskell version are (approximately) identical to the R
+-- ones. This test is problematic in CI: pretending that it's a benchmark will
+-- prevent it from being run automatically but will still allow us to run it
+-- manually; `cabal bench` also sets the working directory to the root of the
+-- relevant package, which makes it easier to find the cost model data files
+-- (unlike `cabal run` for executables, which sets the working directory to the
+-- current shell directory).
+benchmark cost-model-test
+  import:         lang
+  type:           exitcode-stdio-1.0
+  main-is:        TestCostModels.hs
+  other-modules:  TH
+  hs-source-dirs: cost-model/test cost-model/create-cost-model
+
+  if !flag(with-inline-r)
+    buildable: False
+
+  -- This fails on Darwin with strange errors and I don't know why
+  -- > Error: C stack usage  17556409549320 is too close to the limit
+  -- > Fatal error: unable to initialize the JI
+  if os(osx)
+    buildable: False
+
+  -- Can't build on windows as it depends on R.
+  if os(windows)
+    buildable: False
+
+  build-depends:
+    , barbies
+    , base              >=4.9   && <5
+    , bytestring
+    , hedgehog
+    , inline-r          >=1.0.1
+    , mmorph
+    , plutus-core       ^>=1.40
+    , template-haskell
+    , text
+
+  other-modules:
+    BuiltinMemoryModels
+    CreateBuiltinCostModel
+
+executable print-cost-model
+  import:         lang
+  main-is:        Main.hs
+  hs-source-dirs: cost-model/print-cost-model
+  other-modules:  Paths_plutus_core
+  build-depends:
+    , aeson
+    , base         >=4.9   && <5
+    , bytestring
+    , plutus-core  ^>=1.40
+
+----------------------------------------------
+-- satint
+----------------------------------------------
+
+library satint
+  import:          lang
+  exposed-modules: Data.SatInt
+  hs-source-dirs:  satint/src
+  build-depends:
+    , aeson
+    , base              >=4.9 && <5
+    , cassava
+    , deepseq
+    , nothunks
+    , primitive
+    , serialise
+    , template-haskell
+
+test-suite satint-test
+  import:           lang
+  type:             exitcode-stdio-1.0
+  main-is:          TestSatInt.hs
+  build-depends:
+    , base                        >=4.9 && <5
+    , HUnit
+    , QuickCheck
+    , satint
+    , test-framework
+    , test-framework-hunit
+    , test-framework-quickcheck2
+
+  default-language: Haskell2010
+  hs-source-dirs:   satint/test
+
+----------------------------------------------
+-- index-envs
+----------------------------------------------
+
+library index-envs
+  import:           lang
+  visibility:       public
+  hs-source-dirs:   index-envs/src
+  default-language: Haskell2010
+  exposed-modules:
+    Data.RandomAccessList.Class
+    Data.RandomAccessList.RelativizedMap
+    Data.RandomAccessList.SkewBinary
+    Data.RandomAccessList.SkewBinarySlab
+
+  build-depends:
+    , base             >=4.9  && <5
+    , containers
+    , extra
+    , nonempty-vector
+    , ral              ^>=0.2
+
+-- broken for ral-0.2 conflicts with cardano-binary:recursion-schemes
+benchmark index-envs-bench
+  import:           lang
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   index-envs/bench
+  default-language: Haskell2010
+  main-is:          Main.hs
+  build-depends:
+    , base             >=4.9     && <5
+    , criterion        >=1.5.9.0
+    , index-envs
+    , nonempty-vector
+    , ral              ^>=0.2
+    , random           >=1.2.0
+
+-- broken for ral-0.2 conflicts with cardano-binary:recursion-schemes
+test-suite index-envs-test
+  import:           lang
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   index-envs/test
+  default-language: Haskell2010
+  main-is:          Spec.hs
+  other-modules:    RAList.Spec
+  ghc-options:      -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+    , base                  >=4.9 && <5
+    , index-envs
+    , nonempty-vector
+    , QuickCheck
+    , quickcheck-instances
+    , tasty
+    , tasty-quickcheck


### PR DESCRIPTION
From https://github.com/cardano-foundation/cardano-wallet-agda at cfcf563f3455d104bda373c4416518d4fb342e95

This pull request also adds a revision for `plutus-core-1.40.0.0`, which fails to compile with older versions of `cardano-crypto`.
