### PR TITLE
Added cardano-crypto-class-2.2.4.0

### DIFF
--- a/_sources/cardano-crypto-class/2.2.4.0/meta.toml
+++ b/_sources/cardano-crypto-class/2.2.4.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2025-09-30T10:41:16Z
+github = { repo = "IntersectMBO/cardano-base", rev = "1d7e4ed3327f3ecde22341ef08411101469c68b1" }
+subdir = 'cardano-crypto-class'


### PR DESCRIPTION
From https://github.com/IntersectMBO/cardano-base at 1d7e4ed3327f3ecde22341ef08411101469c68b1

<!-- 
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
