### PR TITLE
add iohk-monitoring-0.2.1.2 and three lobemo-backend-* bumps

### DIFF
--- a/_sources/iohk-monitoring/0.2.1.2/meta.toml
+++ b/_sources/iohk-monitoring/0.2.1.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-06-04T08:00:00Z
+github = { repo = "input-output-hk/iohk-monitoring-framework", rev = "1c8a7704003d453c8633f290a8101248a9874b70" }
+subdir = 'iohk-monitoring'

--- a/_sources/lobemo-backend-aggregation/0.1.0.3/meta.toml
+++ b/_sources/lobemo-backend-aggregation/0.1.0.3/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-06-04T08:00:00Z
+github = { repo = "input-output-hk/iohk-monitoring-framework", rev = "1c8a7704003d453c8633f290a8101248a9874b70" }
+subdir = 'plugins/backend-aggregation'

--- a/_sources/lobemo-backend-ekg/0.2.0.1/meta.toml
+++ b/_sources/lobemo-backend-ekg/0.2.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-06-04T08:00:00Z
+github = { repo = "input-output-hk/iohk-monitoring-framework", rev = "1c8a7704003d453c8633f290a8101248a9874b70" }
+subdir = 'plugins/backend-ekg'

--- a/_sources/lobemo-backend-monitoring/0.1.0.3/meta.toml
+++ b/_sources/lobemo-backend-monitoring/0.1.0.3/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-06-04T08:00:00Z
+github = { repo = "input-output-hk/iohk-monitoring-framework", rev = "1c8a7704003d453c8633f290a8101248a9874b70" }
+subdir = 'plugins/backend-monitoring'


### PR DESCRIPTION
Adds
* iohk-monitoring-0.2.1.2
* lobemo-backend-aggregation-0.1.0.3
* lobemo-backend-ekg-0.2.0.1
* lobemo-backend-monitoring-0.1.0.3

from `input-output-hk/iohk-monitoring-framework` @ `1c8a7704003d453c8633f290a8101248a9874b70`