### PR TITLE
Added cardano-cli-10.6.0.0

### DIFF
--- a/_sources/cardano-cli/10.6.0.0/meta.toml
+++ b/_sources/cardano-cli/10.6.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-04-03T12:29:59Z
+github = { repo = "IntersectMBO/cardano-cli", rev = "83d8514856cb03959df327b2b5966f12abe61a2f" }
+subdir = 'cardano-cli'


### PR DESCRIPTION
From https://github.com/IntersectMBO/cardano-cli at 83d8514856cb03959df327b2b5966f12abe61a2f

Related release PR in `cardano-cli`: https://github.com/IntersectMBO/cardano-cli/pull/1122