### PR TITLE
Added hermod-recon-framework-1.3.0

### DIFF
--- a/_sources/hermod-recon-framework/1.3.0/meta.toml
+++ b/_sources/hermod-recon-framework/1.3.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-06-10T14:16:00Z
+github = { repo = "IntersectMBO/hermod-tracing", rev = "e6965add7109268d18bd4f5a3bf3295e9fe229ed" }
+subdir = 'hermod-recon-framework'


### PR DESCRIPTION
## Summary
- Adds `hermod-recon-framework-1.3.0` sourced from `IntersectMBO/hermod-tracing` at commit `e6965add7109268d18bd4f5a3bf3295e9fe229ed`