### PR TITLE
Release consensus packages

### DIFF
--- a/_sources/ouroboros-consensus-cardano/0.23.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-cardano/0.23.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-04-03T07:46:42Z
+github = { repo = "IntersectMBO/ouroboros-consensus", rev = "aa9a7c62f5a42449f843069fc935f9239c57f800" }
+subdir = 'ouroboros-consensus-cardano'

--- a/_sources/ouroboros-consensus-cardano/0.23.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-cardano/0.23.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2025-04-03T07:46:42Z
-github = { repo = "IntersectMBO/ouroboros-consensus", rev = "aa9a7c62f5a42449f843069fc935f9239c57f800" }
+github = { repo = "IntersectMBO/ouroboros-consensus", rev = "da502c2c4d73ea177af3ab7a9630beafae4b7c6c" }
 subdir = 'ouroboros-consensus-cardano'

--- a/_sources/ouroboros-consensus-diffusion/0.21.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-diffusion/0.21.0.1/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2025-04-03T07:46:42Z
-github = { repo = "IntersectMBO/ouroboros-consensus", rev = "aa9a7c62f5a42449f843069fc935f9239c57f800" }
+github = { repo = "IntersectMBO/ouroboros-consensus", rev = "da502c2c4d73ea177af3ab7a9630beafae4b7c6c" }
 subdir = 'ouroboros-consensus-diffusion'

--- a/_sources/ouroboros-consensus-diffusion/0.21.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-diffusion/0.21.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-04-03T07:46:42Z
+github = { repo = "IntersectMBO/ouroboros-consensus", rev = "aa9a7c62f5a42449f843069fc935f9239c57f800" }
+subdir = 'ouroboros-consensus-diffusion'

--- a/_sources/ouroboros-consensus-protocol/0.11.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-protocol/0.11.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2025-03-25T16:05:50Z
 github = { repo = "IntersectMBO/ouroboros-consensus", rev = "4d73a1a53c2253db1e788b05b7ef3349bd2247ef" }
 subdir = 'ouroboros-consensus-protocol'
+
+[[revisions]]
+number = 1
+timestamp = 2025-04-03T07:46:54Z

--- a/_sources/ouroboros-consensus-protocol/0.11.0.0/revisions/1.cabal
+++ b/_sources/ouroboros-consensus-protocol/0.11.0.0/revisions/1.cabal
@@ -1,0 +1,129 @@
+cabal-version: 3.0
+name: ouroboros-consensus-protocol
+version: 0.11.0.0
+synopsis: Cardano consensus protocols
+description: Cardano consensus protocols.
+license: Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+copyright:
+  2021-2023 Input Output Global Inc (IOG), INTERSECT 2023-2024.
+
+author: IOG Engineering Team
+maintainer: operations@iohk.io
+category: Network
+extra-doc-files: CHANGELOG.md
+
+source-repository head
+  type: git
+  location: https://github.com/IntersectMBO/ouroboros-consensus
+  subdir: ouroboros-consensus-protocol
+
+flag asserts
+  description: Enable assertions
+  manual: False
+  default: False
+
+common common-lib
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-uni-patterns
+    -Wincomplete-record-updates
+    -Wpartial-fields
+    -Widentities
+    -Wredundant-constraints
+    -Wmissing-export-lists
+    -Wunused-packages
+    -Wno-unticked-promoted-constructors
+
+  if flag(asserts)
+    ghc-options: -fno-ignore-asserts
+
+common common-test
+  import: common-lib
+  ghc-options:
+    -threaded
+    -rtsopts
+
+library
+  import: common-lib
+  hs-source-dirs: src/ouroboros-consensus-protocol
+  exposed-modules:
+    Ouroboros.Consensus.Protocol.Ledger.HotKey
+    Ouroboros.Consensus.Protocol.Ledger.Util
+    Ouroboros.Consensus.Protocol.Praos
+    Ouroboros.Consensus.Protocol.Praos.Common
+    Ouroboros.Consensus.Protocol.Praos.Header
+    Ouroboros.Consensus.Protocol.Praos.VRF
+    Ouroboros.Consensus.Protocol.Praos.Views
+    Ouroboros.Consensus.Protocol.TPraos
+
+  build-depends:
+    base >=4.14 && <4.22,
+    bytestring,
+    cardano-binary,
+    cardano-crypto-class ^>=2.2,
+    cardano-ledger-binary,
+    cardano-ledger-core,
+    cardano-ledger-shelley,
+    cardano-protocol-tpraos,
+    cardano-slotting,
+    cborg,
+    containers,
+    mtl,
+    nothunks,
+    ouroboros-consensus >=0.23 && <0.25,
+    serialise,
+    text,
+
+library unstable-protocol-testlib
+  import: common-lib
+  visibility: public
+  hs-source-dirs: src/unstable-protocol-testlib
+  exposed-modules:
+    Test.Consensus.Protocol.Serialisation.Generators
+    Test.Ouroboros.Consensus.Protocol.Praos.Header
+
+  build-depends:
+    QuickCheck,
+    aeson,
+    base,
+    base16-bytestring,
+    bytestring,
+    cardano-crypto-class ^>=2.2,
+    cardano-crypto-praos ^>=2.2,
+    cardano-crypto-tests ^>=2.2,
+    cardano-ledger-binary,
+    cardano-ledger-core,
+    cardano-ledger-shelley-test,
+    cardano-protocol-tpraos,
+    cardano-slotting,
+    containers,
+    ouroboros-consensus-protocol,
+    text,
+
+test-suite protocol-test
+  import: common-test
+  type: exitcode-stdio-1.0
+  hs-source-dirs: test/protocol-test
+  main-is: Main.hs
+  other-modules:
+    Test.Consensus.Protocol.Praos.SelectView
+
+  build-depends:
+    QuickCheck,
+    base,
+    cardano-crypto-class ^>=2.2,
+    cardano-ledger-binary:testlib,
+    cardano-ledger-core ^>=1.17,
+    cardano-protocol-tpraos ^>=1.4,
+    containers,
+    ouroboros-consensus:{ouroboros-consensus, unstable-consensus-testlib},
+    ouroboros-consensus-protocol,
+    serialise,
+    tasty,
+    tasty-quickcheck,

--- a/_sources/ouroboros-consensus/0.24.0.0/meta.toml
+++ b/_sources/ouroboros-consensus/0.24.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-04-03T07:46:42Z
+github = { repo = "IntersectMBO/ouroboros-consensus", rev = "aa9a7c62f5a42449f843069fc935f9239c57f800" }
+subdir = 'ouroboros-consensus'

--- a/_sources/ouroboros-consensus/0.24.0.0/meta.toml
+++ b/_sources/ouroboros-consensus/0.24.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2025-04-03T07:46:42Z
-github = { repo = "IntersectMBO/ouroboros-consensus", rev = "aa9a7c62f5a42449f843069fc935f9239c57f800" }
+github = { repo = "IntersectMBO/ouroboros-consensus", rev = "da502c2c4d73ea177af3ab7a9630beafae4b7c6c" }
 subdir = 'ouroboros-consensus'

--- a/_sources/sop-extras/0.3.0.0/meta.toml
+++ b/_sources/sop-extras/0.3.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-04-03T07:46:54Z
+github = { repo = "IntersectMBO/ouroboros-consensus", rev = "aa9a7c62f5a42449f843069fc935f9239c57f800" }
+subdir = 'sop-extras'

--- a/_sources/sop-extras/0.3.0.0/meta.toml
+++ b/_sources/sop-extras/0.3.0.0/meta.toml
@@ -1,3 +1,3 @@
 timestamp = 2025-04-03T07:46:54Z
-github = { repo = "IntersectMBO/ouroboros-consensus", rev = "aa9a7c62f5a42449f843069fc935f9239c57f800" }
+github = { repo = "IntersectMBO/ouroboros-consensus", rev = "da502c2c4d73ea177af3ab7a9630beafae4b7c6c" }
 subdir = 'sop-extras'


### PR DESCRIPTION
- Release ouroboros-consensus 0.24.0.0
- Release ouroboros-consensus-cardano 0.23.0.0
- Revision ouroboros-consensus-diffusion 0.21.0.0
  - Relax upper bound for ouroboros-consensus 0.24.0.0
  - Tighten lower bound for sop-extras to 0.2.2
- Revision ouroboros-consensus-protocol 0.11.0.0
  - Relax upper bound for ouroboros-consensus 0.24.0.0
- Release sop-extras 0.2.3.0

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
