### PR TITLE
Add cardano-api-11.0.0.0

### DIFF
--- a/_sources/cardano-api/11.0.0.0/meta.toml
+++ b/_sources/cardano-api/11.0.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-04-30T13:08:25Z
+github = { repo = "IntersectMBO/cardano-api", rev = "53a77342de3fef8c8ac8c252c5f88f6eda73b2b5" }
+subdir = 'cardano-api'


### PR DESCRIPTION
Adds cardano-api 11.0.0.0 from [tag `cardano-api-11.0.0.0`](https://github.com/IntersectMBO/cardano-api/releases/tag/cardano-api-11.0.0.0) (commit `53a77342de3f`).

Release PR: https://github.com/IntersectMBO/cardano-api/pull/1196