### PR TITLE
Added cardano-api-11.2.0.0

### DIFF
--- a/_sources/cardano-api/11.2.0.0/meta.toml
+++ b/_sources/cardano-api/11.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-05-18T18:23:40Z
+github = { repo = "IntersectMBO/cardano-api", rev = "3baa58e8cc78d84f271ab5596e121b7f5ec3fff4" }
+subdir = 'cardano-api'

--- a/flake.nix
+++ b/flake.nix
@@ -224,6 +224,7 @@
                 ouroboros-network.doHaddock = false;
                 cardano-diffusion.doHaddock = false;
                 cardano-ledger-shelley.doHaddock = false;
+                cardano-api.doHaddock = false;
               };
             })
           ];


### PR DESCRIPTION
Add `cardano-api-11.2.0.0` to CHaP.

Source: https://github.com/IntersectMBO/cardano-api at commit `3baa58e8cc78d84f271ab5596e121b7f5ec3fff4` (the tip of the corresponding cardano-api release PR, re-signed with the IOHK key — see https://github.com/IntersectMBO/cardano-api/pull/1212).

Corresponding cardano-api release PR: https://github.com/IntersectMBO/cardano-api/pull/1212

Also disables haddock for cardano-api as a workaround for [GHC #25739](https://gitlab.haskell.org/ghc/ghc/-/issues/25739) (`tyConStupidTheta` panic during haddock generation on GHC 9.6.7), following the existing precedent for `cardano-ledger-shelley`, `ouroboros-network`, and `cardano-diffusion`.