### PR TITLE
Prepare ledger release for cardano-node-10.6

### DIFF
--- a/_sources/byron-spec-chain/1.0.1.1/meta.toml
+++ b/_sources/byron-spec-chain/1.0.1.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'eras/byron/chain/executable-spec'

--- a/_sources/byron-spec-ledger/1.1.0.1/meta.toml
+++ b/_sources/byron-spec-ledger/1.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'eras/byron/ledger/executable-spec'

--- a/_sources/cardano-crypto-wrapper/1.6.1.0/meta.toml
+++ b/_sources/cardano-crypto-wrapper/1.6.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'eras/byron/crypto'

--- a/_sources/cardano-data/1.2.4.1/meta.toml
+++ b/_sources/cardano-data/1.2.4.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'libs/cardano-data'

--- a/_sources/cardano-ledger-allegra/1.8.0.0/meta.toml
+++ b/_sources/cardano-ledger-allegra/1.8.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'eras/allegra/impl'

--- a/_sources/cardano-ledger-alonzo-test/1.4.0.0/meta.toml
+++ b/_sources/cardano-ledger-alonzo-test/1.4.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'eras/alonzo/test-suite'

--- a/_sources/cardano-ledger-alonzo/1.14.0.0/meta.toml
+++ b/_sources/cardano-ledger-alonzo/1.14.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'eras/alonzo/impl'

--- a/_sources/cardano-ledger-api/1.12.0.0/meta.toml
+++ b/_sources/cardano-ledger-api/1.12.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'libs/cardano-ledger-api'

--- a/_sources/cardano-ledger-babbage/1.12.0.0/meta.toml
+++ b/_sources/cardano-ledger-babbage/1.12.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'eras/babbage/impl'

--- a/_sources/cardano-ledger-binary/1.0.0.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.0.0.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-binary'
 [[revisions]]
 number = 1
 timestamp = 2024-12-11T19:54:23Z
+
+[[revisions]]
+number = 2
+timestamp = 2025-09-10T20:25:59Z

--- a/_sources/cardano-ledger-binary/1.0.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-binary/1.0.0.0/revisions/2.cabal
@@ -1,0 +1,171 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.0.0.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/input-output-hk/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.TreeDiff
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.12 && <4.17,
+        aeson,
+        binary,
+        bytestring,
+        cardano-binary >=1.6,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting,
+        cardano-strict-containers >=0.1.2,
+        cborg,
+        containers,
+        data-fix,
+        deepseq,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.1,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        tree-diff,
+        vector,
+        vector-map >=1.0
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.12 && <4.17,
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances <0.3.32,
+        tasty-hunit,
+        random ^>=1.2,
+        text,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base >=4.12 && <4.17,
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map

--- a/_sources/cardano-ledger-binary/1.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.1.0.0/meta.toml
@@ -9,3 +9,7 @@ timestamp = 2023-04-14T12:36:46Z
 [[revisions]]
 number = 2
 timestamp = 2024-12-11T19:54:27Z
+
+[[revisions]]
+number = 3
+timestamp = 2025-09-10T20:25:56Z

--- a/_sources/cardano-ledger-binary/1.1.0.0/revisions/3.cabal
+++ b/_sources/cardano-ledger-binary/1.1.0.0/revisions/3.cabal
@@ -1,0 +1,173 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.1.0.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/input-output-hk/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.TreeDiff
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.17,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.6,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting,
+        cardano-strict-containers >=0.1.2,
+        cborg,
+        containers,
+        data-fix,
+        deepseq,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api >=1.1,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        tree-diff,
+        vector,
+        vector-map >=1.0
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary >=1.0,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances <0.3.32,
+        tasty-hunit,
+        random ^>=1.2,
+        text,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map

--- a/_sources/cardano-ledger-binary/1.1.0.1/meta.toml
+++ b/_sources/cardano-ledger-binary/1.1.0.1/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-binary'
 [[revisions]]
 number = 1
 timestamp = 2024-12-11T19:54:29Z
+
+[[revisions]]
+number = 2
+timestamp = 2025-09-10T20:25:49Z

--- a/_sources/cardano-ledger-binary/1.1.0.1/revisions/2.cabal
+++ b/_sources/cardano-ledger-binary/1.1.0.1/revisions/2.cabal
@@ -1,0 +1,173 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.1.0.1
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/input-output-hk/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.TreeDiff
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.17,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.6,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting,
+        cardano-strict-containers >=0.1.2,
+        cborg,
+        containers,
+        data-fix,
+        deepseq,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.1,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        tree-diff,
+        vector,
+        vector-map >=1.0
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary >=1.0,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances <0.3.32,
+        tasty-hunit,
+        random ^>=1.2,
+        text,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map

--- a/_sources/cardano-ledger-binary/1.1.1.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.1.1.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-binary'
 [[revisions]]
 number = 1
 timestamp = 2024-12-11T19:54:35Z
+
+[[revisions]]
+number = 2
+timestamp = 2025-09-10T20:25:46Z

--- a/_sources/cardano-ledger-binary/1.1.1.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-binary/1.1.1.0/revisions/2.cabal
@@ -1,0 +1,173 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.1.1.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/input-output-hk/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.TreeDiff
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.17,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.6,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting,
+        cardano-strict-containers >=0.1.2,
+        cborg,
+        containers,
+        data-fix,
+        deepseq,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.5,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        tree-diff,
+        vector,
+        vector-map >=1.0
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary >=1.0,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances <0.3.32,
+        tasty-hunit,
+        random ^>=1.2,
+        text,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map

--- a/_sources/cardano-ledger-binary/1.1.1.1/meta.toml
+++ b/_sources/cardano-ledger-binary/1.1.1.1/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-binary'
 [[revisions]]
 number = 1
 timestamp = 2024-12-11T19:54:36Z
+
+[[revisions]]
+number = 2
+timestamp = 2025-09-10T20:25:44Z

--- a/_sources/cardano-ledger-binary/1.1.1.1/revisions/2.cabal
+++ b/_sources/cardano-ledger-binary/1.1.1.1/revisions/2.cabal
@@ -1,0 +1,173 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.1.1.1
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/input-output-hk/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.TreeDiff
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.7,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        tree-diff,
+        vector,
+        vector-map >=1.0
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary >=1.0,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances <0.3.32,
+        tasty-hunit,
+        random ^>=1.2,
+        text,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map

--- a/_sources/cardano-ledger-binary/1.1.2.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.1.2.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-binary'
 [[revisions]]
 number = 1
 timestamp = 2024-12-11T19:54:41Z
+
+[[revisions]]
+number = 2
+timestamp = 2025-09-10T20:25:40Z

--- a/_sources/cardano-ledger-binary/1.1.2.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-binary/1.1.2.0/revisions/2.cabal
@@ -1,0 +1,173 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.1.2.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/input-output-hk/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.TreeDiff
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.9,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        tree-diff,
+        vector,
+        vector-map >=1.0
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary >=1.0,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances <0.3.32,
+        tasty-hunit,
+        random ^>=1.2,
+        text,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map

--- a/_sources/cardano-ledger-binary/1.1.3.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.1.3.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-binary'
 [[revisions]]
 number = 1
 timestamp = 2024-12-11T19:54:44Z
+
+[[revisions]]
+number = 2
+timestamp = 2025-09-10T20:25:38Z

--- a/_sources/cardano-ledger-binary/1.1.3.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-binary/1.1.3.0/revisions/2.cabal
@@ -1,0 +1,173 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.1.3.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/input-output-hk/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.TreeDiff
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.11,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        tree-diff,
+        vector,
+        vector-map >=1.0
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary >=1.0,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances <0.3.32,
+        tasty-hunit,
+        random ^>=1.2,
+        text,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map

--- a/_sources/cardano-ledger-binary/1.2.0.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.2.0.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-binary'
 [[revisions]]
 number = 1
 timestamp = 2024-12-11T19:54:53Z
+
+[[revisions]]
+number = 2
+timestamp = 2025-09-10T20:25:33Z

--- a/_sources/cardano-ledger-binary/1.2.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-binary/1.2.0.0/revisions/2.cabal
@@ -1,0 +1,173 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.2.0.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/input-output-hk/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.TreeDiff
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.15,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        tree-diff,
+        vector,
+        vector-map >=1.0
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary >=1.0,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances <0.3.32,
+        tasty-hunit,
+        random ^>=1.2,
+        text,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map

--- a/_sources/cardano-ledger-binary/1.2.1.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.2.1.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-binary'
 [[revisions]]
 number = 1
 timestamp = 2024-12-11T19:54:56Z
+
+[[revisions]]
+number = 2
+timestamp = 2025-09-10T20:25:30Z

--- a/_sources/cardano-ledger-binary/1.2.1.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-binary/1.2.1.0/revisions/2.cabal
@@ -1,0 +1,176 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.2.1.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/input-output-hk/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/input-output-hk/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.TreeDiff
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.15,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        tree-diff,
+        vector,
+        vector-map >=1.0
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Cddl
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary >=1.0,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances <0.3.32,
+        tasty-hunit,
+        random ^>=1.2,
+        text,
+        typed-process,
+        unliftio,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map

--- a/_sources/cardano-ledger-binary/1.3.0.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.3.0.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-binary'
 [[revisions]]
 number = 1
 timestamp = 2024-12-11T19:57:09Z
+
+[[revisions]]
+number = 2
+timestamp = 2025-09-10T20:25:27Z

--- a/_sources/cardano-ledger-binary/1.3.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-binary/1.3.0.0/revisions/2.cabal
@@ -1,0 +1,194 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.3.0.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/intersectmbo/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        FailT,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.21,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        vector,
+        vector-map ^>=1.1
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Cddl
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting:{cardano-slotting, testlib} >=0.1.2,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances <0.3.32,
+        tasty-hunit,
+        random ^>=1.2,
+        text,
+        typed-process,
+        unliftio,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map
+
+benchmark bench
+    type:             exitcode-stdio-1.0
+    main-is:          Bench.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        containers,
+        criterion,
+        deepseq,
+        random

--- a/_sources/cardano-ledger-binary/1.3.1.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.3.1.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-binary'
 [[revisions]]
 number = 1
 timestamp = 2024-12-11T19:55:03Z
+
+[[revisions]]
+number = 2
+timestamp = 2025-09-10T20:25:24Z

--- a/_sources/cardano-ledger-binary/1.3.1.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-binary/1.3.1.0/revisions/2.cabal
@@ -1,0 +1,194 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.3.1.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/intersectmbo/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting >=0.2,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        FailT,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.23.0,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        vector,
+        vector-map ^>=1.1
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Cddl
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting:{cardano-slotting, testlib} >=0.1.2,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances <0.3.32,
+        tasty-hunit,
+        random ^>=1.2,
+        text,
+        typed-process,
+        unliftio,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map
+
+benchmark bench
+    type:             exitcode-stdio-1.0
+    main-is:          Bench.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        containers,
+        criterion,
+        deepseq,
+        random

--- a/_sources/cardano-ledger-binary/1.3.2.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.3.2.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-binary'
 [[revisions]]
 number = 1
 timestamp = 2024-12-11T19:55:06Z
+
+[[revisions]]
+number = 2
+timestamp = 2025-09-10T20:25:21Z

--- a/_sources/cardano-ledger-binary/1.3.2.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-binary/1.3.2.0/revisions/2.cabal
@@ -1,0 +1,194 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.3.2.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/intersectmbo/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting >=0.2,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        FailT,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api ^>=1.27.0,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        vector,
+        vector-map ^>=1.1
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Cddl
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting:{cardano-slotting, testlib} >=0.1.2,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances <0.3.32,
+        tasty-hunit,
+        random ^>=1.2,
+        text,
+        typed-process,
+        unliftio,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map
+
+benchmark bench
+    type:             exitcode-stdio-1.0
+    main-is:          Bench.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        containers,
+        criterion,
+        deepseq,
+        random

--- a/_sources/cardano-ledger-binary/1.3.3.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.3.3.0/meta.toml
@@ -9,3 +9,7 @@ timestamp = 2024-08-08T07:17:26Z
 [[revisions]]
 number = 2
 timestamp = 2024-12-11T19:55:09Z
+
+[[revisions]]
+number = 3
+timestamp = 2025-09-10T20:25:19Z

--- a/_sources/cardano-ledger-binary/1.3.3.0/revisions/3.cabal
+++ b/_sources/cardano-ledger-binary/1.3.3.0/revisions/3.cabal
@@ -1,0 +1,194 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.3.3.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/intersectmbo/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting >=0.2,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        FailT,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api >=1.27.0 && <1.32,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        vector,
+        vector-map ^>=1.1
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Cddl
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting:{cardano-slotting, testlib} >=0.1.2,
+        cborg,
+        containers,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        pretty-show,
+        primitive,
+        QuickCheck,
+        quickcheck-instances <0.3.32,
+        tasty-hunit,
+        random ^>=1.2,
+        text,
+        typed-process,
+        unliftio,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map
+
+benchmark bench
+    type:             exitcode-stdio-1.0
+    main-is:          Bench.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        containers,
+        criterion,
+        deepseq,
+        random

--- a/_sources/cardano-ledger-binary/1.3.4.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.3.4.0/meta.toml
@@ -9,3 +9,7 @@ timestamp = 2024-12-11T19:55:11Z
 [[revisions]]
 number = 2
 timestamp = 2025-05-15T10:30:42Z
+
+[[revisions]]
+number = 3
+timestamp = 2025-09-10T20:25:15Z

--- a/_sources/cardano-ledger-binary/1.3.4.0/revisions/3.cabal
+++ b/_sources/cardano-ledger-binary/1.3.4.0/revisions/3.cabal
@@ -1,0 +1,198 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.3.4.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/intersectmbo/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting >=0.2,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        FailT,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api >=1.27.0 && <1.33.0,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        vector,
+        vector-map ^>=1.1
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Cddl
+        Test.Cardano.Ledger.Binary.Cuddle
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting:{cardano-slotting, testlib} >=0.1.2,
+        cborg,
+        containers,
+        cuddle >=0.2.0.0 && <0.4,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        hspec-core,
+        pretty-show,
+        prettyprinter,
+        primitive,
+        QuickCheck,
+        quickcheck-instances <0.3.32,
+        tasty-hunit,
+        random ^>=1.2,
+        text,
+        typed-process,
+        unliftio,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map
+
+benchmark bench
+    type:             exitcode-stdio-1.0
+    main-is:          Bench.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        containers,
+        criterion,
+        deepseq,
+        random

--- a/_sources/cardano-ledger-binary/1.4.0.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.4.0.0/meta.toml
@@ -9,3 +9,7 @@ timestamp = 2024-12-11T19:55:16Z
 [[revisions]]
 number = 2
 timestamp = 2025-05-15T10:30:42Z
+
+[[revisions]]
+number = 3
+timestamp = 2025-09-10T20:25:11Z

--- a/_sources/cardano-ledger-binary/1.4.0.0/revisions/3.cabal
+++ b/_sources/cardano-ledger-binary/1.4.0.0/revisions/3.cabal
@@ -1,0 +1,199 @@
+cabal-version: 3.0
+name:          cardano-ledger-binary
+version:       1.4.0.0
+license:       Apache-2.0
+maintainer:    operations@iohk.io
+author:        IOHK
+homepage:      https://github.com/intersectmbo/cardano-ledger
+synopsis:      Binary serialization library used throughout ledger
+category:      Network
+build-type:    Simple
+
+source-repository head
+    type:     git
+    location: https://github.com/intersectmbo/cardano-ledger
+    subdir:   libs/cardano-ledger-binary
+
+library
+    exposed-modules:
+        Cardano.Ledger.Binary
+        Cardano.Ledger.Binary.Coders
+        Cardano.Ledger.Binary.Crypto
+        Cardano.Ledger.Binary.Decoding
+        Cardano.Ledger.Binary.Encoding
+        Cardano.Ledger.Binary.FlatTerm
+        Cardano.Ledger.Binary.Group
+        Cardano.Ledger.Binary.Plain
+        Cardano.Ledger.Binary.Version
+
+    hs-source-dirs:   src
+    other-modules:
+        Cardano.Ledger.Binary.Encoding.Coders
+        Cardano.Ledger.Binary.Encoding.Encoder
+        Cardano.Ledger.Binary.Encoding.EncCBOR
+        Cardano.Ledger.Binary.Decoding.Annotated
+        Cardano.Ledger.Binary.Decoding.Coders
+        Cardano.Ledger.Binary.Decoding.Decoder
+        Cardano.Ledger.Binary.Decoding.Drop
+        Cardano.Ledger.Binary.Decoding.DecCBOR
+        Cardano.Ledger.Binary.Decoding.Sharing
+        Cardano.Ledger.Binary.Decoding.Sized
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson,
+        base16-bytestring,
+        binary,
+        bytestring,
+        cardano-binary >=1.7,
+        cardano-crypto-class ^>=2.1,
+        cardano-crypto-praos >=2.1,
+        cardano-slotting >=0.2,
+        cardano-strict-containers >=0.1.2,
+        cborg >=0.2.9,
+        containers,
+        data-fix,
+        deepseq,
+        FailT,
+        formatting,
+        iproute,
+        microlens,
+        mtl,
+        network,
+        nothunks,
+        primitive,
+        plutus-ledger-api >=1.27.0,
+        recursion-schemes,
+        serialise,
+        tagged,
+        text,
+        time,
+        transformers >=0.5,
+        vector,
+        vector-map ^>=1.1
+
+library testlib
+    exposed-modules:
+        Test.Cardano.Ledger.Binary.Arbitrary
+        Test.Cardano.Ledger.Binary.Cddl
+        Test.Cardano.Ledger.Binary.Cuddle
+        Test.Cardano.Ledger.Binary.Plain.Golden
+        Test.Cardano.Ledger.Binary.Plain.RoundTrip
+        Test.Cardano.Ledger.Binary.Random
+        Test.Cardano.Ledger.Binary.RoundTrip
+        Test.Cardano.Ledger.Binary.TreeDiff
+        Test.Cardano.Ledger.Binary.Twiddle
+        Test.Cardano.Ledger.Binary.Vintage.Helpers
+        Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+    visibility:       public
+    hs-source-dirs:   testlib
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+
+    build-depends:
+        base,
+        bytestring,
+        base16-bytestring,
+        cardano-binary,
+        cardano-crypto-class,
+        cardano-crypto-tests,
+        cardano-ledger-binary,
+        cardano-prelude-test,
+        cardano-strict-containers,
+        cardano-slotting:{cardano-slotting, testlib} >=0.1.2,
+        cborg,
+        containers,
+        cuddle >=0.3.2 && < 0.4,
+        formatting,
+        tree-diff,
+        iproute,
+        half,
+        hedgehog,
+        hspec,
+        hspec-core,
+        pretty-show,
+        prettyprinter,
+        prettyprinter-ansi-terminal,
+        primitive,
+        QuickCheck,
+        quickcheck-instances <0.3.32,
+        tasty-hunit,
+        random ^>=1.2,
+        text,
+        typed-process,
+        unliftio,
+        vector,
+        vector-map
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    other-modules:
+        Test.Cardano.Ledger.Binary.Failure
+        Test.Cardano.Ledger.Binary.PlainSpec
+        Test.Cardano.Ledger.Binary.Success
+        Test.Cardano.Ledger.Binary.RoundTripSpec
+        Test.Cardano.Ledger.Binary.Vintage.Coders
+        Test.Cardano.Ledger.Binary.Vintage.Drop
+        Test.Cardano.Ledger.Binary.Vintage.Failure
+        Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+        Test.Cardano.Ledger.Binary.Vintage.Serialization
+        Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-crypto-class,
+        cardano-crypto-praos,
+        cardano-prelude-test,
+        cardano-slotting,
+        cardano-strict-containers,
+        cborg,
+        containers,
+        hedgehog,
+        hedgehog-quickcheck,
+        hspec,
+        iproute,
+        primitive,
+        QuickCheck,
+        tagged,
+        text,
+        testlib,
+        time,
+        vector,
+        vector-map
+
+benchmark bench
+    type:             exitcode-stdio-1.0
+    main-is:          Bench.hs
+    hs-source-dirs:   bench
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wunused-packages
+        -threaded -rtsopts -O2
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary,
+        containers,
+        criterion,
+        deepseq,
+        random

--- a/_sources/cardano-ledger-binary/1.5.0.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.5.0.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-binary'
 [[revisions]]
 number = 1
 timestamp = 2025-05-15T10:30:42Z
+
+[[revisions]]
+number = 2
+timestamp = 2025-09-10T20:25:08Z

--- a/_sources/cardano-ledger-binary/1.5.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-binary/1.5.0.0/revisions/2.cabal
@@ -1,0 +1,219 @@
+cabal-version: 3.0
+name: cardano-ledger-binary
+version: 1.5.0.0
+license: Apache-2.0
+maintainer: operations@iohk.io
+author: IOHK
+homepage: https://github.com/intersectmbo/cardano-ledger
+synopsis: Binary serialization library used throughout ledger
+category: Network
+build-type: Simple
+
+source-repository head
+  type: git
+  location: https://github.com/intersectmbo/cardano-ledger
+  subdir: libs/cardano-ledger-binary
+
+library
+  exposed-modules:
+    Cardano.Ledger.Binary
+    Cardano.Ledger.Binary.Coders
+    Cardano.Ledger.Binary.Crypto
+    Cardano.Ledger.Binary.Decoding
+    Cardano.Ledger.Binary.Encoding
+    Cardano.Ledger.Binary.FlatTerm
+    Cardano.Ledger.Binary.Group
+    Cardano.Ledger.Binary.Plain
+    Cardano.Ledger.Binary.Version
+
+  hs-source-dirs: src
+  other-modules:
+    Cardano.Ledger.Binary.Decoding.Annotated
+    Cardano.Ledger.Binary.Decoding.Coders
+    Cardano.Ledger.Binary.Decoding.DecCBOR
+    Cardano.Ledger.Binary.Decoding.Decoder
+    Cardano.Ledger.Binary.Decoding.Drop
+    Cardano.Ledger.Binary.Decoding.Sharing
+    Cardano.Ledger.Binary.Decoding.Sized
+    Cardano.Ledger.Binary.Encoding.Coders
+    Cardano.Ledger.Binary.Encoding.EncCBOR
+    Cardano.Ledger.Binary.Encoding.Encoder
+
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wunused-packages
+
+  build-depends:
+    FailT,
+    aeson,
+    base >=4.14 && <5,
+    base16-bytestring,
+    binary,
+    bytestring,
+    cardano-binary >=1.7,
+    cardano-crypto-class ^>=2.1,
+    cardano-crypto-praos >=2.1,
+    cardano-slotting >=0.2,
+    cardano-strict-containers >=0.1.2,
+    cborg >=0.2.9,
+    containers,
+    data-fix,
+    deepseq,
+    formatting,
+    iproute,
+    microlens,
+    mtl,
+    network,
+    nothunks,
+    plutus-ledger-api >=1.27.0,
+    primitive,
+    recursion-schemes,
+    serialise,
+    tagged,
+    text,
+    time,
+    transformers >=0.5,
+    vector,
+    vector-map ^>=1.1,
+
+library testlib
+  exposed-modules:
+    Test.Cardano.Ledger.Binary.Arbitrary
+    Test.Cardano.Ledger.Binary.Cddl
+    Test.Cardano.Ledger.Binary.Cuddle
+    Test.Cardano.Ledger.Binary.Plain.Golden
+    Test.Cardano.Ledger.Binary.Plain.RoundTrip
+    Test.Cardano.Ledger.Binary.Random
+    Test.Cardano.Ledger.Binary.RoundTrip
+    Test.Cardano.Ledger.Binary.TreeDiff
+    Test.Cardano.Ledger.Binary.Twiddle
+    Test.Cardano.Ledger.Binary.Vintage.Helpers
+    Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+  visibility: public
+  hs-source-dirs: testlib
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wunused-packages
+
+  build-depends:
+    ImpSpec,
+    QuickCheck,
+    base,
+    base16-bytestring,
+    bytestring,
+    cardano-binary,
+    cardano-crypto-class,
+    cardano-crypto-tests,
+    cardano-ledger-binary,
+    cardano-prelude-test,
+    cardano-slotting:{cardano-slotting, testlib} >=0.1.2,
+    cardano-strict-containers,
+    cborg,
+    containers,
+    cuddle >=0.3.2 && < 0.4,
+    formatting,
+    half,
+    hedgehog,
+    hspec,
+    hspec-core,
+    iproute,
+    pretty-show,
+    prettyprinter,
+    prettyprinter-ansi-terminal,
+    primitive,
+    quickcheck-instances >=0.3.32,
+    random ^>=1.2,
+    tasty-hunit,
+    text,
+    tree-diff,
+    typed-process,
+    unliftio,
+    vector-map,
+
+test-suite tests
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs: test
+  other-modules:
+    Test.Cardano.Ledger.Binary.Failure
+    Test.Cardano.Ledger.Binary.PlainSpec
+    Test.Cardano.Ledger.Binary.RoundTripSpec
+    Test.Cardano.Ledger.Binary.Success
+    Test.Cardano.Ledger.Binary.Vintage.Coders
+    Test.Cardano.Ledger.Binary.Vintage.Drop
+    Test.Cardano.Ledger.Binary.Vintage.Failure
+    Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+    Test.Cardano.Ledger.Binary.Vintage.Serialization
+    Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wunused-packages
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N
+
+  build-depends:
+    QuickCheck,
+    base,
+    bytestring,
+    cardano-crypto-class,
+    cardano-crypto-praos,
+    cardano-ledger-binary,
+    cardano-prelude-test,
+    cardano-slotting,
+    cardano-strict-containers,
+    cborg,
+    containers,
+    hedgehog,
+    hedgehog-quickcheck,
+    hspec,
+    iproute,
+    primitive,
+    tagged,
+    testlib,
+    text,
+    time,
+    vector,
+    vector-map,
+
+benchmark bench
+  type: exitcode-stdio-1.0
+  main-is: Bench.hs
+  hs-source-dirs: bench
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wunused-packages
+    -threaded
+    -rtsopts
+    -O2
+
+  build-depends:
+    base,
+    bytestring,
+    cardano-ledger-binary,
+    containers,
+    criterion,
+    deepseq,
+    random,

--- a/_sources/cardano-ledger-binary/1.6.0.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.6.0.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'libs/cardano-ledger-binary'
 [[revisions]]
 number = 1
 timestamp = 2025-05-15T10:30:42Z
+
+[[revisions]]
+number = 2
+timestamp = 2025-09-10T20:23:36Z

--- a/_sources/cardano-ledger-binary/1.6.0.0/revisions/2.cabal
+++ b/_sources/cardano-ledger-binary/1.6.0.0/revisions/2.cabal
@@ -1,0 +1,221 @@
+cabal-version: 3.0
+name: cardano-ledger-binary
+version: 1.6.0.0
+license: Apache-2.0
+maintainer: operations@iohk.io
+author: IOHK
+homepage: https://github.com/intersectmbo/cardano-ledger
+synopsis: Binary serialization library used throughout ledger
+category: Network
+build-type: Simple
+
+source-repository head
+  type: git
+  location: https://github.com/intersectmbo/cardano-ledger
+  subdir: libs/cardano-ledger-binary
+
+library
+  exposed-modules:
+    Cardano.Ledger.Binary
+    Cardano.Ledger.Binary.Coders
+    Cardano.Ledger.Binary.Crypto
+    Cardano.Ledger.Binary.Decoding
+    Cardano.Ledger.Binary.Encoding
+    Cardano.Ledger.Binary.FlatTerm
+    Cardano.Ledger.Binary.Group
+    Cardano.Ledger.Binary.Plain
+    Cardano.Ledger.Binary.Version
+
+  hs-source-dirs: src
+  other-modules:
+    Cardano.Ledger.Binary.Decoding.Annotated
+    Cardano.Ledger.Binary.Decoding.Coders
+    Cardano.Ledger.Binary.Decoding.DecCBOR
+    Cardano.Ledger.Binary.Decoding.Decoder
+    Cardano.Ledger.Binary.Decoding.Drop
+    Cardano.Ledger.Binary.Decoding.Sharing
+    Cardano.Ledger.Binary.Decoding.Sized
+    Cardano.Ledger.Binary.Encoding.Coders
+    Cardano.Ledger.Binary.Encoding.EncCBOR
+    Cardano.Ledger.Binary.Encoding.Encoder
+
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wunused-packages
+
+  build-depends:
+    FailT,
+    aeson,
+    base >=4.14 && <5,
+    base16-bytestring,
+    binary,
+    bytestring,
+    cardano-binary >=1.7,
+    cardano-crypto-class ^>=2.2,
+    cardano-crypto-praos >=2.2,
+    cardano-slotting >=0.2,
+    cardano-strict-containers >=0.1.2,
+    cborg >=0.2.10,
+    containers,
+    data-fix,
+    deepseq,
+    formatting,
+    iproute,
+    mempack,
+    microlens,
+    mtl,
+    network,
+    nothunks,
+    plutus-ledger-api >=1.27.0,
+    primitive,
+    recursion-schemes,
+    serialise,
+    tagged,
+    text,
+    time,
+    transformers >=0.5,
+    vector,
+    vector-map ^>=1.1,
+
+library testlib
+  exposed-modules:
+    Test.Cardano.Ledger.Binary
+    Test.Cardano.Ledger.Binary.Arbitrary
+    Test.Cardano.Ledger.Binary.Cddl
+    Test.Cardano.Ledger.Binary.Cuddle
+    Test.Cardano.Ledger.Binary.Plain.Golden
+    Test.Cardano.Ledger.Binary.Plain.RoundTrip
+    Test.Cardano.Ledger.Binary.Random
+    Test.Cardano.Ledger.Binary.RoundTrip
+    Test.Cardano.Ledger.Binary.TreeDiff
+    Test.Cardano.Ledger.Binary.Twiddle
+    Test.Cardano.Ledger.Binary.Vintage.Helpers
+    Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+  visibility: public
+  hs-source-dirs: testlib
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wunused-packages
+
+  build-depends:
+    ImpSpec,
+    QuickCheck,
+    base,
+    base16-bytestring,
+    bytestring,
+    cardano-binary,
+    cardano-crypto-class,
+    cardano-crypto-tests,
+    cardano-ledger-binary,
+    cardano-prelude-test,
+    cardano-slotting:{cardano-slotting, testlib} >=0.1.2,
+    cardano-strict-containers,
+    cborg,
+    containers,
+    cuddle >=0.3.2 && < 0.4,
+    formatting,
+    half,
+    hedgehog,
+    hspec,
+    hspec-core,
+    iproute,
+    pretty-show,
+    prettyprinter,
+    prettyprinter-ansi-terminal,
+    primitive,
+    quickcheck-instances >=0.3.32,
+    random ^>=1.2,
+    tasty-hunit,
+    text,
+    tree-diff,
+    typed-process,
+    unliftio,
+    vector-map,
+
+test-suite tests
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs: test
+  other-modules:
+    Test.Cardano.Ledger.Binary.Failure
+    Test.Cardano.Ledger.Binary.PlainSpec
+    Test.Cardano.Ledger.Binary.RoundTripSpec
+    Test.Cardano.Ledger.Binary.Success
+    Test.Cardano.Ledger.Binary.Vintage.Coders
+    Test.Cardano.Ledger.Binary.Vintage.Drop
+    Test.Cardano.Ledger.Binary.Vintage.Failure
+    Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+    Test.Cardano.Ledger.Binary.Vintage.Serialization
+    Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wunused-packages
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N
+
+  build-depends:
+    QuickCheck,
+    base,
+    bytestring,
+    cardano-crypto-class,
+    cardano-crypto-praos,
+    cardano-ledger-binary,
+    cardano-prelude-test,
+    cardano-slotting,
+    cardano-strict-containers,
+    cborg,
+    containers,
+    hedgehog,
+    hedgehog-quickcheck,
+    hspec,
+    iproute,
+    primitive,
+    tagged,
+    testlib,
+    text,
+    time,
+    vector,
+    vector-map,
+
+benchmark bench
+  type: exitcode-stdio-1.0
+  main-is: Bench.hs
+  hs-source-dirs: bench
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wunused-packages
+    -threaded
+    -rtsopts
+    -O2
+
+  build-depends:
+    base,
+    bytestring,
+    cardano-ledger-binary,
+    containers,
+    criterion,
+    deepseq,
+    random,

--- a/_sources/cardano-ledger-binary/1.7.0.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.7.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2025-09-10T02:05:10Z
 github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
 subdir = 'libs/cardano-ledger-binary'
+
+[[revisions]]
+number = 1
+timestamp = 2025-09-10T20:31:08Z

--- a/_sources/cardano-ledger-binary/1.7.0.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.7.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'libs/cardano-ledger-binary'

--- a/_sources/cardano-ledger-binary/1.7.0.0/revisions/1.cabal
+++ b/_sources/cardano-ledger-binary/1.7.0.0/revisions/1.cabal
@@ -1,0 +1,223 @@
+cabal-version: 3.0
+name: cardano-ledger-binary
+version: 1.7.0.0
+license: Apache-2.0
+maintainer: operations@iohk.io
+author: IOHK
+homepage: https://github.com/intersectmbo/cardano-ledger
+synopsis: Binary serialization library used throughout ledger
+category: Network
+build-type: Simple
+
+source-repository head
+  type: git
+  location: https://github.com/intersectmbo/cardano-ledger
+  subdir: libs/cardano-ledger-binary
+
+library
+  exposed-modules:
+    Cardano.Ledger.Binary
+    Cardano.Ledger.Binary.Coders
+    Cardano.Ledger.Binary.Crypto
+    Cardano.Ledger.Binary.Decoding
+    Cardano.Ledger.Binary.Encoding
+    Cardano.Ledger.Binary.FlatTerm
+    Cardano.Ledger.Binary.Group
+    Cardano.Ledger.Binary.Plain
+    Cardano.Ledger.Binary.Version
+
+  hs-source-dirs: src
+  other-modules:
+    Cardano.Ledger.Binary.Decoding.Annotated
+    Cardano.Ledger.Binary.Decoding.Coders
+    Cardano.Ledger.Binary.Decoding.DecCBOR
+    Cardano.Ledger.Binary.Decoding.Decoder
+    Cardano.Ledger.Binary.Decoding.Drop
+    Cardano.Ledger.Binary.Decoding.Sharing
+    Cardano.Ledger.Binary.Decoding.Sized
+    Cardano.Ledger.Binary.Encoding.Coders
+    Cardano.Ledger.Binary.Encoding.EncCBOR
+    Cardano.Ledger.Binary.Encoding.Encoder
+
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wunused-packages
+
+  build-depends:
+    FailT,
+    aeson,
+    base >=4.18 && <5,
+    base16-bytestring,
+    binary,
+    bytestring,
+    cardano-binary >=1.7,
+    cardano-crypto-class ^>=2.2,
+    cardano-crypto-praos >=2.2,
+    cardano-slotting >=0.2,
+    cardano-strict-containers >=0.1.2,
+    cborg >=0.2.10,
+    containers,
+    data-fix,
+    deepseq,
+    formatting,
+    iproute,
+    mempack,
+    microlens,
+    mtl,
+    network,
+    nothunks,
+    plutus-ledger-api >=1.27.0,
+    primitive,
+    random,
+    recursion-schemes,
+    serialise,
+    tagged,
+    text,
+    time,
+    transformers >=0.5,
+    vector,
+    vector-map ^>=1.1,
+
+library testlib
+  exposed-modules:
+    Test.Cardano.Ledger.Binary
+    Test.Cardano.Ledger.Binary.Arbitrary
+    Test.Cardano.Ledger.Binary.Cddl
+    Test.Cardano.Ledger.Binary.Cuddle
+    Test.Cardano.Ledger.Binary.Plain.Golden
+    Test.Cardano.Ledger.Binary.Plain.RoundTrip
+    Test.Cardano.Ledger.Binary.Random
+    Test.Cardano.Ledger.Binary.RoundTrip
+    Test.Cardano.Ledger.Binary.TreeDiff
+    Test.Cardano.Ledger.Binary.Twiddle
+    Test.Cardano.Ledger.Binary.Vintage.Helpers
+    Test.Cardano.Ledger.Binary.Vintage.Helpers.GoldenRoundTrip
+
+  visibility: public
+  hs-source-dirs: testlib
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wunused-packages
+
+  build-depends:
+    ImpSpec,
+    QuickCheck,
+    base,
+    base16-bytestring,
+    bytestring,
+    cardano-binary,
+    cardano-crypto-class,
+    cardano-crypto-tests,
+    cardano-ledger-binary,
+    cardano-prelude-test,
+    cardano-slotting:{cardano-slotting, testlib} >=0.1.2,
+    cardano-strict-containers,
+    cborg,
+    containers,
+    cuddle >=0.4,
+    formatting,
+    half,
+    hedgehog,
+    hspec,
+    hspec-core,
+    iproute,
+    pretty-show,
+    pretty-simple,
+    prettyprinter,
+    prettyprinter-ansi-terminal,
+    primitive,
+    quickcheck-instances >=0.3.32,
+    random ^>=1.2,
+    tasty-hunit,
+    text,
+    tree-diff,
+    typed-process,
+    unliftio,
+    vector-map,
+
+test-suite tests
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs: test
+  other-modules:
+    Test.Cardano.Ledger.Binary.Failure
+    Test.Cardano.Ledger.Binary.PlainSpec
+    Test.Cardano.Ledger.Binary.RoundTripSpec
+    Test.Cardano.Ledger.Binary.Success
+    Test.Cardano.Ledger.Binary.Vintage.Coders
+    Test.Cardano.Ledger.Binary.Vintage.Drop
+    Test.Cardano.Ledger.Binary.Vintage.Failure
+    Test.Cardano.Ledger.Binary.Vintage.RoundTrip
+    Test.Cardano.Ledger.Binary.Vintage.Serialization
+    Test.Cardano.Ledger.Binary.Vintage.SizeBounds
+
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wunused-packages
+    -threaded
+    -rtsopts
+    -with-rtsopts=-N
+
+  build-depends:
+    QuickCheck,
+    base,
+    bytestring,
+    cardano-crypto-class,
+    cardano-crypto-praos,
+    cardano-ledger-binary,
+    cardano-prelude-test,
+    cardano-slotting,
+    cardano-strict-containers,
+    cborg,
+    containers,
+    hedgehog,
+    hedgehog-quickcheck,
+    hspec,
+    iproute,
+    primitive,
+    tagged,
+    testlib,
+    text,
+    time,
+    vector,
+    vector-map,
+
+benchmark bench
+  type: exitcode-stdio-1.0
+  main-is: Bench.hs
+  hs-source-dirs: bench
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wunused-packages
+    -threaded
+    -rtsopts
+    -O2
+
+  build-depends:
+    base,
+    bytestring,
+    cardano-ledger-binary,
+    containers,
+    criterion,
+    deepseq,
+    random,

--- a/_sources/cardano-ledger-byron/1.2.0.0/meta.toml
+++ b/_sources/cardano-ledger-byron/1.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'eras/byron/ledger/impl'

--- a/_sources/cardano-ledger-conway/1.20.0.0/meta.toml
+++ b/_sources/cardano-ledger-conway/1.20.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'eras/conway/impl'

--- a/_sources/cardano-ledger-core/1.18.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.18.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'libs/cardano-ledger-core'

--- a/_sources/cardano-ledger-dijkstra/0.1.0.0/meta.toml
+++ b/_sources/cardano-ledger-dijkstra/0.1.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'eras/dijkstra/impl'

--- a/_sources/cardano-ledger-mary/1.9.0.0/meta.toml
+++ b/_sources/cardano-ledger-mary/1.9.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'eras/mary/impl'

--- a/_sources/cardano-ledger-shelley-ma-test/1.4.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley-ma-test/1.4.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'eras/shelley-ma/test-suite'

--- a/_sources/cardano-ledger-shelley-test/1.7.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley-test/1.7.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'eras/shelley/test-suite'

--- a/_sources/cardano-ledger-shelley/1.17.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley/1.17.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'eras/shelley/impl'

--- a/_sources/cardano-protocol-tpraos/1.4.1.0/meta.toml
+++ b/_sources/cardano-protocol-tpraos/1.4.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'libs/cardano-protocol-tpraos'

--- a/_sources/set-algebra/1.1.0.4/meta.toml
+++ b/_sources/set-algebra/1.1.0.4/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'libs/set-algebra'

--- a/_sources/small-steps/1.1.2.0/meta.toml
+++ b/_sources/small-steps/1.1.2.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'libs/small-steps'

--- a/_sources/vector-map/1.1.0.1/meta.toml
+++ b/_sources/vector-map/1.1.0.1/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-10T02:05:10Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
+subdir = 'libs/vector-map'

--- a/flake.lock
+++ b/flake.lock
@@ -231,11 +231,11 @@
     "hackage-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1754396271,
-        "narHash": "sha256-WjOAwwMElU567UlOs3Rimvbs2YbgcQFn+71sNsty038=",
+        "lastModified": 1757469358,
+        "narHash": "sha256-/99VDx6Xf0dN6Fc9YfOSs6iJ+yHB5O+WD3DcCMbpPXM=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "358fd3bc4cf82ce548034b273f373948585d60a2",
+        "rev": "7e49da09235b2a09deda5ab6605ccbde130df303",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This ledger release also requires an update to hackage.nix
