### PR TITLE
cardano-ledger-binary/1.4.0.0: Bump upper bound on a dependency

### DIFF
--- a/_sources/cardano-ledger-binary/1.4.0.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.4.0.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-binary'
 [[revisions]]
 number = 1
 timestamp = 2024-12-11T19:55:16Z
+
+[[revisions]]
+number = 2
+timestamp = 2025-03-26T04:25:56Z

--- a/_sources/cardano-ledger-binary/1.4.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-binary/1.4.0.0/revisions/2.cabal
@@ -1,0 +1,199 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.4.0.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/intersectmbo/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting >=0.2,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        FailT,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api >=1.27.0,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        vector,
+        vector-map ^>=1.1
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Cddl
+        Test.Cardano.Ledger.Binary.Cuddle
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting:{cardano-slotting, testlib} >=0.1.2,
+        cborg,
+        containers,
+        cuddle >=0.3.2,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        hspec-core,
+        pretty-show,
+        prettyprinter,
+        prettyprinter-ansi-terminal,
+        primitive,
+        QuickCheck,
+        quickcheck-instances <0.3.33,
+        tasty-hunit,
+        random >=1.2,
+        text,
+        typed-process,
+        unliftio,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map
+
+benchmark bench
+    type:             exitcode-stdio-1.0
+    main-is:          Bench.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        containers,
+        criterion,
+        deepseq,
+        random


### PR DESCRIPTION
`quickcheck-instances`

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
