### PR TITLE
Added ouroboros-consensus-cardano-0.25.0.1

### DIFF
--- a/_sources/ouroboros-consensus-cardano/0.25.0.1/meta.toml
+++ b/_sources/ouroboros-consensus-cardano/0.25.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-04-25T11:43:03Z
+github = { repo = "IntersectMBO/ouroboros-consensus", rev = "a2606dfc356a7aceb6553c3f7fd2ff16331cc48c" }
+subdir = 'ouroboros-consensus-cardano'


### PR DESCRIPTION
From https://github.com/IntersectMBO/ouroboros-consensus at ae57f6a953f7f0f907b7278b6f2c2ca34b6879fc

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
