### PR TITLE
Added optparse-applicative-fork-0.19.0.0

### DIFF
--- a/_sources/optparse-applicative-fork/0.19.0.0/meta.toml
+++ b/_sources/optparse-applicative-fork/0.19.0.0/meta.toml
@@ -1,0 +1,2 @@
+timestamp = 2026-06-23T21:17:32Z
+github = { repo = "input-output-hk/optparse-applicative", rev = "074b90b38c0415f87023be84221a92be6e3cea0e" }


### PR DESCRIPTION
## Summary

- Adds `optparse-applicative-fork-0.19.0.0` from [input-output-hk/optparse-applicative@074b90b](https://github.com/input-output-hk/optparse-applicative/commit/074b90b38c0415f87023be84221a92be6e3cea0e)
- Upgrades the fork base from upstream 0.18.x to upstream 0.19.0
- Replaces `ansi-wl-pprint` with `prettyprinter` / `prettyprinter-ansi-terminal`
- Adds `helpEmbedBriefDesc` configuration option
- Removes `parserOptionGroup` / `OptGroup` / `propGroup` (breaking change)
- Removes colour/style stubs (`bold`, `ondullwhite`, etc.) — use `prettyprinter-ansi-terminal` directly