### PR TITLE
Added cardano-cli-11.0.0.0

### DIFF
--- a/_sources/cardano-cli/11.0.0.0/meta.toml
+++ b/_sources/cardano-cli/11.0.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-05-01T16:08:05Z
+github = { repo = "IntersectMBO/cardano-cli", rev = "6817fd6aef9a9e28b5dce35c5fc558da14688eb2" }
+subdir = 'cardano-cli'


### PR DESCRIPTION
Add `cardano-cli-11.0.0.0` to CHaP.

Source: https://github.com/IntersectMBO/cardano-cli at commit `6817fd6aef9a9e28b5dce35c5fc558da14688eb2` (the tip of the corresponding cardano-cli release PR).

Corresponding cardano-cli release PR: https://github.com/IntersectMBO/cardano-cli/pull/1371