### PR TITLE
ouroboros-consensus releases for 10.6

### DIFF
--- a/_sources/ouroboros-consensus-cardano/0.26.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-cardano/0.26.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-30T09:14:27Z
+github = { repo = "IntersectMBO/ouroboros-consensus", rev = "4759da500fc9e1d25f2d91c865aa41054cc70f22" }
+subdir = 'ouroboros-consensus-cardano'

--- a/_sources/ouroboros-consensus-diffusion/0.24.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-diffusion/0.24.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-30T09:14:27Z
+github = { repo = "IntersectMBO/ouroboros-consensus", rev = "4759da500fc9e1d25f2d91c865aa41054cc70f22" }
+subdir = 'ouroboros-consensus-diffusion'

--- a/_sources/ouroboros-consensus-protocol/0.13.0.0/meta.toml
+++ b/_sources/ouroboros-consensus-protocol/0.13.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-30T09:14:27Z
+github = { repo = "IntersectMBO/ouroboros-consensus", rev = "4759da500fc9e1d25f2d91c865aa41054cc70f22" }
+subdir = 'ouroboros-consensus-protocol'

--- a/_sources/ouroboros-consensus/0.28.0.0/meta.toml
+++ b/_sources/ouroboros-consensus/0.28.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-30T09:14:27Z
+github = { repo = "IntersectMBO/ouroboros-consensus", rev = "4759da500fc9e1d25f2d91c865aa41054cc70f22" }
+subdir = 'ouroboros-consensus'

--- a/_sources/sop-extras/0.4.1.0/meta.toml
+++ b/_sources/sop-extras/0.4.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-30T09:59:24Z
+github = { repo = "IntersectMBO/ouroboros-consensus", rev = "4759da500fc9e1d25f2d91c865aa41054cc70f22" }
+subdir = 'sop-extras'


### PR DESCRIPTION
- `ouroboros-consensus-0.28.0.0` at `4759da500fc9e1d25f2d91c865aa41054cc70f22`
- `ouroboros-consensus-protocol-0.13.0.0` at `4759da500fc9e1d25f2d91c865aa41054cc70f22`
- `ouroboros-consensus-diffusion-0.24.0.0` at `4759da500fc9e1d25f2d91c865aa41054cc70f22`
- `ouroboros-consensus-cardano-0.26.0.0` at `4759da500fc9e1d25f2d91c865aa41054cc70f22`
- `sop-extras-0.4.1.0` at `4759da500fc9e1d25f2d91c865aa41054cc70f22`