### PR TITLE
Add microlens upper bound in cardano-prelude

### DIFF
--- a/_sources/cardano-prelude/0.1.0.1/meta.toml
+++ b/_sources/cardano-prelude/0.1.0.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2022-10-17T00:00:00Z
 github = { repo = "input-output-hk/cardano-prelude", rev = "f3c145a7f67fe1c1e04828c68fc15608e0debd43" }
 subdir = 'cardano-prelude'
+
+[[revisions]]
+number = 1
+timestamp = 2025-09-30T00:01:00Z

--- a/_sources/cardano-prelude/0.1.0.1/revisions/1.cabal
+++ b/_sources/cardano-prelude/0.1.0.1/revisions/1.cabal
@@ -1,0 +1,67 @@
+cabal-version: 2.2
+
+name:                 cardano-prelude
+version:              0.1.0.1
+synopsis:             A Prelude replacement for the Cardano project
+description:          A Prelude replacement for the Cardano project
+license:              MIT
+license-file:         LICENSE
+author:               IOHK
+maintainer:           operations@iohk.io
+copyright:            2018-2022 IOHK
+category:             Currency
+build-type:           Simple
+extra-source-files:   ChangeLog.md, README.md cbits/hashset.h cbits/worklist.h
+
+flag development
+  description: Disable `-Werror`
+  default: False
+  manual: True
+
+library
+  hs-source-dirs:     src
+  exposed-modules:    Cardano.Prelude
+                      Data.Semigroup.Action
+  other-modules:      Cardano.Prelude.Base
+                      Cardano.Prelude.Compat
+                      Cardano.Prelude.Compat.ByteString.Short
+                      Cardano.Prelude.Error
+                      Cardano.Prelude.Formatting
+                      Cardano.Prelude.GHC.Heap
+                      Cardano.Prelude.GHC.Heap.NormalForm
+                      Cardano.Prelude.GHC.Heap.Size
+                      Cardano.Prelude.GHC.Heap.Tree
+                      Cardano.Prelude.Json.Canonical
+                      Cardano.Prelude.Json.Parse
+                      Cardano.Prelude.Microlens
+                      Cardano.Prelude.Orphans
+                      Cardano.Prelude.Strict
+
+  build-depends:      base               >= 4.14       && < 4.18
+                    , aeson
+                    , base16-bytestring  >= 1
+                    , bytestring
+                    , canonical-json
+                    , cborg
+                    , containers
+                    , formatting
+                    , ghc-heap
+                    , ghc-prim
+                    , integer-gmp
+                    , microlens          < 0.5
+                    , mtl
+                    , protolude
+                    , tagged
+                    , text
+                    , time
+  default-language:   Haskell2010
+  default-extensions: NoImplicitPrelude
+  c-sources:          cbits/hashset.c
+                      cbits/worklist.c
+                      cbits/closure_size.c
+  ghc-options:        -Wall
+
+  cc-options:         -Wall
+
+  if (!flag(development))
+    ghc-options:      -Werror

--- a/_sources/cardano-prelude/0.1.0.2/meta.toml
+++ b/_sources/cardano-prelude/0.1.0.2/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-04-24T15:32:00Z
 github = { repo = "input-output-hk/cardano-prelude", rev = "ef87bb9db808d08641bb11c1a36d038aff421f58" }
 subdir = 'cardano-prelude'
+
+[[revisions]]
+number = 1
+timestamp = 2025-09-29T23:59:47Z

--- a/_sources/cardano-prelude/0.1.0.2/revisions/1.cabal
+++ b/_sources/cardano-prelude/0.1.0.2/revisions/1.cabal
@@ -1,0 +1,70 @@
+cabal-version: 2.2
+
+name:                 cardano-prelude
+version:              0.1.0.2
+synopsis:             A Prelude replacement for the Cardano project
+description:          A Prelude replacement for the Cardano project
+author:               IOHK
+maintainer:           operations@iohk.io
+copyright:            2018-2022 IOHK
+license:              Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+category:             Currency
+build-type:           Simple
+extra-source-files:   ChangeLog.md, README.md cbits/hashset.h cbits/worklist.h
+tested-with:          GHC == 9.2.5, GHC == 8.10.7
+
+flag development
+  description: Disable `-Werror`
+  default: False
+  manual: True
+
+library
+  hs-source-dirs:     src
+  exposed-modules:    Cardano.Prelude
+                      Data.Semigroup.Action
+  other-modules:      Cardano.Prelude.Base
+                      Cardano.Prelude.Compat
+                      Cardano.Prelude.Compat.ByteString.Short
+                      Cardano.Prelude.Error
+                      Cardano.Prelude.Formatting
+                      Cardano.Prelude.GHC.Heap
+                      Cardano.Prelude.GHC.Heap.NormalForm
+                      Cardano.Prelude.GHC.Heap.Size
+                      Cardano.Prelude.GHC.Heap.Tree
+                      Cardano.Prelude.Json.Canonical
+                      Cardano.Prelude.Json.Parse
+                      Cardano.Prelude.Microlens
+                      Cardano.Prelude.Orphans
+                      Cardano.Prelude.Strict
+
+  build-depends:      base                    >= 4.14       && < 4.19
+                    , aeson
+                    , base16-bytestring       >= 1
+                    , bytestring
+                    , canonical-json          >= 0.6.0.1
+                    , cborg
+                    , containers
+                    , formatting
+                    , ghc-heap
+                    , ghc-prim
+                    , integer-gmp
+                    , microlens               < 0.5
+                    , mtl
+                    , protolude
+                    , tagged
+                    , text
+                    , time
+  default-language:   Haskell2010
+  default-extensions: NoImplicitPrelude
+  c-sources:          cbits/hashset.c
+                      cbits/worklist.c
+                      cbits/closure_size.c
+  ghc-options:        -Wall
+
+  cc-options:         -Wall
+
+  if (!flag(development))
+    ghc-options:      -Werror

--- a/_sources/cardano-prelude/0.1.0.4/meta.toml
+++ b/_sources/cardano-prelude/0.1.0.4/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-11-16T05:01:28Z
 github = { repo = "input-output-hk/cardano-prelude", rev = "a6f18f78f325c0c5d33877ecb99d7fe6b282f35c" }
 subdir = 'cardano-prelude'
+
+[[revisions]]
+number = 1
+timestamp = 2025-09-29T23:58:05Z

--- a/_sources/cardano-prelude/0.1.0.4/revisions/1.cabal
+++ b/_sources/cardano-prelude/0.1.0.4/revisions/1.cabal
@@ -1,0 +1,70 @@
+cabal-version: 2.2
+
+name:                 cardano-prelude
+version:              0.1.0.4
+synopsis:             A Prelude replacement for the Cardano project
+description:          A Prelude replacement for the Cardano project
+author:               IOHK
+maintainer:           operations@iohk.io
+copyright:            2018-2023 Input Output Global Inc (IOG)
+license:              Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+category:             Currency
+build-type:           Simple
+extra-source-files:   ChangeLog.md, README.md cbits/hashset.h cbits/worklist.h
+tested-with:          GHC == 9.2.5, GHC == 8.10.7
+
+flag development
+  description: Disable `-Werror`
+  default: False
+  manual: True
+
+library
+  hs-source-dirs:     src
+  exposed-modules:    Cardano.Prelude
+                      Data.Semigroup.Action
+  other-modules:      Cardano.Prelude.Base
+                      Cardano.Prelude.Compat
+                      Cardano.Prelude.Compat.ByteString.Short
+                      Cardano.Prelude.Error
+                      Cardano.Prelude.Formatting
+                      Cardano.Prelude.GHC.Heap
+                      Cardano.Prelude.GHC.Heap.NormalForm
+                      Cardano.Prelude.GHC.Heap.Size
+                      Cardano.Prelude.GHC.Heap.Tree
+                      Cardano.Prelude.Json.Canonical
+                      Cardano.Prelude.Json.Parse
+                      Cardano.Prelude.Microlens
+                      Cardano.Prelude.Orphans
+                      Cardano.Prelude.Strict
+
+  build-depends:      base                    >= 4.14       && < 5
+                    , aeson                   >= 2.0
+                    , base16-bytestring       >= 1
+                    , bytestring
+                    , canonical-json          >= 0.6.0.1
+                    , cborg
+                    , containers
+                    , formatting
+                    , ghc-heap
+                    , ghc-prim
+                    , integer-gmp
+                    , microlens               < 0.5
+                    , mtl
+                    , protolude
+                    , tagged
+                    , text
+                    , time
+  default-language:   Haskell2010
+  default-extensions: NoImplicitPrelude
+  c-sources:          cbits/hashset.c
+                      cbits/worklist.c
+                      cbits/closure_size.c
+  ghc-options:        -Wall
+
+  cc-options:         -Wall
+
+  if (!flag(development))
+    ghc-options:      -Werror

--- a/_sources/cardano-prelude/0.2.0.0/meta.toml
+++ b/_sources/cardano-prelude/0.2.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-06-12T07:10:17Z
 github = { repo = "IntersectMBO/cardano-prelude", rev = "273167c18b7b03c654765c023fc5b52b41a7df6e" }
 subdir = 'cardano-prelude'
+
+[[revisions]]
+number = 1
+timestamp = 2025-09-29T23:56:59Z

--- a/_sources/cardano-prelude/0.2.0.0/revisions/1.cabal
+++ b/_sources/cardano-prelude/0.2.0.0/revisions/1.cabal
@@ -1,0 +1,80 @@
+cabal-version: 2.2
+
+name:                 cardano-prelude
+version:              0.2.0.0
+synopsis:             A Prelude replacement for the Cardano project
+description:          A Prelude replacement for the Cardano project
+author:               IOHK
+maintainer:           operations@iohk.io
+copyright:            2018-2023 Input Output Global Inc (IOG)
+license:              Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+category:             Currency
+build-type:           Simple
+extra-source-files:   ChangeLog.md, README.md cbits/hashset.h cbits/worklist.h
+tested-with:          GHC == 9.2.5, GHC == 8.10.7
+
+flag development
+  description: Disable `-Werror`
+  default: False
+  manual: True
+
+library
+  hs-source-dirs:     src
+  exposed-modules:    Cardano.Prelude
+                      Data.Semigroup.Action
+  other-modules:      Cardano.Prelude.Base
+                      Cardano.Prelude.Bool
+                      Cardano.Prelude.ConvertText
+                      Cardano.Prelude.Compat.ByteString.Short
+                      Cardano.Prelude.Either
+                      Cardano.Prelude.Error
+                      Cardano.Prelude.Formatting
+                      Cardano.Prelude.Functor
+                      Cardano.Prelude.GHC.Heap
+                      Cardano.Prelude.GHC.Heap.NormalForm
+                      Cardano.Prelude.GHC.Heap.Size
+                      Cardano.Prelude.GHC.Heap.Tree
+                      Cardano.Prelude.Json.Canonical
+                      Cardano.Prelude.Json.Parse
+                      Cardano.Prelude.Microlens
+                      Cardano.Prelude.Orphans
+                      Cardano.Prelude.Panic
+                      Cardano.Prelude.Read
+                      Cardano.Prelude.Safe
+                      Cardano.Prelude.Show
+                      Cardano.Prelude.Strict
+
+  build-depends:      base                    >= 4.14       && < 5
+                    , aeson                   >= 2.0
+                    , async
+                    , base16-bytestring       >= 1
+                    , bytestring
+                    , canonical-json          >= 0.6.0.1
+                    , cborg
+                    , containers
+                    , deepseq
+                    , extra
+                    , formatting
+                    , ghc-heap
+                    , ghc-prim
+                    , integer-gmp
+                    , microlens               < 0.5
+                    , mtl
+                    , stm
+                    , tagged
+                    , text
+                    , time
+                    , transformers
+  default-language:   Haskell2010
+  c-sources:          cbits/hashset.c
+                      cbits/worklist.c
+                      cbits/closure_size.c
+  ghc-options:        -Wall
+
+  cc-options:         -Wall
+
+  if (!flag(development))
+    ghc-options:      -Werror

--- a/_sources/cardano-prelude/0.2.1.0/meta.toml
+++ b/_sources/cardano-prelude/0.2.1.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2025-01-13T22:30:16Z
 github = { repo = "IntersectMBO/cardano-prelude/", rev = "68e015f6e7f17e67d8dbf16bc1590b926d064962" }
 subdir = 'cardano-prelude'
+
+[[revisions]]
+number = 1
+timestamp = 2025-09-29T23:47:47Z

--- a/_sources/cardano-prelude/0.2.1.0/revisions/1.cabal
+++ b/_sources/cardano-prelude/0.2.1.0/revisions/1.cabal
@@ -1,0 +1,80 @@
+cabal-version: 2.2
+
+name:                 cardano-prelude
+version:              0.2.1.0
+synopsis:             A Prelude replacement for the Cardano project
+description:          A Prelude replacement for the Cardano project
+author:               IOHK
+maintainer:           operations@iohk.io
+copyright:            2018-2023 Input Output Global Inc (IOG)
+license:              Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+category:             Currency
+build-type:           Simple
+extra-source-files:   ChangeLog.md, README.md cbits/hashset.h cbits/worklist.h
+tested-with:          GHC == 9.2.5, GHC == 8.10.7
+
+flag development
+  description: Disable `-Werror`
+  default: False
+  manual: True
+
+library
+  hs-source-dirs:     src
+  exposed-modules:    Cardano.Prelude
+                      Data.Semigroup.Action
+  other-modules:      Cardano.Prelude.Base
+                      Cardano.Prelude.Bool
+                      Cardano.Prelude.ConvertText
+                      Cardano.Prelude.Compat.ByteString.Short
+                      Cardano.Prelude.Either
+                      Cardano.Prelude.Error
+                      Cardano.Prelude.Formatting
+                      Cardano.Prelude.Functor
+                      Cardano.Prelude.GHC.Heap
+                      Cardano.Prelude.GHC.Heap.NormalForm
+                      Cardano.Prelude.GHC.Heap.Size
+                      Cardano.Prelude.GHC.Heap.Tree
+                      Cardano.Prelude.Json.Canonical
+                      Cardano.Prelude.Json.Parse
+                      Cardano.Prelude.Microlens
+                      Cardano.Prelude.Orphans
+                      Cardano.Prelude.Panic
+                      Cardano.Prelude.Read
+                      Cardano.Prelude.Safe
+                      Cardano.Prelude.Show
+                      Cardano.Prelude.Strict
+
+  build-depends:      base                    >= 4.14       && < 5
+                    , aeson                   >= 2.0
+                    , async
+                    , base16-bytestring       >= 1
+                    , bytestring
+                    , canonical-json          >= 0.6.0.1
+                    , cborg
+                    , containers
+                    , deepseq
+                    , extra
+                    , formatting
+                    , ghc-heap
+                    , ghc-prim
+                    , integer-gmp
+                    , microlens               < 0.5
+                    , mtl
+                    , stm
+                    , tagged
+                    , text
+                    , time
+                    , transformers
+  default-language:   Haskell2010
+  c-sources:          cbits/hashset.c
+                      cbits/worklist.c
+                      cbits/closure_size.c
+  ghc-options:        -Wall
+
+  cc-options:         -Wall
+
+  if (!flag(development))
+    ghc-options:      -Werror


### PR DESCRIPTION
`microlens-0.5` removes functionality from `Lens.Micro.Internal` that was being used in `cardano-prelude` so for now add upper bound.

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
