### PR TITLE
Added hermod-recon-framework-1.4.0

### DIFF
--- a/_sources/hermod-recon-framework/1.4.0/meta.toml
+++ b/_sources/hermod-recon-framework/1.4.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-06-18T17:45:00Z
+github = { repo = "IntersectMBO/hermod-tracing", rev = "8e1c24ed138df08d9f3527a90db46eda3126d745" }
+subdir = 'hermod-recon-framework'


### PR DESCRIPTION
## Summary
- Adds `hermod-recon-framework-1.4.0` sourced from `IntersectMBO/hermod-tracing` at commit `8e1c24ed138df08d9f3527a90db46eda3126d745`