### PR TITLE
ouroboros-network-framework/0.18.0.1: Bump base dependency in all components

### DIFF
--- a/_sources/ouroboros-network-framework/0.18.0.1/meta.toml
+++ b/_sources/ouroboros-network-framework/0.18.0.1/meta.toml
@@ -5,3 +5,7 @@ subdir = 'ouroboros-network-framework'
 [[revisions]]
 number = 1
 timestamp = 2025-06-19T23:32:17Z
+
+[[revisions]]
+number = 2
+timestamp = 2025-06-20T04:57:28Z

--- a/_sources/ouroboros-network-framework/0.18.0.1/revisions/2.cabal
+++ b/_sources/ouroboros-network-framework/0.18.0.1/revisions/2.cabal
@@ -1,0 +1,360 @@
+cabal-version: 3.0
+name: ouroboros-network-framework
+version: 0.18.0.1
+synopsis: Ouroboros network framework
+description: Ouroboros network framework.
+license: Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+
+copyright: 2019-2023 Input Output Global Inc (IOG), 2023-2025 Intersect
+author: Alexander Vieth, Duncan Coutts, Marcin Szamotulski
+maintainer: marcin.szamotulski@iohk.io
+category: Network
+build-type: Simple
+extra-doc-files: CHANGELOG.md
+
+flag ipv6
+  description: Enable IPv6 test cases
+  manual: True
+  -- Default to False since travis lacks IPv6 support
+  default: False
+
+library
+  exposed-modules:
+    Data.Cache
+    Data.Wedge
+    NoThunks.Class.Orphans
+    Ouroboros.Network.Channel
+    Ouroboros.Network.ConnectionHandler
+    Ouroboros.Network.ConnectionId
+    Ouroboros.Network.ConnectionManager.ConnMap
+    Ouroboros.Network.ConnectionManager.Core
+    Ouroboros.Network.ConnectionManager.InformationChannel
+    Ouroboros.Network.ConnectionManager.State
+    Ouroboros.Network.ConnectionManager.Types
+    Ouroboros.Network.Context
+    Ouroboros.Network.Driver
+    Ouroboros.Network.Driver.Limits
+    Ouroboros.Network.Driver.Simple
+    Ouroboros.Network.Driver.Stateful
+    Ouroboros.Network.ErrorPolicy
+    Ouroboros.Network.IOManager
+    Ouroboros.Network.InboundGovernor
+    Ouroboros.Network.InboundGovernor.Event
+    Ouroboros.Network.InboundGovernor.State
+    Ouroboros.Network.Mux
+    Ouroboros.Network.MuxMode
+    Ouroboros.Network.Protocol.Handshake
+    Ouroboros.Network.Protocol.Handshake.Client
+    Ouroboros.Network.Protocol.Handshake.Codec
+    Ouroboros.Network.Protocol.Handshake.Server
+    Ouroboros.Network.Protocol.Handshake.Type
+    Ouroboros.Network.Protocol.Handshake.Unversioned
+    Ouroboros.Network.Protocol.Handshake.Version
+    Ouroboros.Network.RawBearer
+    Ouroboros.Network.RethrowPolicy
+    Ouroboros.Network.Server.ConnectionTable
+    Ouroboros.Network.Server.RateLimiting
+    Ouroboros.Network.Server.Socket
+    Ouroboros.Network.Server2
+    Ouroboros.Network.Snocket
+    Ouroboros.Network.Socket
+    Ouroboros.Network.Subscription
+    Ouroboros.Network.Subscription.Client
+    Ouroboros.Network.Subscription.Dns
+    Ouroboros.Network.Subscription.Ip
+    Ouroboros.Network.Subscription.PeerState
+    Ouroboros.Network.Subscription.Subscriber
+    Ouroboros.Network.Subscription.Worker
+    Simulation.Network.Snocket
+
+  -- other-extensions:
+  build-depends:
+    -- ^ only to derive nothunk instances
+    Win32-network ^>=0.2,
+    async >=2.1 && <2.3,
+    base >=4.12 && <4.22,
+    bytestring >=0.10 && <0.13,
+    cardano-prelude,
+    cborg >=0.2.1 && <0.3,
+    containers >=0.5 && <0.8,
+    contra-tracer,
+    deepseq,
+    dns <4.3,
+    hashable,
+    io-classes ^>=1.5.0,
+    iproute >=1.7 && <1.8,
+    monoidal-synchronisation ^>=0.1.0.6,
+    mtl,
+    network ^>=3.2.7,
+    network-mux ^>=0.8.0.1,
+    nothunks,
+    nothunks ^>=0.1.4 || ^>=0.2,
+    ouroboros-network-api ^>=0.14,
+    ouroboros-network-testing,
+    psqueues,
+    quiet,
+    random,
+    si-timers,
+    stm,
+    strict-stm,
+    text,
+    typed-protocols ^>=0.3,
+    typed-protocols-cborg ^>=0.3,
+    typed-protocols-stateful ^>=0.3,
+
+  if os(windows)
+    build-depends: Win32 >=2.5.4.1 && <3.0
+  hs-source-dirs: src
+  default-language: Haskell2010
+  default-extensions: ImportQualifiedPost
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-uni-patterns
+    -Wincomplete-record-updates
+    -Wpartial-fields
+    -Widentities
+    -Wredundant-constraints
+    -Wno-unticked-promoted-constructors
+    -Wunused-packages
+
+library testlib
+  visibility: public
+  hs-source-dirs: testlib
+  exposed-modules:
+    Test.Ouroboros.Network.ConnectionManager.Experiments
+    Test.Ouroboros.Network.ConnectionManager.Timeouts
+    Test.Ouroboros.Network.ConnectionManager.Utils
+    Test.Ouroboros.Network.InboundGovernor.Utils
+    Test.Ouroboros.Network.Orphans
+    Test.Ouroboros.Network.RawBearer.Utils
+
+  other-modules:
+  build-depends:
+    QuickCheck,
+    base >=4.14 && <4.22,
+    bytestring,
+    cborg,
+    containers,
+    contra-tracer,
+    hashable,
+    io-classes,
+    io-sim,
+    network-mux,
+    ouroboros-network-api,
+    ouroboros-network-framework,
+    ouroboros-network-testing,
+    quickcheck-monoids,
+    random,
+    serialise,
+    si-timers,
+    strict-stm,
+    typed-protocols,
+    typed-protocols-examples,
+
+  default-language: Haskell2010
+  default-extensions: ImportQualifiedPost
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-uni-patterns
+    -Wincomplete-record-updates
+    -Wpartial-fields
+    -Widentities
+    -Wredundant-constraints
+    -Wno-unticked-promoted-constructors
+    -Wunused-packages
+
+test-suite sim-tests
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs: sim-tests
+  other-modules:
+    Test.Ouroboros.Network.ConnectionManager
+    Test.Ouroboros.Network.RateLimiting
+    Test.Ouroboros.Network.RawBearer
+    Test.Ouroboros.Network.Server2.Sim
+    Test.Ouroboros.Network.Socket
+    Test.Ouroboros.Network.Subscription
+    Test.Simulation.Network.Snocket
+
+  build-depends:
+    QuickCheck,
+    base >=4.14 && <4.22,
+    bytestring,
+    cborg,
+    containers,
+    contra-tracer,
+    directory,
+    dns,
+    io-classes,
+    io-sim,
+    iproute,
+    monoidal-synchronisation,
+    network,
+    network-mux,
+    ouroboros-network-api,
+    ouroboros-network-framework,
+    ouroboros-network-framework:testlib,
+    ouroboros-network-testing,
+    pretty-simple,
+    psqueues,
+    quickcheck-instances,
+    quickcheck-monoids,
+    quiet,
+    random,
+    serialise,
+    si-timers,
+    strict-stm,
+    tasty,
+    tasty-quickcheck,
+    text,
+    time,
+    typed-protocols,
+    typed-protocols-cborg,
+    typed-protocols-examples,
+    with-utf8,
+
+  if os(windows)
+    build-depends: Win32-network <0.3
+  else
+    build-depends: directory
+
+  default-language: Haskell2010
+  default-extensions: ImportQualifiedPost
+  ghc-options:
+    -rtsopts
+    -threaded
+    -Wall
+    -Wcompat
+    -Wincomplete-uni-patterns
+    -Wincomplete-record-updates
+    -Wpartial-fields
+    -Widentities
+    -Wredundant-constraints
+    -Wno-unticked-promoted-constructors
+    -Wunused-packages
+
+  if flag(ipv6)
+    cpp-options: -DOUROBOROS_NETWORK_IPV6
+
+test-suite io-tests
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs: io-tests
+  other-modules:
+    Test.Ouroboros.Network.Driver
+    Test.Ouroboros.Network.RawBearer
+    Test.Ouroboros.Network.Server2.IO
+    Test.Ouroboros.Network.Socket
+    Test.Ouroboros.Network.Subscription
+
+  build-depends:
+    QuickCheck,
+    base >=4.14 && <4.22,
+    bytestring,
+    containers,
+    contra-tracer,
+    directory,
+    dns,
+    io-classes,
+    io-sim,
+    iproute,
+    monoidal-synchronisation,
+    network,
+    network-mux,
+    ouroboros-network-api,
+    ouroboros-network-framework,
+    ouroboros-network-framework:testlib,
+    random,
+    si-timers,
+    strict-stm,
+    tasty,
+    tasty-quickcheck,
+    time,
+    typed-protocols,
+    typed-protocols-examples >=0.5,
+    typed-protocols-stateful,
+    with-utf8,
+
+  if os(windows)
+    build-depends: Win32-network <0.3
+  default-language: Haskell2010
+  default-extensions: ImportQualifiedPost
+  ghc-options:
+    -rtsopts
+    -threaded
+    -Wall
+    -Wcompat
+    -Wincomplete-uni-patterns
+    -Wincomplete-record-updates
+    -Wpartial-fields
+    -Widentities
+    -Wredundant-constraints
+    -Wno-unticked-promoted-constructors
+    -Wunused-packages
+
+executable demo-ping-pong
+  hs-source-dirs: demo
+  main-is: ping-pong.hs
+  build-depends:
+    async,
+    base >=4.14 && <4.22,
+    bytestring,
+    contra-tracer,
+    directory,
+    network-mux,
+    ouroboros-network-api,
+    ouroboros-network-framework,
+    typed-protocols-examples,
+
+  default-language: Haskell2010
+  default-extensions: ImportQualifiedPost
+  ghc-options:
+    -Wall
+    -threaded
+    -Wcompat
+    -Wincomplete-uni-patterns
+    -Wincomplete-record-updates
+    -Wpartial-fields
+    -Widentities
+    -Wredundant-constraints
+    -Wno-unticked-promoted-constructors
+    -Wunused-packages
+
+executable demo-connection-manager
+  hs-source-dirs: demo
+  main-is: connection-manager.hs
+  build-depends:
+    base >=4.14 && <4.22,
+    bytestring,
+    contra-tracer,
+    hashable,
+    io-classes,
+    network,
+    network-mux,
+    optparse-applicative,
+    ouroboros-network-api,
+    ouroboros-network-framework,
+    random,
+    si-timers,
+    strict-stm,
+    typed-protocols,
+    typed-protocols-examples,
+
+  default-language: Haskell2010
+  default-extensions: ImportQualifiedPost
+  ghc-options:
+    -Wall
+    -threaded
+    -Wcompat
+    -Wincomplete-uni-patterns
+    -Wincomplete-record-updates
+    -Wpartial-fields
+    -Widentities
+    -Wredundant-constraints
+    -Wno-unticked-promoted-constructors
+    -Wunused-packages


### PR DESCRIPTION
<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
