### PR TITLE
Added cardano-api-10.18.0.0

### DIFF
--- a/_sources/cardano-api/10.18.0.0/meta.toml
+++ b/_sources/cardano-api/10.18.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-15T19:20:34Z
+github = { repo = "IntersectMBO/cardano-api", rev = "842ad95ff8f1ee43989e50d1dd42514a51e3a35f" }
+subdir = 'cardano-api'


### PR DESCRIPTION
From https://github.com/IntersectMBO/cardano-api at 842ad95ff8f1ee43989e50d1dd42514a51e3a35f

Related release PR in cardano-api: https://github.com/IntersectMBO/cardano-api/pull/957