### PR TITLE
Revision with ledger binary upper bound

### DIFF
--- a/_sources/cardano-ledger-byron/1.0.0.0/meta.toml
+++ b/_sources/cardano-ledger-byron/1.0.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-02-23T15:33:46Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "2f5956038233e4df0a065d96db32398605603f9b" }
 subdir = 'eras/byron/ledger/impl'
+
+[[revisions]]
+number = 1
+timestamp = 2025-03-22T21:55:03Z

--- a/_sources/cardano-ledger-byron/1.0.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-byron/1.0.0.0/revisions/1.cabal
@@ -1,0 +1,401 @@
+cabal-version:      3.0
+name:               cardano-ledger-byron
+version:            1.0.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+synopsis:           The blockchain layer of Cardano during the Byron era
+description:        The blockchain layer of Cardano during the Byron era
+category:           Currency
+build-type:         Simple
+data-files:
+    golden/cbor/block/BlockSignature
+    golden/cbor/block/Body
+    golden/cbor/block/BoundaryBlockHeader
+    golden/cbor/block/BoundaryBody
+    golden/cbor/block/BoundaryConsensusData
+    golden/cbor/block/BoundaryProof
+    golden/cbor/block/ExtraBodyData
+    golden/cbor/block/Header
+    golden/cbor/block/HeaderHash
+    golden/cbor/block/Proof
+    golden/cbor/block/StaticConfig_GCSpec
+    golden/cbor/block/ToSign
+    golden/cbor/common/Address
+    golden/cbor/common/Address0
+    golden/cbor/common/Address1
+    golden/cbor/common/Address2
+    golden/cbor/common/Address3
+    golden/cbor/common/Address4
+    golden/cbor/common/AddrSpendingData_Redeem
+    golden/cbor/common/AddrSpendingData_VerKey
+    golden/cbor/common/AddrType_R
+    golden/cbor/common/AddrType_VK
+    golden/cbor/common/Attributes
+    golden/cbor/common/BlockCount
+    golden/cbor/common/ChainDifficulty
+    golden/cbor/common/KeyHash
+    golden/cbor/common/Lovelace
+    golden/cbor/common/LovelacePortion
+    golden/cbor/common/MerkleRoot
+    golden/cbor/common/MerkleTree
+    golden/cbor/common/TxFeePolicy_Linear
+    golden/cbor/common/TxSizeLinear
+    golden/cbor/delegation/Certificate
+    golden/cbor/delegation/DlgPayload
+    golden/cbor/mempoolpayload/MempoolPayload
+    golden/cbor/mempoolpayload/MempoolPayload1
+    golden/cbor/mempoolpayload/MempoolPayload2
+    golden/cbor/mempoolpayload/MempoolPayload3
+    golden/cbor/slotting/EpochAndSlotCount
+    golden/cbor/slotting/EpochNumber
+    golden/cbor/slotting/EpochSlots
+    golden/cbor/slotting/SlotNumber
+    golden/cbor/ssc/Commitment
+    golden/cbor/ssc/CommitmentsMap
+    golden/cbor/ssc/InnerSharesMap
+    golden/cbor/ssc/Opening
+    golden/cbor/ssc/OpeningsMap
+    golden/cbor/ssc/SharesMap
+    golden/cbor/ssc/SignedCommitment
+    golden/cbor/ssc/SscPayload_CertificatesPayload
+    golden/cbor/ssc/SscPayload_CommitmentsPayload
+    golden/cbor/ssc/SscPayload_OpeningsPayload
+    golden/cbor/ssc/SscPayload_SharesPayload
+    golden/cbor/ssc/SscProof_CertificatesProof
+    golden/cbor/ssc/SscProof_CommitmentsProof
+    golden/cbor/ssc/SscProof_OpeningsProof
+    golden/cbor/ssc/SscProof_SharesProof
+    golden/cbor/ssc/VssCertificate
+    golden/cbor/ssc/VssCertificatesHash
+    golden/cbor/ssc/VssCertificatesMap
+    golden/cbor/update/ApplicationName
+    golden/cbor/update/AttackTarget_NetworkAddressTarget
+    golden/cbor/update/AttackTarget_PubKeyAddressTarget
+    golden/cbor/update/BlockHeader_Boundary
+    golden/cbor/update/CommitmentSignature
+    golden/cbor/update/HashRaw
+    golden/cbor/update/HashTx
+    golden/cbor/update/InstallerHash
+    golden/cbor/update/Payload
+    golden/cbor/update/Proof
+    golden/cbor/update/Proposal
+    golden/cbor/update/ProposalBody
+    golden/cbor/update/ProtocolParameters
+    golden/cbor/update/ProtocolParametersUpdate
+    golden/cbor/update/ProtocolVersion
+    golden/cbor/update/SharesDistribution
+    golden/cbor/update/SoftforkRule
+    golden/cbor/update/SoftwareVersion
+    golden/cbor/update/StaticConfig_GCSpec
+    golden/cbor/update/StaticConfig_GCSrc
+    golden/cbor/update/SystemTag
+    golden/cbor/update/UpId
+    golden/cbor/update/Vote
+    golden/cbor/utxo/HashTx
+    golden/cbor/utxo/Tx
+    golden/cbor/utxo/TxAttributes
+    golden/cbor/utxo/TxId
+    golden/cbor/utxo/TxInList
+    golden/cbor/utxo/TxIn_Utxo
+    golden/cbor/utxo/TxInWitness_RedeemWitness
+    golden/cbor/utxo/TxInWitness_VKWitness
+    golden/cbor/utxo/TxOut
+    golden/cbor/utxo/TxOut1
+    golden/cbor/utxo/TxOutList
+    golden/cbor/utxo/TxOutList1
+    golden/cbor/utxo/TxPayload1
+    golden/cbor/utxo/TxProof
+    golden/cbor/utxo/TxSig
+    golden/cbor/utxo/TxSigData
+    golden/cbor/utxo/TxWitness
+    golden/json/genesis/GenesisData0_Legacy_HasNetworkMagic
+
+data-dir:           test
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+flag test-normal-form
+    description: Test ledger state normal form during epoch validation
+    default:     False
+    manual:      True
+
+library
+    exposed-modules:
+        Cardano.Chain.Block
+        Cardano.Chain.Byron.API
+        Cardano.Chain.Common
+        Cardano.Chain.Constants
+        Cardano.Chain.Delegation
+        Cardano.Chain.Delegation.Validation.Activation
+        Cardano.Chain.Delegation.Validation.Interface
+        Cardano.Chain.Delegation.Validation.Scheduling
+        Cardano.Chain.Epoch.File
+        Cardano.Chain.Epoch.Validation
+        Cardano.Chain.Genesis
+        Cardano.Chain.MempoolPayload
+        Cardano.Chain.ProtocolConstants
+        Cardano.Chain.Slotting
+        Cardano.Chain.Ssc
+        Cardano.Chain.UTxO
+        Cardano.Chain.UTxO.UTxO
+        Cardano.Chain.UTxO.Validation
+        Cardano.Chain.Update
+        Cardano.Chain.Update.Proposal
+        Cardano.Chain.Update.Validation.Endorsement
+        Cardano.Chain.Update.Validation.Interface
+        Cardano.Chain.Update.Validation.Registration
+        Cardano.Chain.Update.Validation.Voting
+        Cardano.Chain.Update.Vote
+        Cardano.Chain.ValidationMode
+
+    hs-source-dirs:     src
+    other-modules:
+        Cardano.Chain.Block.Block
+        Cardano.Chain.Block.Body
+        Cardano.Chain.Block.Boundary
+        Cardano.Chain.Block.Header
+        Cardano.Chain.Block.Proof
+        Cardano.Chain.Block.Validation
+        Cardano.Chain.Block.ValidationMode
+        Cardano.Chain.Byron.API.Common
+        Cardano.Chain.Byron.API.Mempool
+        Cardano.Chain.Byron.API.Protocol
+        Cardano.Chain.Byron.API.Validation
+        Cardano.Chain.Common.AddrAttributes
+        Cardano.Chain.Common.AddrSpendingData
+        Cardano.Chain.Common.Address
+        Cardano.Chain.Common.AddressHash
+        Cardano.Chain.Common.Attributes
+        Cardano.Chain.Common.BlockCount
+        Cardano.Chain.Common.CBOR
+        Cardano.Chain.Common.ChainDifficulty
+        Cardano.Chain.Common.Compact
+        Cardano.Chain.Common.KeyHash
+        Cardano.Chain.Common.Lovelace
+        Cardano.Chain.Common.LovelacePortion
+        Cardano.Chain.Common.Merkle
+        Cardano.Chain.Common.NetworkMagic
+        Cardano.Chain.Common.TxFeePolicy
+        Cardano.Chain.Common.TxSizeLinear
+        Cardano.Chain.Delegation.Certificate
+        Cardano.Chain.Delegation.Map
+        Cardano.Chain.Delegation.Payload
+        Cardano.Chain.Genesis.AvvmBalances
+        Cardano.Chain.Genesis.Config
+        Cardano.Chain.Genesis.Data
+        Cardano.Chain.Genesis.Delegation
+        Cardano.Chain.Genesis.Generate
+        Cardano.Chain.Genesis.Hash
+        Cardano.Chain.Genesis.Initializer
+        Cardano.Chain.Genesis.KeyHashes
+        Cardano.Chain.Genesis.NonAvvmBalances
+        Cardano.Chain.Genesis.Spec
+        Cardano.Chain.Slotting.EpochAndSlotCount
+        Cardano.Chain.Slotting.EpochNumber
+        Cardano.Chain.Slotting.EpochSlots
+        Cardano.Chain.Slotting.SlotCount
+        Cardano.Chain.Slotting.SlotNumber
+        Cardano.Chain.UTxO.Compact
+        Cardano.Chain.UTxO.GenesisUTxO
+        Cardano.Chain.UTxO.Tx
+        Cardano.Chain.UTxO.TxAux
+        Cardano.Chain.UTxO.TxPayload
+        Cardano.Chain.UTxO.UTxOConfiguration
+        Cardano.Chain.UTxO.TxProof
+        Cardano.Chain.UTxO.TxWitness
+        Cardano.Chain.UTxO.ValidationMode
+        Cardano.Chain.Update.ApplicationName
+        Cardano.Chain.Update.InstallerHash
+        Cardano.Chain.Update.Payload
+        Cardano.Chain.Update.Proof
+        Cardano.Chain.Update.ProtocolParameters
+        Cardano.Chain.Update.ProtocolParametersUpdate
+        Cardano.Chain.Update.ProtocolVersion
+        Cardano.Chain.Update.SoftforkRule
+        Cardano.Chain.Update.SoftwareVersion
+        Cardano.Chain.Update.SystemTag
+        Cardano.Chain.Update.Validation.Interface.ProtocolVersionBump
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+
+    build-depends:
+        base >=4.12 && <4.17,
+        aeson,
+        base58-bytestring,
+        bimap >=0.4 && <0.5,
+        binary,
+        bytestring,
+        canonical-json,
+        cardano-crypto,
+        cardano-crypto-wrapper,
+        cardano-ledger-binary <1.5,
+        cardano-prelude,
+        cborg,
+        containers,
+        contra-tracer,
+        cryptonite,
+        Cabal,
+        digest,
+        directory,
+        filepath,
+        formatting,
+        heapwords,
+        nothunks,
+        quiet,
+        resourcet,
+        streaming,
+        streaming-binary >=0.2 && <0.3,
+        streaming-bytestring,
+        text,
+        time,
+        vector
+
+test-suite cardano-ledger-byron-test
+    type:               exitcode-stdio-1.0
+    main-is:            test.hs
+    hs-source-dirs:     test
+    other-modules:
+        Test.Cardano.Chain.Block.CBOR
+        Test.Cardano.Chain.Block.Gen
+        Test.Cardano.Chain.Block.Model
+        Test.Cardano.Chain.Block.Model.Examples
+        Test.Cardano.Chain.Block.Size
+        Test.Cardano.Chain.Block.Validation
+        Test.Cardano.Chain.Block.ValidationMode
+        Test.Cardano.Chain.Byron.API
+        Test.Cardano.Chain.Buildable
+        Test.Cardano.Chain.Common.Address
+        Test.Cardano.Chain.Common.Attributes
+        Test.Cardano.Chain.Common.CBOR
+        Test.Cardano.Chain.Common.Compact
+        Test.Cardano.Chain.Common.Example
+        Test.Cardano.Chain.Common.Gen
+        Test.Cardano.Chain.Common.Lovelace
+        Test.Cardano.Chain.Config
+        Test.Cardano.Chain.Delegation.CBOR
+        Test.Cardano.Chain.Delegation.Certificate
+        Test.Cardano.Chain.Delegation.Example
+        Test.Cardano.Chain.Delegation.Gen
+        Test.Cardano.Chain.Delegation.Model
+        Test.Cardano.Chain.Elaboration.Block
+        Test.Cardano.Chain.Elaboration.Delegation
+        Test.Cardano.Chain.Elaboration.Keys
+        Test.Cardano.Chain.Elaboration.Update
+        Test.Cardano.Chain.Elaboration.UTxO
+        Test.Cardano.Chain.Epoch.File
+        Test.Cardano.Chain.Genesis.CBOR
+        Test.Cardano.Chain.Genesis.Dummy
+        Test.Cardano.Chain.Genesis.Example
+        Test.Cardano.Chain.Genesis.Gen
+        Test.Cardano.Chain.Genesis.Json
+        Test.Cardano.Chain.MempoolPayload.CBOR
+        Test.Cardano.Chain.MempoolPayload.Example
+        Test.Cardano.Chain.MempoolPayload.Gen
+        Test.Cardano.Chain.Ssc.CBOR
+        Test.Cardano.Chain.Slotting.CBOR
+        Test.Cardano.Chain.Slotting.Example
+        Test.Cardano.Chain.Slotting.Gen
+        Test.Cardano.Chain.Slotting.Properties
+        Test.Cardano.Chain.UTxO.CBOR
+        Test.Cardano.Chain.UTxO.Compact
+        Test.Cardano.Chain.UTxO.Example
+        Test.Cardano.Chain.UTxO.Gen
+        Test.Cardano.Chain.UTxO.Model
+        Test.Cardano.Chain.UTxO.ValidationMode
+        Test.Cardano.Chain.Update.CBOR
+        Test.Cardano.Chain.Update.Example
+        Test.Cardano.Chain.Update.Gen
+        Test.Cardano.Chain.Update.Properties
+        Test.Cardano.Mirror
+        Test.Options
+        GetDataFileName
+        Paths_cardano_ledger_byron
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+        "-with-rtsopts=-K450K -M500M"
+
+    build-depends:
+        base >=4.12 && <4.17,
+        base16-bytestring >=1,
+        bimap >=0.4 && <0.5,
+        bytestring,
+        cardano-crypto,
+        cardano-crypto-test,
+        cardano-crypto-wrapper,
+        cardano-ledger-binary,
+        cardano-ledger-binary:testlib,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-prelude-test,
+        containers,
+        byron-spec-chain,
+        byron-spec-ledger,
+        directory,
+        filepath,
+        formatting,
+        generic-monoid,
+        heapwords,
+        hedgehog >=1.0.4,
+        microlens,
+        resourcet,
+        small-steps,
+        small-steps-test,
+        streaming,
+        tasty,
+        tasty-hedgehog,
+        text,
+        time,
+        vector
+
+test-suite epoch-validation-normal-form-test
+    type:               exitcode-stdio-1.0
+    main-is:            NormalFormTest.hs
+    hs-source-dirs:     test
+    other-modules:
+        Test.Cardano.Chain.Block.Validation
+        Test.Cardano.Chain.Config
+        Test.Cardano.Mirror
+        Test.Options
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+        "-with-rtsopts=-K450K -M500M"
+
+    build-depends:
+        base >=4.12 && <4.17,
+        bytestring,
+        cardano-ledger,
+        cardano-ledger-binary,
+        cardano-crypto-wrapper,
+        cardano-prelude,
+        cardano-prelude-test,
+        directory,
+        filepath,
+        hedgehog >=1.0.4,
+        resourcet,
+        silently,
+        streaming,
+        tasty,
+        tasty-hedgehog
+
+    if !flag(test-normal-form)
+        buildable: False

--- a/_sources/cardano-ledger-byron/1.0.0.1/meta.toml
+++ b/_sources/cardano-ledger-byron/1.0.0.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-06-08T18:20:50Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "eae43793dc80533fe7f3fc02b76303e7df7d001f" }
 subdir = 'eras/byron/ledger/impl'
+
+[[revisions]]
+number = 1
+timestamp = 2025-03-22T21:55:00Z

--- a/_sources/cardano-ledger-byron/1.0.0.1/revisions/1.cabal
+++ b/_sources/cardano-ledger-byron/1.0.0.1/revisions/1.cabal
@@ -1,0 +1,401 @@
+cabal-version:      3.0
+name:               cardano-ledger-byron
+version:            1.0.0.1
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+synopsis:           The blockchain layer of Cardano during the Byron era
+description:        The blockchain layer of Cardano during the Byron era
+category:           Currency
+build-type:         Simple
+data-files:
+    golden/cbor/block/BlockSignature
+    golden/cbor/block/Body
+    golden/cbor/block/BoundaryBlockHeader
+    golden/cbor/block/BoundaryBody
+    golden/cbor/block/BoundaryConsensusData
+    golden/cbor/block/BoundaryProof
+    golden/cbor/block/ExtraBodyData
+    golden/cbor/block/Header
+    golden/cbor/block/HeaderHash
+    golden/cbor/block/Proof
+    golden/cbor/block/StaticConfig_GCSpec
+    golden/cbor/block/ToSign
+    golden/cbor/common/Address
+    golden/cbor/common/Address0
+    golden/cbor/common/Address1
+    golden/cbor/common/Address2
+    golden/cbor/common/Address3
+    golden/cbor/common/Address4
+    golden/cbor/common/AddrSpendingData_Redeem
+    golden/cbor/common/AddrSpendingData_VerKey
+    golden/cbor/common/AddrType_R
+    golden/cbor/common/AddrType_VK
+    golden/cbor/common/Attributes
+    golden/cbor/common/BlockCount
+    golden/cbor/common/ChainDifficulty
+    golden/cbor/common/KeyHash
+    golden/cbor/common/Lovelace
+    golden/cbor/common/LovelacePortion
+    golden/cbor/common/MerkleRoot
+    golden/cbor/common/MerkleTree
+    golden/cbor/common/TxFeePolicy_Linear
+    golden/cbor/common/TxSizeLinear
+    golden/cbor/delegation/Certificate
+    golden/cbor/delegation/DlgPayload
+    golden/cbor/mempoolpayload/MempoolPayload
+    golden/cbor/mempoolpayload/MempoolPayload1
+    golden/cbor/mempoolpayload/MempoolPayload2
+    golden/cbor/mempoolpayload/MempoolPayload3
+    golden/cbor/slotting/EpochAndSlotCount
+    golden/cbor/slotting/EpochNumber
+    golden/cbor/slotting/EpochSlots
+    golden/cbor/slotting/SlotNumber
+    golden/cbor/ssc/Commitment
+    golden/cbor/ssc/CommitmentsMap
+    golden/cbor/ssc/InnerSharesMap
+    golden/cbor/ssc/Opening
+    golden/cbor/ssc/OpeningsMap
+    golden/cbor/ssc/SharesMap
+    golden/cbor/ssc/SignedCommitment
+    golden/cbor/ssc/SscPayload_CertificatesPayload
+    golden/cbor/ssc/SscPayload_CommitmentsPayload
+    golden/cbor/ssc/SscPayload_OpeningsPayload
+    golden/cbor/ssc/SscPayload_SharesPayload
+    golden/cbor/ssc/SscProof_CertificatesProof
+    golden/cbor/ssc/SscProof_CommitmentsProof
+    golden/cbor/ssc/SscProof_OpeningsProof
+    golden/cbor/ssc/SscProof_SharesProof
+    golden/cbor/ssc/VssCertificate
+    golden/cbor/ssc/VssCertificatesHash
+    golden/cbor/ssc/VssCertificatesMap
+    golden/cbor/update/ApplicationName
+    golden/cbor/update/AttackTarget_NetworkAddressTarget
+    golden/cbor/update/AttackTarget_PubKeyAddressTarget
+    golden/cbor/update/BlockHeader_Boundary
+    golden/cbor/update/CommitmentSignature
+    golden/cbor/update/HashRaw
+    golden/cbor/update/HashTx
+    golden/cbor/update/InstallerHash
+    golden/cbor/update/Payload
+    golden/cbor/update/Proof
+    golden/cbor/update/Proposal
+    golden/cbor/update/ProposalBody
+    golden/cbor/update/ProtocolParameters
+    golden/cbor/update/ProtocolParametersUpdate
+    golden/cbor/update/ProtocolVersion
+    golden/cbor/update/SharesDistribution
+    golden/cbor/update/SoftforkRule
+    golden/cbor/update/SoftwareVersion
+    golden/cbor/update/StaticConfig_GCSpec
+    golden/cbor/update/StaticConfig_GCSrc
+    golden/cbor/update/SystemTag
+    golden/cbor/update/UpId
+    golden/cbor/update/Vote
+    golden/cbor/utxo/HashTx
+    golden/cbor/utxo/Tx
+    golden/cbor/utxo/TxAttributes
+    golden/cbor/utxo/TxId
+    golden/cbor/utxo/TxInList
+    golden/cbor/utxo/TxIn_Utxo
+    golden/cbor/utxo/TxInWitness_RedeemWitness
+    golden/cbor/utxo/TxInWitness_VKWitness
+    golden/cbor/utxo/TxOut
+    golden/cbor/utxo/TxOut1
+    golden/cbor/utxo/TxOutList
+    golden/cbor/utxo/TxOutList1
+    golden/cbor/utxo/TxPayload1
+    golden/cbor/utxo/TxProof
+    golden/cbor/utxo/TxSig
+    golden/cbor/utxo/TxSigData
+    golden/cbor/utxo/TxWitness
+    golden/json/genesis/GenesisData0_Legacy_HasNetworkMagic
+
+data-dir:           test
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+flag test-normal-form
+    description: Test ledger state normal form during epoch validation
+    default:     False
+    manual:      True
+
+library
+    exposed-modules:
+        Cardano.Chain.Block
+        Cardano.Chain.Byron.API
+        Cardano.Chain.Common
+        Cardano.Chain.Constants
+        Cardano.Chain.Delegation
+        Cardano.Chain.Delegation.Validation.Activation
+        Cardano.Chain.Delegation.Validation.Interface
+        Cardano.Chain.Delegation.Validation.Scheduling
+        Cardano.Chain.Epoch.File
+        Cardano.Chain.Epoch.Validation
+        Cardano.Chain.Genesis
+        Cardano.Chain.MempoolPayload
+        Cardano.Chain.ProtocolConstants
+        Cardano.Chain.Slotting
+        Cardano.Chain.Ssc
+        Cardano.Chain.UTxO
+        Cardano.Chain.UTxO.UTxO
+        Cardano.Chain.UTxO.Validation
+        Cardano.Chain.Update
+        Cardano.Chain.Update.Proposal
+        Cardano.Chain.Update.Validation.Endorsement
+        Cardano.Chain.Update.Validation.Interface
+        Cardano.Chain.Update.Validation.Registration
+        Cardano.Chain.Update.Validation.Voting
+        Cardano.Chain.Update.Vote
+        Cardano.Chain.ValidationMode
+
+    hs-source-dirs:     src
+    other-modules:
+        Cardano.Chain.Block.Block
+        Cardano.Chain.Block.Body
+        Cardano.Chain.Block.Boundary
+        Cardano.Chain.Block.Header
+        Cardano.Chain.Block.Proof
+        Cardano.Chain.Block.Validation
+        Cardano.Chain.Block.ValidationMode
+        Cardano.Chain.Byron.API.Common
+        Cardano.Chain.Byron.API.Mempool
+        Cardano.Chain.Byron.API.Protocol
+        Cardano.Chain.Byron.API.Validation
+        Cardano.Chain.Common.AddrAttributes
+        Cardano.Chain.Common.AddrSpendingData
+        Cardano.Chain.Common.Address
+        Cardano.Chain.Common.AddressHash
+        Cardano.Chain.Common.Attributes
+        Cardano.Chain.Common.BlockCount
+        Cardano.Chain.Common.CBOR
+        Cardano.Chain.Common.ChainDifficulty
+        Cardano.Chain.Common.Compact
+        Cardano.Chain.Common.KeyHash
+        Cardano.Chain.Common.Lovelace
+        Cardano.Chain.Common.LovelacePortion
+        Cardano.Chain.Common.Merkle
+        Cardano.Chain.Common.NetworkMagic
+        Cardano.Chain.Common.TxFeePolicy
+        Cardano.Chain.Common.TxSizeLinear
+        Cardano.Chain.Delegation.Certificate
+        Cardano.Chain.Delegation.Map
+        Cardano.Chain.Delegation.Payload
+        Cardano.Chain.Genesis.AvvmBalances
+        Cardano.Chain.Genesis.Config
+        Cardano.Chain.Genesis.Data
+        Cardano.Chain.Genesis.Delegation
+        Cardano.Chain.Genesis.Generate
+        Cardano.Chain.Genesis.Hash
+        Cardano.Chain.Genesis.Initializer
+        Cardano.Chain.Genesis.KeyHashes
+        Cardano.Chain.Genesis.NonAvvmBalances
+        Cardano.Chain.Genesis.Spec
+        Cardano.Chain.Slotting.EpochAndSlotCount
+        Cardano.Chain.Slotting.EpochNumber
+        Cardano.Chain.Slotting.EpochSlots
+        Cardano.Chain.Slotting.SlotCount
+        Cardano.Chain.Slotting.SlotNumber
+        Cardano.Chain.UTxO.Compact
+        Cardano.Chain.UTxO.GenesisUTxO
+        Cardano.Chain.UTxO.Tx
+        Cardano.Chain.UTxO.TxAux
+        Cardano.Chain.UTxO.TxPayload
+        Cardano.Chain.UTxO.UTxOConfiguration
+        Cardano.Chain.UTxO.TxProof
+        Cardano.Chain.UTxO.TxWitness
+        Cardano.Chain.UTxO.ValidationMode
+        Cardano.Chain.Update.ApplicationName
+        Cardano.Chain.Update.InstallerHash
+        Cardano.Chain.Update.Payload
+        Cardano.Chain.Update.Proof
+        Cardano.Chain.Update.ProtocolParameters
+        Cardano.Chain.Update.ProtocolParametersUpdate
+        Cardano.Chain.Update.ProtocolVersion
+        Cardano.Chain.Update.SoftforkRule
+        Cardano.Chain.Update.SoftwareVersion
+        Cardano.Chain.Update.SystemTag
+        Cardano.Chain.Update.Validation.Interface.ProtocolVersionBump
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson,
+        base58-bytestring,
+        bimap >=0.4 && <0.5,
+        binary,
+        bytestring,
+        canonical-json,
+        cardano-crypto,
+        cardano-crypto-wrapper,
+        cardano-ledger-binary >=1.0 && <1.5,
+        cardano-prelude,
+        cborg,
+        containers,
+        contra-tracer,
+        cryptonite,
+        Cabal,
+        digest,
+        directory,
+        filepath,
+        formatting,
+        heapwords,
+        nothunks,
+        quiet,
+        resourcet,
+        streaming,
+        streaming-binary >=0.2 && <0.3,
+        streaming-bytestring,
+        text,
+        time,
+        vector
+
+test-suite cardano-ledger-byron-test
+    type:               exitcode-stdio-1.0
+    main-is:            test.hs
+    hs-source-dirs:     test
+    other-modules:
+        Test.Cardano.Chain.Block.CBOR
+        Test.Cardano.Chain.Block.Gen
+        Test.Cardano.Chain.Block.Model
+        Test.Cardano.Chain.Block.Model.Examples
+        Test.Cardano.Chain.Block.Size
+        Test.Cardano.Chain.Block.Validation
+        Test.Cardano.Chain.Block.ValidationMode
+        Test.Cardano.Chain.Byron.API
+        Test.Cardano.Chain.Buildable
+        Test.Cardano.Chain.Common.Address
+        Test.Cardano.Chain.Common.Attributes
+        Test.Cardano.Chain.Common.CBOR
+        Test.Cardano.Chain.Common.Compact
+        Test.Cardano.Chain.Common.Example
+        Test.Cardano.Chain.Common.Gen
+        Test.Cardano.Chain.Common.Lovelace
+        Test.Cardano.Chain.Config
+        Test.Cardano.Chain.Delegation.CBOR
+        Test.Cardano.Chain.Delegation.Certificate
+        Test.Cardano.Chain.Delegation.Example
+        Test.Cardano.Chain.Delegation.Gen
+        Test.Cardano.Chain.Delegation.Model
+        Test.Cardano.Chain.Elaboration.Block
+        Test.Cardano.Chain.Elaboration.Delegation
+        Test.Cardano.Chain.Elaboration.Keys
+        Test.Cardano.Chain.Elaboration.Update
+        Test.Cardano.Chain.Elaboration.UTxO
+        Test.Cardano.Chain.Epoch.File
+        Test.Cardano.Chain.Genesis.CBOR
+        Test.Cardano.Chain.Genesis.Dummy
+        Test.Cardano.Chain.Genesis.Example
+        Test.Cardano.Chain.Genesis.Gen
+        Test.Cardano.Chain.Genesis.Json
+        Test.Cardano.Chain.MempoolPayload.CBOR
+        Test.Cardano.Chain.MempoolPayload.Example
+        Test.Cardano.Chain.MempoolPayload.Gen
+        Test.Cardano.Chain.Ssc.CBOR
+        Test.Cardano.Chain.Slotting.CBOR
+        Test.Cardano.Chain.Slotting.Example
+        Test.Cardano.Chain.Slotting.Gen
+        Test.Cardano.Chain.Slotting.Properties
+        Test.Cardano.Chain.UTxO.CBOR
+        Test.Cardano.Chain.UTxO.Compact
+        Test.Cardano.Chain.UTxO.Example
+        Test.Cardano.Chain.UTxO.Gen
+        Test.Cardano.Chain.UTxO.Model
+        Test.Cardano.Chain.UTxO.ValidationMode
+        Test.Cardano.Chain.Update.CBOR
+        Test.Cardano.Chain.Update.Example
+        Test.Cardano.Chain.Update.Gen
+        Test.Cardano.Chain.Update.Properties
+        Test.Cardano.Mirror
+        Test.Options
+        GetDataFileName
+        Paths_cardano_ledger_byron
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+        "-with-rtsopts=-K450K -M500M"
+
+    build-depends:
+        base,
+        base16-bytestring >=1,
+        bimap,
+        bytestring,
+        cardano-crypto,
+        cardano-crypto-test,
+        cardano-crypto-wrapper,
+        cardano-ledger-binary,
+        cardano-ledger-binary:testlib,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-prelude-test,
+        containers,
+        byron-spec-chain,
+        byron-spec-ledger,
+        directory,
+        filepath,
+        formatting,
+        generic-monoid,
+        heapwords,
+        hedgehog >=1.0.4,
+        microlens,
+        resourcet,
+        small-steps,
+        small-steps-test,
+        streaming,
+        tasty,
+        tasty-hedgehog,
+        text,
+        time,
+        vector
+
+test-suite epoch-validation-normal-form-test
+    type:               exitcode-stdio-1.0
+    main-is:            NormalFormTest.hs
+    hs-source-dirs:     test
+    other-modules:
+        Test.Cardano.Chain.Block.Validation
+        Test.Cardano.Chain.Config
+        Test.Cardano.Mirror
+        Test.Options
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+        "-with-rtsopts=-K450K -M500M"
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger,
+        cardano-ledger-binary,
+        cardano-crypto-wrapper,
+        cardano-prelude,
+        cardano-prelude-test,
+        directory,
+        filepath,
+        hedgehog >=1.0.4,
+        resourcet,
+        silently,
+        streaming,
+        tasty,
+        tasty-hedgehog
+
+    if !flag(test-normal-form)
+        buildable: False

--- a/_sources/cardano-ledger-byron/1.0.0.2/meta.toml
+++ b/_sources/cardano-ledger-byron/1.0.0.2/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-07-05T12:27:25Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "9b3a09485f1ba14ce8dc267d5596f85116ce5330" }
 subdir = 'eras/byron/ledger/impl'
+
+[[revisions]]
+number = 1
+timestamp = 2025-03-22T21:54:58Z

--- a/_sources/cardano-ledger-byron/1.0.0.2/revisions/1.cabal
+++ b/_sources/cardano-ledger-byron/1.0.0.2/revisions/1.cabal
@@ -1,0 +1,401 @@
+cabal-version:      3.0
+name:               cardano-ledger-byron
+version:            1.0.0.2
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+synopsis:           The blockchain layer of Cardano during the Byron era
+description:        The blockchain layer of Cardano during the Byron era
+category:           Currency
+build-type:         Simple
+data-files:
+    golden/cbor/block/BlockSignature
+    golden/cbor/block/Body
+    golden/cbor/block/BoundaryBlockHeader
+    golden/cbor/block/BoundaryBody
+    golden/cbor/block/BoundaryConsensusData
+    golden/cbor/block/BoundaryProof
+    golden/cbor/block/ExtraBodyData
+    golden/cbor/block/Header
+    golden/cbor/block/HeaderHash
+    golden/cbor/block/Proof
+    golden/cbor/block/StaticConfig_GCSpec
+    golden/cbor/block/ToSign
+    golden/cbor/common/Address
+    golden/cbor/common/Address0
+    golden/cbor/common/Address1
+    golden/cbor/common/Address2
+    golden/cbor/common/Address3
+    golden/cbor/common/Address4
+    golden/cbor/common/AddrSpendingData_Redeem
+    golden/cbor/common/AddrSpendingData_VerKey
+    golden/cbor/common/AddrType_R
+    golden/cbor/common/AddrType_VK
+    golden/cbor/common/Attributes
+    golden/cbor/common/BlockCount
+    golden/cbor/common/ChainDifficulty
+    golden/cbor/common/KeyHash
+    golden/cbor/common/Lovelace
+    golden/cbor/common/LovelacePortion
+    golden/cbor/common/MerkleRoot
+    golden/cbor/common/MerkleTree
+    golden/cbor/common/TxFeePolicy_Linear
+    golden/cbor/common/TxSizeLinear
+    golden/cbor/delegation/Certificate
+    golden/cbor/delegation/DlgPayload
+    golden/cbor/mempoolpayload/MempoolPayload
+    golden/cbor/mempoolpayload/MempoolPayload1
+    golden/cbor/mempoolpayload/MempoolPayload2
+    golden/cbor/mempoolpayload/MempoolPayload3
+    golden/cbor/slotting/EpochAndSlotCount
+    golden/cbor/slotting/EpochNumber
+    golden/cbor/slotting/EpochSlots
+    golden/cbor/slotting/SlotNumber
+    golden/cbor/ssc/Commitment
+    golden/cbor/ssc/CommitmentsMap
+    golden/cbor/ssc/InnerSharesMap
+    golden/cbor/ssc/Opening
+    golden/cbor/ssc/OpeningsMap
+    golden/cbor/ssc/SharesMap
+    golden/cbor/ssc/SignedCommitment
+    golden/cbor/ssc/SscPayload_CertificatesPayload
+    golden/cbor/ssc/SscPayload_CommitmentsPayload
+    golden/cbor/ssc/SscPayload_OpeningsPayload
+    golden/cbor/ssc/SscPayload_SharesPayload
+    golden/cbor/ssc/SscProof_CertificatesProof
+    golden/cbor/ssc/SscProof_CommitmentsProof
+    golden/cbor/ssc/SscProof_OpeningsProof
+    golden/cbor/ssc/SscProof_SharesProof
+    golden/cbor/ssc/VssCertificate
+    golden/cbor/ssc/VssCertificatesHash
+    golden/cbor/ssc/VssCertificatesMap
+    golden/cbor/update/ApplicationName
+    golden/cbor/update/AttackTarget_NetworkAddressTarget
+    golden/cbor/update/AttackTarget_PubKeyAddressTarget
+    golden/cbor/update/BlockHeader_Boundary
+    golden/cbor/update/CommitmentSignature
+    golden/cbor/update/HashRaw
+    golden/cbor/update/HashTx
+    golden/cbor/update/InstallerHash
+    golden/cbor/update/Payload
+    golden/cbor/update/Proof
+    golden/cbor/update/Proposal
+    golden/cbor/update/ProposalBody
+    golden/cbor/update/ProtocolParameters
+    golden/cbor/update/ProtocolParametersUpdate
+    golden/cbor/update/ProtocolVersion
+    golden/cbor/update/SharesDistribution
+    golden/cbor/update/SoftforkRule
+    golden/cbor/update/SoftwareVersion
+    golden/cbor/update/StaticConfig_GCSpec
+    golden/cbor/update/StaticConfig_GCSrc
+    golden/cbor/update/SystemTag
+    golden/cbor/update/UpId
+    golden/cbor/update/Vote
+    golden/cbor/utxo/HashTx
+    golden/cbor/utxo/Tx
+    golden/cbor/utxo/TxAttributes
+    golden/cbor/utxo/TxId
+    golden/cbor/utxo/TxInList
+    golden/cbor/utxo/TxIn_Utxo
+    golden/cbor/utxo/TxInWitness_RedeemWitness
+    golden/cbor/utxo/TxInWitness_VKWitness
+    golden/cbor/utxo/TxOut
+    golden/cbor/utxo/TxOut1
+    golden/cbor/utxo/TxOutList
+    golden/cbor/utxo/TxOutList1
+    golden/cbor/utxo/TxPayload1
+    golden/cbor/utxo/TxProof
+    golden/cbor/utxo/TxSig
+    golden/cbor/utxo/TxSigData
+    golden/cbor/utxo/TxWitness
+    golden/json/genesis/GenesisData0_Legacy_HasNetworkMagic
+
+data-dir:           test
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+flag test-normal-form
+    description: Test ledger state normal form during epoch validation
+    default:     False
+    manual:      True
+
+library
+    exposed-modules:
+        Cardano.Chain.Block
+        Cardano.Chain.Byron.API
+        Cardano.Chain.Common
+        Cardano.Chain.Constants
+        Cardano.Chain.Delegation
+        Cardano.Chain.Delegation.Validation.Activation
+        Cardano.Chain.Delegation.Validation.Interface
+        Cardano.Chain.Delegation.Validation.Scheduling
+        Cardano.Chain.Epoch.File
+        Cardano.Chain.Epoch.Validation
+        Cardano.Chain.Genesis
+        Cardano.Chain.MempoolPayload
+        Cardano.Chain.ProtocolConstants
+        Cardano.Chain.Slotting
+        Cardano.Chain.Ssc
+        Cardano.Chain.UTxO
+        Cardano.Chain.UTxO.UTxO
+        Cardano.Chain.UTxO.Validation
+        Cardano.Chain.Update
+        Cardano.Chain.Update.Proposal
+        Cardano.Chain.Update.Validation.Endorsement
+        Cardano.Chain.Update.Validation.Interface
+        Cardano.Chain.Update.Validation.Registration
+        Cardano.Chain.Update.Validation.Voting
+        Cardano.Chain.Update.Vote
+        Cardano.Chain.ValidationMode
+
+    hs-source-dirs:     src
+    other-modules:
+        Cardano.Chain.Block.Block
+        Cardano.Chain.Block.Body
+        Cardano.Chain.Block.Boundary
+        Cardano.Chain.Block.Header
+        Cardano.Chain.Block.Proof
+        Cardano.Chain.Block.Validation
+        Cardano.Chain.Block.ValidationMode
+        Cardano.Chain.Byron.API.Common
+        Cardano.Chain.Byron.API.Mempool
+        Cardano.Chain.Byron.API.Protocol
+        Cardano.Chain.Byron.API.Validation
+        Cardano.Chain.Common.AddrAttributes
+        Cardano.Chain.Common.AddrSpendingData
+        Cardano.Chain.Common.Address
+        Cardano.Chain.Common.AddressHash
+        Cardano.Chain.Common.Attributes
+        Cardano.Chain.Common.BlockCount
+        Cardano.Chain.Common.CBOR
+        Cardano.Chain.Common.ChainDifficulty
+        Cardano.Chain.Common.Compact
+        Cardano.Chain.Common.KeyHash
+        Cardano.Chain.Common.Lovelace
+        Cardano.Chain.Common.LovelacePortion
+        Cardano.Chain.Common.Merkle
+        Cardano.Chain.Common.NetworkMagic
+        Cardano.Chain.Common.TxFeePolicy
+        Cardano.Chain.Common.TxSizeLinear
+        Cardano.Chain.Delegation.Certificate
+        Cardano.Chain.Delegation.Map
+        Cardano.Chain.Delegation.Payload
+        Cardano.Chain.Genesis.AvvmBalances
+        Cardano.Chain.Genesis.Config
+        Cardano.Chain.Genesis.Data
+        Cardano.Chain.Genesis.Delegation
+        Cardano.Chain.Genesis.Generate
+        Cardano.Chain.Genesis.Hash
+        Cardano.Chain.Genesis.Initializer
+        Cardano.Chain.Genesis.KeyHashes
+        Cardano.Chain.Genesis.NonAvvmBalances
+        Cardano.Chain.Genesis.Spec
+        Cardano.Chain.Slotting.EpochAndSlotCount
+        Cardano.Chain.Slotting.EpochNumber
+        Cardano.Chain.Slotting.EpochSlots
+        Cardano.Chain.Slotting.SlotCount
+        Cardano.Chain.Slotting.SlotNumber
+        Cardano.Chain.UTxO.Compact
+        Cardano.Chain.UTxO.GenesisUTxO
+        Cardano.Chain.UTxO.Tx
+        Cardano.Chain.UTxO.TxAux
+        Cardano.Chain.UTxO.TxPayload
+        Cardano.Chain.UTxO.UTxOConfiguration
+        Cardano.Chain.UTxO.TxProof
+        Cardano.Chain.UTxO.TxWitness
+        Cardano.Chain.UTxO.ValidationMode
+        Cardano.Chain.Update.ApplicationName
+        Cardano.Chain.Update.InstallerHash
+        Cardano.Chain.Update.Payload
+        Cardano.Chain.Update.Proof
+        Cardano.Chain.Update.ProtocolParameters
+        Cardano.Chain.Update.ProtocolParametersUpdate
+        Cardano.Chain.Update.ProtocolVersion
+        Cardano.Chain.Update.SoftforkRule
+        Cardano.Chain.Update.SoftwareVersion
+        Cardano.Chain.Update.SystemTag
+        Cardano.Chain.Update.Validation.Interface.ProtocolVersionBump
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson,
+        base58-bytestring,
+        bimap >=0.4 && <0.6,
+        binary,
+        bytestring,
+        canonical-json,
+        cardano-crypto,
+        cardano-crypto-wrapper,
+        cardano-ledger-binary >=1.0 && <1.5,
+        cardano-prelude,
+        cborg,
+        containers,
+        contra-tracer,
+        cryptonite,
+        Cabal,
+        digest,
+        directory,
+        filepath,
+        formatting,
+        heapwords,
+        nothunks,
+        quiet,
+        resourcet,
+        streaming,
+        streaming-binary >=0.2 && <0.3,
+        streaming-bytestring,
+        text,
+        time,
+        vector
+
+test-suite cardano-ledger-byron-test
+    type:               exitcode-stdio-1.0
+    main-is:            test.hs
+    hs-source-dirs:     test
+    other-modules:
+        Test.Cardano.Chain.Block.CBOR
+        Test.Cardano.Chain.Block.Gen
+        Test.Cardano.Chain.Block.Model
+        Test.Cardano.Chain.Block.Model.Examples
+        Test.Cardano.Chain.Block.Size
+        Test.Cardano.Chain.Block.Validation
+        Test.Cardano.Chain.Block.ValidationMode
+        Test.Cardano.Chain.Byron.API
+        Test.Cardano.Chain.Buildable
+        Test.Cardano.Chain.Common.Address
+        Test.Cardano.Chain.Common.Attributes
+        Test.Cardano.Chain.Common.CBOR
+        Test.Cardano.Chain.Common.Compact
+        Test.Cardano.Chain.Common.Example
+        Test.Cardano.Chain.Common.Gen
+        Test.Cardano.Chain.Common.Lovelace
+        Test.Cardano.Chain.Config
+        Test.Cardano.Chain.Delegation.CBOR
+        Test.Cardano.Chain.Delegation.Certificate
+        Test.Cardano.Chain.Delegation.Example
+        Test.Cardano.Chain.Delegation.Gen
+        Test.Cardano.Chain.Delegation.Model
+        Test.Cardano.Chain.Elaboration.Block
+        Test.Cardano.Chain.Elaboration.Delegation
+        Test.Cardano.Chain.Elaboration.Keys
+        Test.Cardano.Chain.Elaboration.Update
+        Test.Cardano.Chain.Elaboration.UTxO
+        Test.Cardano.Chain.Epoch.File
+        Test.Cardano.Chain.Genesis.CBOR
+        Test.Cardano.Chain.Genesis.Dummy
+        Test.Cardano.Chain.Genesis.Example
+        Test.Cardano.Chain.Genesis.Gen
+        Test.Cardano.Chain.Genesis.Json
+        Test.Cardano.Chain.MempoolPayload.CBOR
+        Test.Cardano.Chain.MempoolPayload.Example
+        Test.Cardano.Chain.MempoolPayload.Gen
+        Test.Cardano.Chain.Ssc.CBOR
+        Test.Cardano.Chain.Slotting.CBOR
+        Test.Cardano.Chain.Slotting.Example
+        Test.Cardano.Chain.Slotting.Gen
+        Test.Cardano.Chain.Slotting.Properties
+        Test.Cardano.Chain.UTxO.CBOR
+        Test.Cardano.Chain.UTxO.Compact
+        Test.Cardano.Chain.UTxO.Example
+        Test.Cardano.Chain.UTxO.Gen
+        Test.Cardano.Chain.UTxO.Model
+        Test.Cardano.Chain.UTxO.ValidationMode
+        Test.Cardano.Chain.Update.CBOR
+        Test.Cardano.Chain.Update.Example
+        Test.Cardano.Chain.Update.Gen
+        Test.Cardano.Chain.Update.Properties
+        Test.Cardano.Mirror
+        Test.Options
+        GetDataFileName
+        Paths_cardano_ledger_byron
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+        "-with-rtsopts=-K450K -M500M"
+
+    build-depends:
+        base,
+        base16-bytestring >=1,
+        bimap,
+        bytestring,
+        cardano-crypto,
+        cardano-crypto-test,
+        cardano-crypto-wrapper,
+        cardano-ledger-binary,
+        cardano-ledger-binary:testlib,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-prelude-test,
+        containers,
+        byron-spec-chain,
+        byron-spec-ledger,
+        directory,
+        filepath,
+        formatting,
+        generic-monoid,
+        heapwords,
+        hedgehog >=1.0.4,
+        microlens,
+        resourcet,
+        small-steps,
+        small-steps-test,
+        streaming,
+        tasty,
+        tasty-hedgehog,
+        text,
+        time,
+        vector
+
+test-suite epoch-validation-normal-form-test
+    type:               exitcode-stdio-1.0
+    main-is:            NormalFormTest.hs
+    hs-source-dirs:     test
+    other-modules:
+        Test.Cardano.Chain.Block.Validation
+        Test.Cardano.Chain.Config
+        Test.Cardano.Mirror
+        Test.Options
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+        "-with-rtsopts=-K450K -M500M"
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger,
+        cardano-ledger-binary,
+        cardano-crypto-wrapper,
+        cardano-prelude,
+        cardano-prelude-test,
+        directory,
+        filepath,
+        hedgehog >=1.0.4,
+        resourcet,
+        silently,
+        streaming,
+        tasty,
+        tasty-hedgehog
+
+    if !flag(test-normal-form)
+        buildable: False

--- a/_sources/cardano-ledger-byron/1.0.0.3/meta.toml
+++ b/_sources/cardano-ledger-byron/1.0.0.3/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-11-14T12:07:29Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "f85ec6f2e0a80101009187f79ff154ab33a82a21" }
 subdir = 'eras/byron/ledger/impl'
+
+[[revisions]]
+number = 1
+timestamp = 2025-03-22T21:54:56Z

--- a/_sources/cardano-ledger-byron/1.0.0.3/revisions/1.cabal
+++ b/_sources/cardano-ledger-byron/1.0.0.3/revisions/1.cabal
@@ -1,0 +1,401 @@
+cabal-version:      3.0
+name:               cardano-ledger-byron
+version:            1.0.0.3
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+synopsis:           The blockchain layer of Cardano during the Byron era
+description:        The blockchain layer of Cardano during the Byron era
+category:           Currency
+build-type:         Simple
+data-files:
+    golden/cbor/block/BlockSignature
+    golden/cbor/block/Body
+    golden/cbor/block/BoundaryBlockHeader
+    golden/cbor/block/BoundaryBody
+    golden/cbor/block/BoundaryConsensusData
+    golden/cbor/block/BoundaryProof
+    golden/cbor/block/ExtraBodyData
+    golden/cbor/block/Header
+    golden/cbor/block/HeaderHash
+    golden/cbor/block/Proof
+    golden/cbor/block/StaticConfig_GCSpec
+    golden/cbor/block/ToSign
+    golden/cbor/common/Address
+    golden/cbor/common/Address0
+    golden/cbor/common/Address1
+    golden/cbor/common/Address2
+    golden/cbor/common/Address3
+    golden/cbor/common/Address4
+    golden/cbor/common/AddrSpendingData_Redeem
+    golden/cbor/common/AddrSpendingData_VerKey
+    golden/cbor/common/AddrType_R
+    golden/cbor/common/AddrType_VK
+    golden/cbor/common/Attributes
+    golden/cbor/common/BlockCount
+    golden/cbor/common/ChainDifficulty
+    golden/cbor/common/KeyHash
+    golden/cbor/common/Lovelace
+    golden/cbor/common/LovelacePortion
+    golden/cbor/common/MerkleRoot
+    golden/cbor/common/MerkleTree
+    golden/cbor/common/TxFeePolicy_Linear
+    golden/cbor/common/TxSizeLinear
+    golden/cbor/delegation/Certificate
+    golden/cbor/delegation/DlgPayload
+    golden/cbor/mempoolpayload/MempoolPayload
+    golden/cbor/mempoolpayload/MempoolPayload1
+    golden/cbor/mempoolpayload/MempoolPayload2
+    golden/cbor/mempoolpayload/MempoolPayload3
+    golden/cbor/slotting/EpochAndSlotCount
+    golden/cbor/slotting/EpochNumber
+    golden/cbor/slotting/EpochSlots
+    golden/cbor/slotting/SlotNumber
+    golden/cbor/ssc/Commitment
+    golden/cbor/ssc/CommitmentsMap
+    golden/cbor/ssc/InnerSharesMap
+    golden/cbor/ssc/Opening
+    golden/cbor/ssc/OpeningsMap
+    golden/cbor/ssc/SharesMap
+    golden/cbor/ssc/SignedCommitment
+    golden/cbor/ssc/SscPayload_CertificatesPayload
+    golden/cbor/ssc/SscPayload_CommitmentsPayload
+    golden/cbor/ssc/SscPayload_OpeningsPayload
+    golden/cbor/ssc/SscPayload_SharesPayload
+    golden/cbor/ssc/SscProof_CertificatesProof
+    golden/cbor/ssc/SscProof_CommitmentsProof
+    golden/cbor/ssc/SscProof_OpeningsProof
+    golden/cbor/ssc/SscProof_SharesProof
+    golden/cbor/ssc/VssCertificate
+    golden/cbor/ssc/VssCertificatesHash
+    golden/cbor/ssc/VssCertificatesMap
+    golden/cbor/update/ApplicationName
+    golden/cbor/update/AttackTarget_NetworkAddressTarget
+    golden/cbor/update/AttackTarget_PubKeyAddressTarget
+    golden/cbor/update/BlockHeader_Boundary
+    golden/cbor/update/CommitmentSignature
+    golden/cbor/update/HashRaw
+    golden/cbor/update/HashTx
+    golden/cbor/update/InstallerHash
+    golden/cbor/update/Payload
+    golden/cbor/update/Proof
+    golden/cbor/update/Proposal
+    golden/cbor/update/ProposalBody
+    golden/cbor/update/ProtocolParameters
+    golden/cbor/update/ProtocolParametersUpdate
+    golden/cbor/update/ProtocolVersion
+    golden/cbor/update/SharesDistribution
+    golden/cbor/update/SoftforkRule
+    golden/cbor/update/SoftwareVersion
+    golden/cbor/update/StaticConfig_GCSpec
+    golden/cbor/update/StaticConfig_GCSrc
+    golden/cbor/update/SystemTag
+    golden/cbor/update/UpId
+    golden/cbor/update/Vote
+    golden/cbor/utxo/HashTx
+    golden/cbor/utxo/Tx
+    golden/cbor/utxo/TxAttributes
+    golden/cbor/utxo/TxId
+    golden/cbor/utxo/TxInList
+    golden/cbor/utxo/TxIn_Utxo
+    golden/cbor/utxo/TxInWitness_RedeemWitness
+    golden/cbor/utxo/TxInWitness_VKWitness
+    golden/cbor/utxo/TxOut
+    golden/cbor/utxo/TxOut1
+    golden/cbor/utxo/TxOutList
+    golden/cbor/utxo/TxOutList1
+    golden/cbor/utxo/TxPayload1
+    golden/cbor/utxo/TxProof
+    golden/cbor/utxo/TxSig
+    golden/cbor/utxo/TxSigData
+    golden/cbor/utxo/TxWitness
+    golden/json/genesis/GenesisData0_Legacy_HasNetworkMagic
+
+data-dir:           test
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+flag test-normal-form
+    description: Test ledger state normal form during epoch validation
+    default:     False
+    manual:      True
+
+library
+    exposed-modules:
+        Cardano.Chain.Block
+        Cardano.Chain.Byron.API
+        Cardano.Chain.Common
+        Cardano.Chain.Constants
+        Cardano.Chain.Delegation
+        Cardano.Chain.Delegation.Validation.Activation
+        Cardano.Chain.Delegation.Validation.Interface
+        Cardano.Chain.Delegation.Validation.Scheduling
+        Cardano.Chain.Epoch.File
+        Cardano.Chain.Epoch.Validation
+        Cardano.Chain.Genesis
+        Cardano.Chain.MempoolPayload
+        Cardano.Chain.ProtocolConstants
+        Cardano.Chain.Slotting
+        Cardano.Chain.Ssc
+        Cardano.Chain.UTxO
+        Cardano.Chain.UTxO.UTxO
+        Cardano.Chain.UTxO.Validation
+        Cardano.Chain.Update
+        Cardano.Chain.Update.Proposal
+        Cardano.Chain.Update.Validation.Endorsement
+        Cardano.Chain.Update.Validation.Interface
+        Cardano.Chain.Update.Validation.Registration
+        Cardano.Chain.Update.Validation.Voting
+        Cardano.Chain.Update.Vote
+        Cardano.Chain.ValidationMode
+
+    hs-source-dirs:     src
+    other-modules:
+        Cardano.Chain.Block.Block
+        Cardano.Chain.Block.Body
+        Cardano.Chain.Block.Boundary
+        Cardano.Chain.Block.Header
+        Cardano.Chain.Block.Proof
+        Cardano.Chain.Block.Validation
+        Cardano.Chain.Block.ValidationMode
+        Cardano.Chain.Byron.API.Common
+        Cardano.Chain.Byron.API.Mempool
+        Cardano.Chain.Byron.API.Protocol
+        Cardano.Chain.Byron.API.Validation
+        Cardano.Chain.Common.AddrAttributes
+        Cardano.Chain.Common.AddrSpendingData
+        Cardano.Chain.Common.Address
+        Cardano.Chain.Common.AddressHash
+        Cardano.Chain.Common.Attributes
+        Cardano.Chain.Common.BlockCount
+        Cardano.Chain.Common.CBOR
+        Cardano.Chain.Common.ChainDifficulty
+        Cardano.Chain.Common.Compact
+        Cardano.Chain.Common.KeyHash
+        Cardano.Chain.Common.Lovelace
+        Cardano.Chain.Common.LovelacePortion
+        Cardano.Chain.Common.Merkle
+        Cardano.Chain.Common.NetworkMagic
+        Cardano.Chain.Common.TxFeePolicy
+        Cardano.Chain.Common.TxSizeLinear
+        Cardano.Chain.Delegation.Certificate
+        Cardano.Chain.Delegation.Map
+        Cardano.Chain.Delegation.Payload
+        Cardano.Chain.Genesis.AvvmBalances
+        Cardano.Chain.Genesis.Config
+        Cardano.Chain.Genesis.Data
+        Cardano.Chain.Genesis.Delegation
+        Cardano.Chain.Genesis.Generate
+        Cardano.Chain.Genesis.Hash
+        Cardano.Chain.Genesis.Initializer
+        Cardano.Chain.Genesis.KeyHashes
+        Cardano.Chain.Genesis.NonAvvmBalances
+        Cardano.Chain.Genesis.Spec
+        Cardano.Chain.Slotting.EpochAndSlotCount
+        Cardano.Chain.Slotting.EpochNumber
+        Cardano.Chain.Slotting.EpochSlots
+        Cardano.Chain.Slotting.SlotCount
+        Cardano.Chain.Slotting.SlotNumber
+        Cardano.Chain.UTxO.Compact
+        Cardano.Chain.UTxO.GenesisUTxO
+        Cardano.Chain.UTxO.Tx
+        Cardano.Chain.UTxO.TxAux
+        Cardano.Chain.UTxO.TxPayload
+        Cardano.Chain.UTxO.UTxOConfiguration
+        Cardano.Chain.UTxO.TxProof
+        Cardano.Chain.UTxO.TxWitness
+        Cardano.Chain.UTxO.ValidationMode
+        Cardano.Chain.Update.ApplicationName
+        Cardano.Chain.Update.InstallerHash
+        Cardano.Chain.Update.Payload
+        Cardano.Chain.Update.Proof
+        Cardano.Chain.Update.ProtocolParameters
+        Cardano.Chain.Update.ProtocolParametersUpdate
+        Cardano.Chain.Update.ProtocolVersion
+        Cardano.Chain.Update.SoftforkRule
+        Cardano.Chain.Update.SoftwareVersion
+        Cardano.Chain.Update.SystemTag
+        Cardano.Chain.Update.Validation.Interface.ProtocolVersionBump
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson,
+        base58-bytestring,
+        bimap >=0.4 && <0.6,
+        binary,
+        bytestring,
+        canonical-json,
+        cardano-crypto,
+        cardano-crypto-wrapper,
+        cardano-ledger-binary >=1.0 && <1.5,
+        cardano-prelude,
+        cborg,
+        containers,
+        contra-tracer,
+        cryptonite,
+        Cabal,
+        digest,
+        directory,
+        filepath,
+        formatting,
+        heapwords,
+        nothunks,
+        quiet,
+        resourcet,
+        streaming,
+        streaming-binary >=0.2 && <0.4,
+        streaming-bytestring,
+        text,
+        time,
+        vector
+
+test-suite cardano-ledger-byron-test
+    type:               exitcode-stdio-1.0
+    main-is:            test.hs
+    hs-source-dirs:     test
+    other-modules:
+        Test.Cardano.Chain.Block.CBOR
+        Test.Cardano.Chain.Block.Gen
+        Test.Cardano.Chain.Block.Model
+        Test.Cardano.Chain.Block.Model.Examples
+        Test.Cardano.Chain.Block.Size
+        Test.Cardano.Chain.Block.Validation
+        Test.Cardano.Chain.Block.ValidationMode
+        Test.Cardano.Chain.Byron.API
+        Test.Cardano.Chain.Buildable
+        Test.Cardano.Chain.Common.Address
+        Test.Cardano.Chain.Common.Attributes
+        Test.Cardano.Chain.Common.CBOR
+        Test.Cardano.Chain.Common.Compact
+        Test.Cardano.Chain.Common.Example
+        Test.Cardano.Chain.Common.Gen
+        Test.Cardano.Chain.Common.Lovelace
+        Test.Cardano.Chain.Config
+        Test.Cardano.Chain.Delegation.CBOR
+        Test.Cardano.Chain.Delegation.Certificate
+        Test.Cardano.Chain.Delegation.Example
+        Test.Cardano.Chain.Delegation.Gen
+        Test.Cardano.Chain.Delegation.Model
+        Test.Cardano.Chain.Elaboration.Block
+        Test.Cardano.Chain.Elaboration.Delegation
+        Test.Cardano.Chain.Elaboration.Keys
+        Test.Cardano.Chain.Elaboration.Update
+        Test.Cardano.Chain.Elaboration.UTxO
+        Test.Cardano.Chain.Epoch.File
+        Test.Cardano.Chain.Genesis.CBOR
+        Test.Cardano.Chain.Genesis.Dummy
+        Test.Cardano.Chain.Genesis.Example
+        Test.Cardano.Chain.Genesis.Gen
+        Test.Cardano.Chain.Genesis.Json
+        Test.Cardano.Chain.MempoolPayload.CBOR
+        Test.Cardano.Chain.MempoolPayload.Example
+        Test.Cardano.Chain.MempoolPayload.Gen
+        Test.Cardano.Chain.Ssc.CBOR
+        Test.Cardano.Chain.Slotting.CBOR
+        Test.Cardano.Chain.Slotting.Example
+        Test.Cardano.Chain.Slotting.Gen
+        Test.Cardano.Chain.Slotting.Properties
+        Test.Cardano.Chain.UTxO.CBOR
+        Test.Cardano.Chain.UTxO.Compact
+        Test.Cardano.Chain.UTxO.Example
+        Test.Cardano.Chain.UTxO.Gen
+        Test.Cardano.Chain.UTxO.Model
+        Test.Cardano.Chain.UTxO.ValidationMode
+        Test.Cardano.Chain.Update.CBOR
+        Test.Cardano.Chain.Update.Example
+        Test.Cardano.Chain.Update.Gen
+        Test.Cardano.Chain.Update.Properties
+        Test.Cardano.Mirror
+        Test.Options
+        GetDataFileName
+        Paths_cardano_ledger_byron
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+        "-with-rtsopts=-K450K -M500M"
+
+    build-depends:
+        base,
+        base16-bytestring >=1,
+        bimap,
+        bytestring,
+        cardano-crypto,
+        cardano-crypto-test,
+        cardano-crypto-wrapper,
+        cardano-ledger-binary,
+        cardano-ledger-binary:testlib,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-prelude-test,
+        containers,
+        byron-spec-chain,
+        byron-spec-ledger,
+        directory,
+        filepath,
+        formatting,
+        generic-monoid,
+        heapwords,
+        hedgehog >=1.0.4,
+        microlens,
+        resourcet,
+        small-steps,
+        small-steps-test,
+        streaming,
+        tasty,
+        tasty-hedgehog,
+        text,
+        time,
+        vector
+
+test-suite epoch-validation-normal-form-test
+    type:               exitcode-stdio-1.0
+    main-is:            NormalFormTest.hs
+    hs-source-dirs:     test
+    other-modules:
+        Test.Cardano.Chain.Block.Validation
+        Test.Cardano.Chain.Config
+        Test.Cardano.Mirror
+        Test.Options
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+        "-with-rtsopts=-K450K -M500M"
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger,
+        cardano-ledger-binary,
+        cardano-crypto-wrapper,
+        cardano-prelude,
+        cardano-prelude-test,
+        directory,
+        filepath,
+        hedgehog >=1.0.4,
+        resourcet,
+        silently,
+        streaming,
+        tasty,
+        tasty-hedgehog
+
+    if !flag(test-normal-form)
+        buildable: False

--- a/_sources/cardano-ledger-byron/1.0.0.4/meta.toml
+++ b/_sources/cardano-ledger-byron/1.0.0.4/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-01-26T10:34:07Z
 github = { repo = "IntersectMBO/cardano-ledger", rev = "6e2d37cc0f47bd02e89b4ce9f78b59c35c958e96" }
 subdir = 'eras/byron/ledger/impl'
+
+[[revisions]]
+number = 1
+timestamp = 2025-03-22T21:54:54Z

--- a/_sources/cardano-ledger-byron/1.0.0.4/revisions/1.cabal
+++ b/_sources/cardano-ledger-byron/1.0.0.4/revisions/1.cabal
@@ -1,0 +1,400 @@
+cabal-version:      3.0
+name:               cardano-ledger-byron
+version:            1.0.0.4
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+synopsis:           The blockchain layer of Cardano during the Byron era
+description:        The blockchain layer of Cardano during the Byron era
+category:           Currency
+build-type:         Simple
+data-files:
+    golden/cbor/block/BlockSignature
+    golden/cbor/block/Body
+    golden/cbor/block/BoundaryBlockHeader
+    golden/cbor/block/BoundaryBody
+    golden/cbor/block/BoundaryConsensusData
+    golden/cbor/block/BoundaryProof
+    golden/cbor/block/ExtraBodyData
+    golden/cbor/block/Header
+    golden/cbor/block/HeaderHash
+    golden/cbor/block/Proof
+    golden/cbor/block/StaticConfig_GCSpec
+    golden/cbor/block/ToSign
+    golden/cbor/common/Address
+    golden/cbor/common/Address0
+    golden/cbor/common/Address1
+    golden/cbor/common/Address2
+    golden/cbor/common/Address3
+    golden/cbor/common/Address4
+    golden/cbor/common/AddrSpendingData_Redeem
+    golden/cbor/common/AddrSpendingData_VerKey
+    golden/cbor/common/AddrType_R
+    golden/cbor/common/AddrType_VK
+    golden/cbor/common/Attributes
+    golden/cbor/common/BlockCount
+    golden/cbor/common/ChainDifficulty
+    golden/cbor/common/KeyHash
+    golden/cbor/common/Lovelace
+    golden/cbor/common/LovelacePortion
+    golden/cbor/common/MerkleRoot
+    golden/cbor/common/MerkleTree
+    golden/cbor/common/TxFeePolicy_Linear
+    golden/cbor/common/TxSizeLinear
+    golden/cbor/delegation/Certificate
+    golden/cbor/delegation/DlgPayload
+    golden/cbor/mempoolpayload/MempoolPayload
+    golden/cbor/mempoolpayload/MempoolPayload1
+    golden/cbor/mempoolpayload/MempoolPayload2
+    golden/cbor/mempoolpayload/MempoolPayload3
+    golden/cbor/slotting/EpochAndSlotCount
+    golden/cbor/slotting/EpochNumber
+    golden/cbor/slotting/EpochSlots
+    golden/cbor/slotting/SlotNumber
+    golden/cbor/ssc/Commitment
+    golden/cbor/ssc/CommitmentsMap
+    golden/cbor/ssc/InnerSharesMap
+    golden/cbor/ssc/Opening
+    golden/cbor/ssc/OpeningsMap
+    golden/cbor/ssc/SharesMap
+    golden/cbor/ssc/SignedCommitment
+    golden/cbor/ssc/SscPayload_CertificatesPayload
+    golden/cbor/ssc/SscPayload_CommitmentsPayload
+    golden/cbor/ssc/SscPayload_OpeningsPayload
+    golden/cbor/ssc/SscPayload_SharesPayload
+    golden/cbor/ssc/SscProof_CertificatesProof
+    golden/cbor/ssc/SscProof_CommitmentsProof
+    golden/cbor/ssc/SscProof_OpeningsProof
+    golden/cbor/ssc/SscProof_SharesProof
+    golden/cbor/ssc/VssCertificate
+    golden/cbor/ssc/VssCertificatesHash
+    golden/cbor/ssc/VssCertificatesMap
+    golden/cbor/update/ApplicationName
+    golden/cbor/update/AttackTarget_NetworkAddressTarget
+    golden/cbor/update/AttackTarget_PubKeyAddressTarget
+    golden/cbor/update/BlockHeader_Boundary
+    golden/cbor/update/CommitmentSignature
+    golden/cbor/update/HashRaw
+    golden/cbor/update/HashTx
+    golden/cbor/update/InstallerHash
+    golden/cbor/update/Payload
+    golden/cbor/update/Proof
+    golden/cbor/update/Proposal
+    golden/cbor/update/ProposalBody
+    golden/cbor/update/ProtocolParameters
+    golden/cbor/update/ProtocolParametersUpdate
+    golden/cbor/update/ProtocolVersion
+    golden/cbor/update/SharesDistribution
+    golden/cbor/update/SoftforkRule
+    golden/cbor/update/SoftwareVersion
+    golden/cbor/update/StaticConfig_GCSpec
+    golden/cbor/update/StaticConfig_GCSrc
+    golden/cbor/update/SystemTag
+    golden/cbor/update/UpId
+    golden/cbor/update/Vote
+    golden/cbor/utxo/HashTx
+    golden/cbor/utxo/Tx
+    golden/cbor/utxo/TxAttributes
+    golden/cbor/utxo/TxId
+    golden/cbor/utxo/TxInList
+    golden/cbor/utxo/TxIn_Utxo
+    golden/cbor/utxo/TxInWitness_RedeemWitness
+    golden/cbor/utxo/TxInWitness_VKWitness
+    golden/cbor/utxo/TxOut
+    golden/cbor/utxo/TxOut1
+    golden/cbor/utxo/TxOutList
+    golden/cbor/utxo/TxOutList1
+    golden/cbor/utxo/TxPayload1
+    golden/cbor/utxo/TxProof
+    golden/cbor/utxo/TxSig
+    golden/cbor/utxo/TxSigData
+    golden/cbor/utxo/TxWitness
+    golden/json/genesis/GenesisData0_Legacy_HasNetworkMagic
+
+data-dir:           test
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+flag test-normal-form
+    description: Test ledger state normal form during epoch validation
+    default:     False
+    manual:      True
+
+library
+    exposed-modules:
+        Cardano.Chain.Block
+        Cardano.Chain.Byron.API
+        Cardano.Chain.Common
+        Cardano.Chain.Constants
+        Cardano.Chain.Delegation
+        Cardano.Chain.Delegation.Validation.Activation
+        Cardano.Chain.Delegation.Validation.Interface
+        Cardano.Chain.Delegation.Validation.Scheduling
+        Cardano.Chain.Epoch.File
+        Cardano.Chain.Epoch.Validation
+        Cardano.Chain.Genesis
+        Cardano.Chain.MempoolPayload
+        Cardano.Chain.ProtocolConstants
+        Cardano.Chain.Slotting
+        Cardano.Chain.Ssc
+        Cardano.Chain.UTxO
+        Cardano.Chain.UTxO.UTxO
+        Cardano.Chain.UTxO.Validation
+        Cardano.Chain.Update
+        Cardano.Chain.Update.Proposal
+        Cardano.Chain.Update.Validation.Endorsement
+        Cardano.Chain.Update.Validation.Interface
+        Cardano.Chain.Update.Validation.Registration
+        Cardano.Chain.Update.Validation.Voting
+        Cardano.Chain.Update.Vote
+        Cardano.Chain.ValidationMode
+
+    hs-source-dirs:     src
+    other-modules:
+        Cardano.Chain.Block.Block
+        Cardano.Chain.Block.Body
+        Cardano.Chain.Block.Boundary
+        Cardano.Chain.Block.Header
+        Cardano.Chain.Block.Proof
+        Cardano.Chain.Block.Validation
+        Cardano.Chain.Block.ValidationMode
+        Cardano.Chain.Byron.API.Common
+        Cardano.Chain.Byron.API.Mempool
+        Cardano.Chain.Byron.API.Protocol
+        Cardano.Chain.Byron.API.Validation
+        Cardano.Chain.Common.AddrAttributes
+        Cardano.Chain.Common.AddrSpendingData
+        Cardano.Chain.Common.Address
+        Cardano.Chain.Common.AddressHash
+        Cardano.Chain.Common.Attributes
+        Cardano.Chain.Common.BlockCount
+        Cardano.Chain.Common.CBOR
+        Cardano.Chain.Common.ChainDifficulty
+        Cardano.Chain.Common.Compact
+        Cardano.Chain.Common.KeyHash
+        Cardano.Chain.Common.Lovelace
+        Cardano.Chain.Common.LovelacePortion
+        Cardano.Chain.Common.Merkle
+        Cardano.Chain.Common.NetworkMagic
+        Cardano.Chain.Common.TxFeePolicy
+        Cardano.Chain.Common.TxSizeLinear
+        Cardano.Chain.Delegation.Certificate
+        Cardano.Chain.Delegation.Map
+        Cardano.Chain.Delegation.Payload
+        Cardano.Chain.Genesis.AvvmBalances
+        Cardano.Chain.Genesis.Config
+        Cardano.Chain.Genesis.Data
+        Cardano.Chain.Genesis.Delegation
+        Cardano.Chain.Genesis.Generate
+        Cardano.Chain.Genesis.Hash
+        Cardano.Chain.Genesis.Initializer
+        Cardano.Chain.Genesis.KeyHashes
+        Cardano.Chain.Genesis.NonAvvmBalances
+        Cardano.Chain.Genesis.Spec
+        Cardano.Chain.Slotting.EpochAndSlotCount
+        Cardano.Chain.Slotting.EpochNumber
+        Cardano.Chain.Slotting.EpochSlots
+        Cardano.Chain.Slotting.SlotCount
+        Cardano.Chain.Slotting.SlotNumber
+        Cardano.Chain.UTxO.Compact
+        Cardano.Chain.UTxO.GenesisUTxO
+        Cardano.Chain.UTxO.Tx
+        Cardano.Chain.UTxO.TxAux
+        Cardano.Chain.UTxO.TxPayload
+        Cardano.Chain.UTxO.UTxOConfiguration
+        Cardano.Chain.UTxO.TxProof
+        Cardano.Chain.UTxO.TxWitness
+        Cardano.Chain.UTxO.ValidationMode
+        Cardano.Chain.Update.ApplicationName
+        Cardano.Chain.Update.InstallerHash
+        Cardano.Chain.Update.Payload
+        Cardano.Chain.Update.Proof
+        Cardano.Chain.Update.ProtocolParameters
+        Cardano.Chain.Update.ProtocolParametersUpdate
+        Cardano.Chain.Update.ProtocolVersion
+        Cardano.Chain.Update.SoftforkRule
+        Cardano.Chain.Update.SoftwareVersion
+        Cardano.Chain.Update.SystemTag
+        Cardano.Chain.Update.Validation.Interface.ProtocolVersionBump
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson,
+        base58-bytestring,
+        bimap >=0.4 && <0.6,
+        binary,
+        bytestring,
+        canonical-json,
+        cardano-crypto,
+        cardano-crypto-wrapper,
+        cardano-ledger-binary >=1.0 && <1.5,
+        cardano-prelude,
+        cborg,
+        containers,
+        contra-tracer,
+        cryptonite,
+        Cabal,
+        digest,
+        directory,
+        filepath,
+        formatting,
+        heapwords,
+        nothunks,
+        quiet,
+        resourcet,
+        streaming,
+        streaming-binary >=0.2 && <0.4,
+        streaming-bytestring,
+        text,
+        time,
+        vector
+
+test-suite cardano-ledger-byron-test
+    type:               exitcode-stdio-1.0
+    main-is:            test.hs
+    hs-source-dirs:     test
+    other-modules:
+        Test.Cardano.Chain.Block.CBOR
+        Test.Cardano.Chain.Block.Gen
+        Test.Cardano.Chain.Block.Model
+        Test.Cardano.Chain.Block.Model.Examples
+        Test.Cardano.Chain.Block.Size
+        Test.Cardano.Chain.Block.Validation
+        Test.Cardano.Chain.Block.ValidationMode
+        Test.Cardano.Chain.Byron.API
+        Test.Cardano.Chain.Buildable
+        Test.Cardano.Chain.Common.Address
+        Test.Cardano.Chain.Common.Attributes
+        Test.Cardano.Chain.Common.CBOR
+        Test.Cardano.Chain.Common.Compact
+        Test.Cardano.Chain.Common.Example
+        Test.Cardano.Chain.Common.Gen
+        Test.Cardano.Chain.Common.Lovelace
+        Test.Cardano.Chain.Config
+        Test.Cardano.Chain.Delegation.CBOR
+        Test.Cardano.Chain.Delegation.Certificate
+        Test.Cardano.Chain.Delegation.Example
+        Test.Cardano.Chain.Delegation.Gen
+        Test.Cardano.Chain.Delegation.Model
+        Test.Cardano.Chain.Elaboration.Block
+        Test.Cardano.Chain.Elaboration.Delegation
+        Test.Cardano.Chain.Elaboration.Keys
+        Test.Cardano.Chain.Elaboration.Update
+        Test.Cardano.Chain.Elaboration.UTxO
+        Test.Cardano.Chain.Epoch.File
+        Test.Cardano.Chain.Genesis.CBOR
+        Test.Cardano.Chain.Genesis.Dummy
+        Test.Cardano.Chain.Genesis.Example
+        Test.Cardano.Chain.Genesis.Gen
+        Test.Cardano.Chain.Genesis.Json
+        Test.Cardano.Chain.MempoolPayload.CBOR
+        Test.Cardano.Chain.MempoolPayload.Example
+        Test.Cardano.Chain.MempoolPayload.Gen
+        Test.Cardano.Chain.Ssc.CBOR
+        Test.Cardano.Chain.Slotting.CBOR
+        Test.Cardano.Chain.Slotting.Example
+        Test.Cardano.Chain.Slotting.Gen
+        Test.Cardano.Chain.Slotting.Properties
+        Test.Cardano.Chain.UTxO.CBOR
+        Test.Cardano.Chain.UTxO.Compact
+        Test.Cardano.Chain.UTxO.Example
+        Test.Cardano.Chain.UTxO.Gen
+        Test.Cardano.Chain.UTxO.Model
+        Test.Cardano.Chain.UTxO.ValidationMode
+        Test.Cardano.Chain.Update.CBOR
+        Test.Cardano.Chain.Update.Example
+        Test.Cardano.Chain.Update.Gen
+        Test.Cardano.Chain.Update.Properties
+        Test.Cardano.Mirror
+        Test.Options
+        GetDataFileName
+        Paths_cardano_ledger_byron
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+        "-with-rtsopts=-K450K -M500M"
+
+    build-depends:
+        base,
+        base16-bytestring >=1,
+        bimap,
+        bytestring,
+        cardano-crypto,
+        cardano-crypto-test,
+        cardano-crypto-wrapper,
+        cardano-ledger-binary,
+        cardano-ledger-binary:testlib,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-prelude-test,
+        containers,
+        byron-spec-chain,
+        byron-spec-ledger,
+        directory,
+        filepath,
+        formatting,
+        heapwords,
+        hedgehog >=1.0.4,
+        microlens,
+        resourcet,
+        small-steps,
+        small-steps-test,
+        streaming,
+        tasty,
+        tasty-hedgehog,
+        text,
+        time,
+        vector
+
+test-suite epoch-validation-normal-form-test
+    type:               exitcode-stdio-1.0
+    main-is:            NormalFormTest.hs
+    hs-source-dirs:     test
+    other-modules:
+        Test.Cardano.Chain.Block.Validation
+        Test.Cardano.Chain.Config
+        Test.Cardano.Mirror
+        Test.Options
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+        "-with-rtsopts=-K450K -M500M"
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger,
+        cardano-ledger-binary,
+        cardano-crypto-wrapper,
+        cardano-prelude,
+        cardano-prelude-test,
+        directory,
+        filepath,
+        hedgehog >=1.0.4,
+        resourcet,
+        silently,
+        streaming,
+        tasty,
+        tasty-hedgehog
+
+    if !flag(test-normal-form)
+        buildable: False

--- a/_sources/cardano-ledger-byron/1.0.1.0/meta.toml
+++ b/_sources/cardano-ledger-byron/1.0.1.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'eras/byron/ledger/impl'
 [[revisions]]
 number = 1
 timestamp = 2025-03-20T18:42:33Z
+
+[[revisions]]
+number = 2
+timestamp = 2025-03-22T21:54:46Z

--- a/_sources/cardano-ledger-byron/1.0.1.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-byron/1.0.1.0/revisions/2.cabal
@@ -1,0 +1,399 @@
+cabal-version:      3.0
+name:               cardano-ledger-byron
+version:            1.0.1.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+synopsis:           The blockchain layer of Cardano during the Byron era
+description:        The blockchain layer of Cardano during the Byron era
+category:           Currency
+build-type:         Simple
+data-files:
+    golden/cbor/block/BlockSignature
+    golden/cbor/block/Body
+    golden/cbor/block/BoundaryBlockHeader
+    golden/cbor/block/BoundaryBody
+    golden/cbor/block/BoundaryConsensusData
+    golden/cbor/block/BoundaryProof
+    golden/cbor/block/ExtraBodyData
+    golden/cbor/block/Header
+    golden/cbor/block/HeaderHash
+    golden/cbor/block/Proof
+    golden/cbor/block/StaticConfig_GCSpec
+    golden/cbor/block/ToSign
+    golden/cbor/common/Address
+    golden/cbor/common/Address0
+    golden/cbor/common/Address1
+    golden/cbor/common/Address2
+    golden/cbor/common/Address3
+    golden/cbor/common/Address4
+    golden/cbor/common/AddrSpendingData_Redeem
+    golden/cbor/common/AddrSpendingData_VerKey
+    golden/cbor/common/AddrType_R
+    golden/cbor/common/AddrType_VK
+    golden/cbor/common/Attributes
+    golden/cbor/common/BlockCount
+    golden/cbor/common/ChainDifficulty
+    golden/cbor/common/KeyHash
+    golden/cbor/common/Lovelace
+    golden/cbor/common/LovelacePortion
+    golden/cbor/common/MerkleRoot
+    golden/cbor/common/MerkleTree
+    golden/cbor/common/TxFeePolicy_Linear
+    golden/cbor/common/TxSizeLinear
+    golden/cbor/delegation/Certificate
+    golden/cbor/delegation/DlgPayload
+    golden/cbor/mempoolpayload/MempoolPayload
+    golden/cbor/mempoolpayload/MempoolPayload1
+    golden/cbor/mempoolpayload/MempoolPayload2
+    golden/cbor/mempoolpayload/MempoolPayload3
+    golden/cbor/slotting/EpochAndSlotCount
+    golden/cbor/slotting/EpochNumber
+    golden/cbor/slotting/EpochSlots
+    golden/cbor/slotting/SlotNumber
+    golden/cbor/ssc/Commitment
+    golden/cbor/ssc/CommitmentsMap
+    golden/cbor/ssc/InnerSharesMap
+    golden/cbor/ssc/Opening
+    golden/cbor/ssc/OpeningsMap
+    golden/cbor/ssc/SharesMap
+    golden/cbor/ssc/SignedCommitment
+    golden/cbor/ssc/SscPayload_CertificatesPayload
+    golden/cbor/ssc/SscPayload_CommitmentsPayload
+    golden/cbor/ssc/SscPayload_OpeningsPayload
+    golden/cbor/ssc/SscPayload_SharesPayload
+    golden/cbor/ssc/SscProof_CertificatesProof
+    golden/cbor/ssc/SscProof_CommitmentsProof
+    golden/cbor/ssc/SscProof_OpeningsProof
+    golden/cbor/ssc/SscProof_SharesProof
+    golden/cbor/ssc/VssCertificate
+    golden/cbor/ssc/VssCertificatesHash
+    golden/cbor/ssc/VssCertificatesMap
+    golden/cbor/update/ApplicationName
+    golden/cbor/update/AttackTarget_NetworkAddressTarget
+    golden/cbor/update/AttackTarget_PubKeyAddressTarget
+    golden/cbor/update/BlockHeader_Boundary
+    golden/cbor/update/CommitmentSignature
+    golden/cbor/update/HashRaw
+    golden/cbor/update/HashTx
+    golden/cbor/update/InstallerHash
+    golden/cbor/update/Payload
+    golden/cbor/update/Proof
+    golden/cbor/update/Proposal
+    golden/cbor/update/ProposalBody
+    golden/cbor/update/ProtocolParameters
+    golden/cbor/update/ProtocolParametersUpdate
+    golden/cbor/update/ProtocolVersion
+    golden/cbor/update/SharesDistribution
+    golden/cbor/update/SoftforkRule
+    golden/cbor/update/SoftwareVersion
+    golden/cbor/update/StaticConfig_GCSpec
+    golden/cbor/update/StaticConfig_GCSrc
+    golden/cbor/update/SystemTag
+    golden/cbor/update/UpId
+    golden/cbor/update/Vote
+    golden/cbor/utxo/HashTx
+    golden/cbor/utxo/Tx
+    golden/cbor/utxo/TxAttributes
+    golden/cbor/utxo/TxId
+    golden/cbor/utxo/TxInList
+    golden/cbor/utxo/TxIn_Utxo
+    golden/cbor/utxo/TxInWitness_RedeemWitness
+    golden/cbor/utxo/TxInWitness_VKWitness
+    golden/cbor/utxo/TxOut
+    golden/cbor/utxo/TxOut1
+    golden/cbor/utxo/TxOutList
+    golden/cbor/utxo/TxOutList1
+    golden/cbor/utxo/TxPayload1
+    golden/cbor/utxo/TxProof
+    golden/cbor/utxo/TxSig
+    golden/cbor/utxo/TxSigData
+    golden/cbor/utxo/TxWitness
+    golden/json/genesis/GenesisData0_Legacy_HasNetworkMagic
+
+data-dir:           test
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+flag test-normal-form
+    description: Test ledger state normal form during epoch validation
+    default:     False
+    manual:      True
+
+library
+    exposed-modules:
+        Cardano.Chain.Block
+        Cardano.Chain.Byron.API
+        Cardano.Chain.Common
+        Cardano.Chain.Constants
+        Cardano.Chain.Delegation
+        Cardano.Chain.Delegation.Validation.Activation
+        Cardano.Chain.Delegation.Validation.Interface
+        Cardano.Chain.Delegation.Validation.Scheduling
+        Cardano.Chain.Epoch.File
+        Cardano.Chain.Epoch.Validation
+        Cardano.Chain.Genesis
+        Cardano.Chain.MempoolPayload
+        Cardano.Chain.ProtocolConstants
+        Cardano.Chain.Slotting
+        Cardano.Chain.Ssc
+        Cardano.Chain.UTxO
+        Cardano.Chain.UTxO.UTxO
+        Cardano.Chain.UTxO.Validation
+        Cardano.Chain.Update
+        Cardano.Chain.Update.Proposal
+        Cardano.Chain.Update.Validation.Endorsement
+        Cardano.Chain.Update.Validation.Interface
+        Cardano.Chain.Update.Validation.Registration
+        Cardano.Chain.Update.Validation.Voting
+        Cardano.Chain.Update.Vote
+        Cardano.Chain.ValidationMode
+
+    hs-source-dirs:     src
+    other-modules:
+        Cardano.Chain.Block.Block
+        Cardano.Chain.Block.Body
+        Cardano.Chain.Block.Boundary
+        Cardano.Chain.Block.Header
+        Cardano.Chain.Block.Proof
+        Cardano.Chain.Block.Validation
+        Cardano.Chain.Block.ValidationMode
+        Cardano.Chain.Byron.API.Common
+        Cardano.Chain.Byron.API.Mempool
+        Cardano.Chain.Byron.API.Protocol
+        Cardano.Chain.Byron.API.Validation
+        Cardano.Chain.Common.AddrAttributes
+        Cardano.Chain.Common.AddrSpendingData
+        Cardano.Chain.Common.Address
+        Cardano.Chain.Common.AddressHash
+        Cardano.Chain.Common.Attributes
+        Cardano.Chain.Common.BlockCount
+        Cardano.Chain.Common.CBOR
+        Cardano.Chain.Common.ChainDifficulty
+        Cardano.Chain.Common.Compact
+        Cardano.Chain.Common.KeyHash
+        Cardano.Chain.Common.Lovelace
+        Cardano.Chain.Common.LovelacePortion
+        Cardano.Chain.Common.Merkle
+        Cardano.Chain.Common.NetworkMagic
+        Cardano.Chain.Common.TxFeePolicy
+        Cardano.Chain.Common.TxSizeLinear
+        Cardano.Chain.Delegation.Certificate
+        Cardano.Chain.Delegation.Map
+        Cardano.Chain.Delegation.Payload
+        Cardano.Chain.Genesis.AvvmBalances
+        Cardano.Chain.Genesis.Config
+        Cardano.Chain.Genesis.Data
+        Cardano.Chain.Genesis.Delegation
+        Cardano.Chain.Genesis.Generate
+        Cardano.Chain.Genesis.Hash
+        Cardano.Chain.Genesis.Initializer
+        Cardano.Chain.Genesis.KeyHashes
+        Cardano.Chain.Genesis.NonAvvmBalances
+        Cardano.Chain.Genesis.Spec
+        Cardano.Chain.Slotting.EpochAndSlotCount
+        Cardano.Chain.Slotting.EpochNumber
+        Cardano.Chain.Slotting.EpochSlots
+        Cardano.Chain.Slotting.SlotCount
+        Cardano.Chain.Slotting.SlotNumber
+        Cardano.Chain.UTxO.Compact
+        Cardano.Chain.UTxO.GenesisUTxO
+        Cardano.Chain.UTxO.Tx
+        Cardano.Chain.UTxO.TxAux
+        Cardano.Chain.UTxO.TxPayload
+        Cardano.Chain.UTxO.UTxOConfiguration
+        Cardano.Chain.UTxO.TxProof
+        Cardano.Chain.UTxO.TxWitness
+        Cardano.Chain.UTxO.ValidationMode
+        Cardano.Chain.Update.ApplicationName
+        Cardano.Chain.Update.InstallerHash
+        Cardano.Chain.Update.Payload
+        Cardano.Chain.Update.Proof
+        Cardano.Chain.Update.ProtocolParameters
+        Cardano.Chain.Update.ProtocolParametersUpdate
+        Cardano.Chain.Update.ProtocolVersion
+        Cardano.Chain.Update.SoftforkRule
+        Cardano.Chain.Update.SoftwareVersion
+        Cardano.Chain.Update.SystemTag
+        Cardano.Chain.Update.Validation.Interface.ProtocolVersionBump
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson,
+        base58-bytestring,
+        bimap >=0.4 && <0.6,
+        binary,
+        bytestring,
+        canonical-json,
+        cardano-crypto,
+        cardano-crypto-wrapper ^>=1.5,
+        cardano-ledger-binary >=1.3.1 && <1.5,
+        cardano-prelude,
+        cborg,
+        containers,
+        contra-tracer,
+        cryptonite,
+        Cabal,
+        digest,
+        directory,
+        filepath,
+        formatting,
+        heapwords,
+        nothunks,
+        quiet,
+        resourcet,
+        streaming,
+        streaming-binary >=0.2 && <0.4,
+        streaming-bytestring,
+        text,
+        time,
+        vector
+
+test-suite cardano-ledger-byron-test
+    type:               exitcode-stdio-1.0
+    main-is:            test.hs
+    hs-source-dirs:     test
+    other-modules:
+        Test.Cardano.Chain.Block.CBOR
+        Test.Cardano.Chain.Block.Gen
+        Test.Cardano.Chain.Block.Model
+        Test.Cardano.Chain.Block.Model.Examples
+        Test.Cardano.Chain.Block.Size
+        Test.Cardano.Chain.Block.Validation
+        Test.Cardano.Chain.Block.ValidationMode
+        Test.Cardano.Chain.Byron.API
+        Test.Cardano.Chain.Buildable
+        Test.Cardano.Chain.Common.Address
+        Test.Cardano.Chain.Common.Attributes
+        Test.Cardano.Chain.Common.CBOR
+        Test.Cardano.Chain.Common.Compact
+        Test.Cardano.Chain.Common.Example
+        Test.Cardano.Chain.Common.Gen
+        Test.Cardano.Chain.Common.Lovelace
+        Test.Cardano.Chain.Config
+        Test.Cardano.Chain.Delegation.CBOR
+        Test.Cardano.Chain.Delegation.Certificate
+        Test.Cardano.Chain.Delegation.Example
+        Test.Cardano.Chain.Delegation.Gen
+        Test.Cardano.Chain.Delegation.Model
+        Test.Cardano.Chain.Elaboration.Block
+        Test.Cardano.Chain.Elaboration.Delegation
+        Test.Cardano.Chain.Elaboration.Keys
+        Test.Cardano.Chain.Elaboration.Update
+        Test.Cardano.Chain.Elaboration.UTxO
+        Test.Cardano.Chain.Epoch.File
+        Test.Cardano.Chain.Genesis.CBOR
+        Test.Cardano.Chain.Genesis.Dummy
+        Test.Cardano.Chain.Genesis.Example
+        Test.Cardano.Chain.Genesis.Gen
+        Test.Cardano.Chain.Genesis.Json
+        Test.Cardano.Chain.MempoolPayload.CBOR
+        Test.Cardano.Chain.MempoolPayload.Example
+        Test.Cardano.Chain.MempoolPayload.Gen
+        Test.Cardano.Chain.Ssc.CBOR
+        Test.Cardano.Chain.Slotting.CBOR
+        Test.Cardano.Chain.Slotting.Example
+        Test.Cardano.Chain.Slotting.Gen
+        Test.Cardano.Chain.Slotting.Properties
+        Test.Cardano.Chain.UTxO.CBOR
+        Test.Cardano.Chain.UTxO.Compact
+        Test.Cardano.Chain.UTxO.Example
+        Test.Cardano.Chain.UTxO.Gen
+        Test.Cardano.Chain.UTxO.Model
+        Test.Cardano.Chain.UTxO.ValidationMode
+        Test.Cardano.Chain.Update.CBOR
+        Test.Cardano.Chain.Update.Example
+        Test.Cardano.Chain.Update.Gen
+        Test.Cardano.Chain.Update.Properties
+        Test.Cardano.Mirror
+        Test.Options
+        GetDataFileName
+        Paths_cardano_ledger_byron
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+        "-with-rtsopts=-K450K -M500M"
+
+    build-depends:
+        base,
+        base16-bytestring >=1,
+        bimap,
+        bytestring,
+        cardano-crypto,
+        cardano-crypto-test,
+        cardano-crypto-wrapper,
+        cardano-ledger-binary,
+        cardano-ledger-binary:testlib,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-prelude-test,
+        containers,
+        byron-spec-chain,
+        byron-spec-ledger,
+        directory,
+        filepath,
+        formatting,
+        heapwords,
+        hedgehog >=1.0.4,
+        microlens,
+        resourcet,
+        small-steps:{small-steps, testlib} >=1.1,
+        streaming,
+        tasty,
+        tasty-hedgehog,
+        text,
+        time,
+        vector
+
+test-suite epoch-validation-normal-form-test
+    type:               exitcode-stdio-1.0
+    main-is:            NormalFormTest.hs
+    hs-source-dirs:     test
+    other-modules:
+        Test.Cardano.Chain.Block.Validation
+        Test.Cardano.Chain.Config
+        Test.Cardano.Mirror
+        Test.Options
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+        "-with-rtsopts=-K450K -M500M"
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger,
+        cardano-ledger-binary,
+        cardano-crypto-wrapper,
+        cardano-prelude,
+        cardano-prelude-test,
+        directory,
+        filepath,
+        hedgehog >=1.0.4,
+        resourcet,
+        silently,
+        streaming,
+        tasty,
+        tasty-hedgehog
+
+    if !flag(test-normal-form)
+        buildable: False

--- a/_sources/cardano-ledger-core/1.0.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.0.0.0/meta.toml
@@ -9,3 +9,7 @@ timestamp = 2024-01-25T14:10:44Z
 [[revisions]]
 number = 2
 timestamp = 2024-12-12T00:23:01Z
+
+[[revisions]]
+number = 3
+timestamp = 2025-03-22T22:01:49Z

--- a/_sources/cardano-ledger-core/1.0.0.0/revisions/3.cabal
+++ b/_sources/cardano-ledger-core/1.0.0.0/revisions/3.cabal
@@ -1,0 +1,184 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.0.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.CompactAddress
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.DPState
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMapCompact
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.12 && <4.17,
+        aeson >=2,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary <1.5,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data >=1.0 && <1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default <0.8,
+        data-default-class <0.2,
+        deepseq,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        quiet,
+        scientific,
+        set-algebra,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.0,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        tree-diff,
+        validation-selective,
+        vector-map ^>=1.0
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron-test,
+        containers,
+        deepseq,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        text,
+        vector-map
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core,
+        testlib,
+        cardano-crypto-class,
+        genvalidity,
+        genvalidity-scientific,
+        scientific

--- a/_sources/cardano-ledger-core/1.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.1.0.0/meta.toml
@@ -9,3 +9,7 @@ timestamp = 2024-01-25T14:10:44Z
 [[revisions]]
 number = 2
 timestamp = 2024-12-12T00:23:01Z
+
+[[revisions]]
+number = 3
+timestamp = 2025-03-22T22:02:03Z

--- a/_sources/cardano-ledger-core/1.1.0.0/revisions/3.cabal
+++ b/_sources/cardano-ledger-core/1.1.0.0/revisions/3.cabal
@@ -1,0 +1,186 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.1.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.CompactAddress
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.DPState
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMapCompact
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.17,
+        aeson >=2,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary >=1.0 && <1.5,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data >=1.0 && <1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default <0.8,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        quiet,
+        scientific,
+        set-algebra,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.0,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        tree-diff,
+        validation-selective,
+        vector-map ^>=1.0
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron-test,
+        containers,
+        deepseq,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        text,
+        vector-map
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core,
+        cardano-crypto-class,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific

--- a/_sources/cardano-ledger-core/1.1.0.1/meta.toml
+++ b/_sources/cardano-ledger-core/1.1.0.1/meta.toml
@@ -9,3 +9,7 @@ timestamp = 2024-01-25T14:10:44Z
 [[revisions]]
 number = 2
 timestamp = 2024-12-12T00:23:01Z
+
+[[revisions]]
+number = 3
+timestamp = 2025-03-22T22:02:05Z

--- a/_sources/cardano-ledger-core/1.1.0.1/revisions/3.cabal
+++ b/_sources/cardano-ledger-core/1.1.0.1/revisions/3.cabal
@@ -1,0 +1,186 @@
+cabal-version:      3.0
+name:               cardano-ledger-core
+version:            1.1.0.1
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+bug-reports:        https://github.com/input-output-hk/cardano-ledger/issues
+synopsis:
+    Core components of Cardano ledgers from the Shelley release on.
+
+description:
+    Cardano ledgers from the Shelley release onwards share a core basis rooted in
+    the Shelley ledger specification. This package abstracts a number of components
+    which we expect to be shared amongst all future ledgers implemented around this base.
+
+extra-source-files: CHANGELOG.md
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-core
+
+flag asserts
+    description: Enable assertions
+    default:     False
+
+library
+    exposed-modules:
+        Cardano.Ledger.Address
+        Cardano.Ledger.CompactAddress
+        Cardano.Ledger.AuxiliaryData
+        Cardano.Ledger.BaseTypes
+        Cardano.Ledger.BHeaderView
+        Cardano.Ledger.Block
+        Cardano.Ledger.Coin
+        Cardano.Ledger.Compactible
+        Cardano.Ledger.Core
+        Cardano.Ledger.Credential
+        Cardano.Ledger.Crypto
+        Cardano.Ledger.DPState
+        Cardano.Ledger.EpochBoundary
+        Cardano.Ledger.Era
+        Cardano.Ledger.Hashes
+        Cardano.Ledger.HKD
+        Cardano.Ledger.Keys
+        Cardano.Ledger.Keys.Bootstrap
+        Cardano.Ledger.Keys.WitVKey
+        Cardano.Ledger.Language
+        Cardano.Ledger.MemoBytes
+        Cardano.Ledger.Orphans
+        Cardano.Ledger.PoolDistr
+        Cardano.Ledger.PoolParams
+        Cardano.Ledger.Rewards
+        Cardano.Ledger.Rules.ValidationMode
+        Cardano.Ledger.SafeHash
+        Cardano.Ledger.Serialization
+        Cardano.Ledger.Slot
+        Cardano.Ledger.TxIn
+        Cardano.Ledger.UTxO
+        Cardano.Ledger.Val
+        Cardano.Ledger.UMapCompact
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Core.Era
+        Cardano.Ledger.Core.PParams
+        Cardano.Ledger.Core.Translation
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.17,
+        aeson >=2,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-ledger-binary >=1.0 && <1.5,
+        cardano-crypto,
+        cardano-crypto-class <2.2,
+        cardano-crypto-praos,
+        cardano-crypto-wrapper,
+        cardano-data >=1.0 && <1.2,
+        cardano-ledger-byron,
+        cardano-prelude,
+        cardano-slotting,
+        containers,
+        data-default <0.8,
+        data-default-class <0.2,
+        deepseq,
+        FailT,
+        groups,
+        heapwords,
+        iproute,
+        mtl,
+        microlens,
+        network,
+        nothunks,
+        partial-order,
+        quiet,
+        scientific,
+        set-algebra,
+        non-integral >=1.0,
+        primitive,
+        small-steps >=1.0,
+        cardano-strict-containers,
+        text,
+        time,
+        transformers,
+        tree-diff,
+        validation-selective,
+        vector-map ^>=1.0
+
+    if flag(asserts)
+        ghc-options: -fno-ignore-asserts
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Common
+        Test.Cardano.Ledger.Core.Address
+        Test.Cardano.Ledger.Core.Arbitrary
+        Test.Cardano.Ledger.Core.KeyPair
+        Test.Cardano.Ledger.Core.Utils
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages
+
+    build-depends:
+        base,
+        binary,
+        bytestring,
+        cardano-crypto-class,
+        cardano-ledger-core,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-byron-test,
+        containers,
+        deepseq,
+        generic-random,
+        genvalidity,
+        hspec,
+        hedgehog-quickcheck,
+        mtl,
+        nothunks,
+        primitive,
+        QuickCheck,
+        text,
+        vector-map
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-name-shadowing
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.AddressSpec
+        Test.Cardano.Ledger.BaseTypesSpec
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        aeson,
+        binary,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-ledger-core,
+        cardano-crypto-class,
+        FailT,
+        testlib,
+        genvalidity,
+        genvalidity-scientific,
+        scientific


### PR DESCRIPTION
This PR adds a revision for `cardano-ledger-core` and `cardano-ledger-byron` that adds an upper bound for `cardano-ledger-binary <1.5`, wince there was a breaking change that affected older versions of these packages. 