### PR TITLE
Added cardano-api-10.16.3.0

### DIFF
--- a/_sources/cardano-api/10.16.3.0/meta.toml
+++ b/_sources/cardano-api/10.16.3.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-05-26T19:51:53Z
+github = { repo = "IntersectMBO/cardano-api", rev = "6c60253618590781f664469da62ed5361c86ea1e" }
+subdir = 'cardano-api'


### PR DESCRIPTION
From https://github.com/IntersectMBO/cardano-api at 6c60253618590781f664469da62ed5361c86ea1e

Related release PR in cardano-api: https://github.com/IntersectMBO/cardano-api/pull/850