### PR TITLE
Revised cardano-node-10.6.1: add optparse-applicative-fork < 0.19 upper bound

### DIFF
--- a/_sources/cardano-node/10.6.1/revisions/1.cabal
+++ b/_sources/cardano-node/10.6.1/revisions/1.cabal
@@ -1,0 +1,289 @@
+cabal-version: 3.8
+
+name:                   cardano-node
+version:                10.6.1
+synopsis:               The cardano full node
+description:            The cardano full node.
+category:               Cardano,
+                        Validator,
+copyright:              2019-2023 Input Output Global Inc (IOG), 2023-2025 Intersect.
+author:                 IOHK
+maintainer:             operations@iohk.io
+license:                Apache-2.0
+license-files:          LICENSE
+                        NOTICE
+build-type:             Simple
+extra-doc-files:        ChangeLog.md
+
+Flag unexpected_thunks
+  Description:          Turn on unexpected thunks checks
+  Default:              False
+
+flag systemd
+  description:          Enable systemd support
+  default:              True
+  manual:               False
+
+common project-config
+  default-language:     Haskell2010
+
+  default-extensions:   OverloadedStrings
+  build-depends:        base >= 4.14 && < 5
+
+  ghc-options:          -Wall
+                        -Wcompat
+                        -Wincomplete-record-updates
+                        -Wincomplete-uni-patterns
+                        -Wno-unticked-promoted-constructors
+                        -Wpartial-fields
+                        -Wredundant-constraints
+                        -Wunused-packages
+common maybe-Win32
+  if os(windows)
+    build-depends:      Win32
+
+common maybe-unix
+  if !os(windows)
+    build-depends:      unix
+
+library
+  import:               project-config
+                      , maybe-unix
+                      , maybe-Win32
+  if flag(unexpected_thunks)
+    cpp-options:        -DUNEXPECTED_THUNKS
+
+  if os(linux) && flag(systemd)
+    cpp-options:        -DSYSTEMD
+    build-depends:      lobemo-scribe-systemd
+                      , systemd >= 2.3.0
+
+  hs-source-dirs:       src
+
+  exposed-modules:      Cardano.Node.Configuration.Logging
+                        Cardano.Node.Configuration.NodeAddress
+                        Cardano.Node.Configuration.POM
+                        Cardano.Node.Configuration.LedgerDB
+                        Cardano.Node.Configuration.Socket
+                        Cardano.Node.Configuration.TopologyP2P
+                        Cardano.Node.Handlers.Shutdown
+                        Cardano.Node.Handlers.TopLevel
+                        Cardano.Node.Orphans
+                        Cardano.Node.Parsers
+                        Cardano.Node.Pretty
+                        Cardano.Node.Protocol
+                        Cardano.Node.Protocol.Alonzo
+                        Cardano.Node.Protocol.Byron
+                        Cardano.Node.Protocol.Cardano
+                        Cardano.Node.Protocol.Checkpoints
+                        Cardano.Node.Protocol.Conway
+                        Cardano.Node.Protocol.Dijkstra
+                        Cardano.Node.Protocol.Shelley
+                        Cardano.Node.Protocol.Types
+                        Cardano.Node.Queries
+                        Cardano.Node.Run
+                        Cardano.Node.Startup
+                        Cardano.Node.STM
+                        Cardano.Node.TraceConstraints
+                        Cardano.Node.Tracing
+                        Cardano.Node.Tracing.API
+                        Cardano.Node.Tracing.Compat
+                        Cardano.Node.Tracing.Consistency
+                        Cardano.Node.Tracing.DefaultTraceConfig
+                        Cardano.Node.Tracing.Documentation
+                        Cardano.Node.Tracing.Era.Byron
+                        Cardano.Node.Tracing.Era.HardFork
+                        Cardano.Node.Tracing.Era.Shelley
+                        Cardano.Node.Tracing.Formatting
+                        Cardano.Node.Tracing.NodeInfo
+                        Cardano.Node.Tracing.NodeStartupInfo
+                        Cardano.Node.Tracing.Peers
+                        Cardano.Node.Tracing.Render
+                        Cardano.Node.Tracing.StateRep
+                        Cardano.Node.Tracing.Tracers
+                        Cardano.Node.Tracing.Tracers.BlockReplayProgress
+                        Cardano.Node.Tracing.Tracers.ChainDB
+                        Cardano.Node.Tracing.Tracers.Consensus
+                        Cardano.Node.Tracing.Tracers.ConsensusStartupException
+                        Cardano.Node.Tracing.Tracers.Diffusion
+                        Cardano.Node.Tracing.Tracers.ForgingStats
+                        Cardano.Node.Tracing.Tracers.KESInfo
+                        Cardano.Node.Tracing.Tracers.LedgerMetrics
+                        Cardano.Node.Tracing.Tracers.NodeToClient
+                        Cardano.Node.Tracing.Tracers.NodeToNode
+                        Cardano.Node.Tracing.Tracers.NodeVersion
+                        Cardano.Node.Tracing.Tracers.P2P
+                        Cardano.Node.Tracing.Tracers.Peer
+                        Cardano.Node.Tracing.Tracers.Resources
+                        Cardano.Node.Tracing.Tracers.Shutdown
+                        Cardano.Node.Tracing.Tracers.Startup
+                        Cardano.Node.Types
+                        Cardano.Tracing.Config
+                        Cardano.Tracing.HasIssuer
+                        Cardano.Tracing.Metrics
+                        Cardano.Tracing.OrphanInstances.Byron
+                        Cardano.Tracing.OrphanInstances.Common
+                        Cardano.Tracing.OrphanInstances.Consensus
+                        Cardano.Tracing.OrphanInstances.HardFork
+                        Cardano.Tracing.OrphanInstances.Network
+                        Cardano.Tracing.OrphanInstances.Shelley
+                        Cardano.Tracing.Peer
+                        Cardano.Tracing.Render
+                        Cardano.Tracing.Shutdown
+                        Cardano.Tracing.Startup
+                        Cardano.Tracing.Tracers
+
+  other-modules:        Paths_cardano_node
+  autogen-modules:      Paths_cardano_node
+
+  build-depends:        base
+                      , aeson >= 2.1.0.0
+                      , async
+                      , base16-bytestring
+                      , bytestring
+                      , cardano-api ^>= 10.19
+                      , cardano-crypto-class ^>=2.2.3.2
+                      , cardano-crypto-wrapper
+                      , cardano-git-rev ^>=0.2.2
+                      , cardano-ledger-alonzo
+                      , cardano-ledger-allegra
+                      , cardano-ledger-api
+                      , cardano-ledger-babbage
+                      , cardano-ledger-binary
+                      , cardano-ledger-byron
+                      , cardano-ledger-conway
+                      , cardano-ledger-core
+                      , cardano-ledger-dijkstra
+                      , cardano-ledger-shelley
+                      , cardano-prelude
+                      , cardano-protocol-tpraos >= 1.4
+                      , cardano-slotting >= 0.2
+                      , cborg ^>= 0.2.4
+                      , containers
+                      , contra-tracer
+                      , data-default-class
+                      , deepseq
+                      , directory
+                      , dns
+                      , ekg-wai
+                      , ekg-core
+                      , filepath
+                      , formatting
+                      , generic-data
+                      , hashable
+                      , hostname
+                      , io-classes:{io-classes,strict-stm,si-timers} >= 1.5
+                      , iohk-monitoring ^>= 0.2
+                      , kes-agent ^>=0.2
+                      , microlens
+                      , mmap
+                      , network-mux
+                      , iproute
+                      , lobemo-backend-aggregation
+                      , lobemo-backend-ekg ^>= 0.2
+                      , lobemo-backend-monitoring
+                      , lobemo-backend-trace-forwarder
+                      , mtl
+                      , network
+                      , network-mux >= 0.8
+                      , nothunks
+                      , optparse-applicative-fork >= 0.18.1 && < 0.19
+                      , ouroboros-consensus ^>= 0.28
+                      , ouroboros-consensus-cardano ^>= 0.26
+                      , ouroboros-consensus-diffusion ^>= 0.24
+                      , ouroboros-consensus-protocol
+                      , ouroboros-network-api ^>= 0.16
+                      , ouroboros-network:{ouroboros-network, cardano-diffusion, orphan-instances} ^>= 0.22.4
+                      , ouroboros-network-framework ^>= 0.19.2
+                      , ouroboros-network-protocols ^>= 0.15
+                      , prettyprinter
+                      , prettyprinter-ansi-terminal
+                      , psqueues
+                      , random
+                      , resource-registry
+                      , safe-exceptions
+                      , scientific
+                      , sop-core
+                      -- avoid stm-2.5.2 https://github.com/haskell/stm/issues/76
+                      , stm <2.5.2 || >=2.5.3
+                      , strict-sop-core
+                      , sop-core
+                      , sop-extras
+                      , text >= 2.0
+                      , time
+                      , trace-dispatcher ^>= 2.10.0
+                      , trace-forward ^>= 2.3.0
+                      , trace-resources ^>= 0.2.4
+                      , tracer-transformers
+                      , transformers
+                      , transformers-except
+                      , typed-protocols:{typed-protocols, stateful} >= 1.0
+                      , yaml
+
+executable cardano-node
+  import:               project-config
+  hs-source-dirs:       app
+  main-is:              cardano-node.hs
+  ghc-options:          -threaded
+                        -rtsopts
+
+  if arch(arm)
+    ghc-options:        "-with-rtsopts=-T -I0 -A16m -N1 --disable-delayed-os-memory-return"
+  else
+    ghc-options:        "-with-rtsopts=-T -I0 -A16m -N2 --disable-delayed-os-memory-return"
+
+  other-modules:        Paths_cardano_node
+  autogen-modules:      Paths_cardano_node
+
+  build-depends:        base
+                      , cardano-crypto-class
+                      , cardano-git-rev
+                      , cardano-node
+                      , optparse-applicative-fork
+                      , text
+
+test-suite cardano-node-test
+  import:               project-config
+                      , maybe-unix
+  hs-source-dirs:       test
+  main-is:              cardano-node-test.hs
+  type:                 exitcode-stdio-1.0
+
+  build-depends:        base
+                      , aeson
+                      , bytestring
+                      , cardano-crypto-class
+                      , cardano-crypto-wrapper
+                      , cardano-api
+                      , cardano-protocol-tpraos
+                      , cardano-node
+                      , cardano-slotting
+                      , contra-tracer
+                      , directory
+                      , filepath
+                      , hedgehog
+                      , hedgehog-corpus
+                      , hedgehog-extras ^>= 0.10
+                      , iproute
+                      , mtl
+                      , ouroboros-consensus
+                      , ouroboros-consensus-cardano
+                      , ouroboros-consensus-diffusion
+                      , ouroboros-network:{ouroboros-network, cardano-diffusion}
+                      , ouroboros-network-api
+                      , strict-sop-core
+                      , text
+                      , trace-dispatcher
+                      , transformers
+                      , vector
+                      , yaml
+
+  other-modules:        Test.Cardano.Config.Mainnet
+                        Test.Cardano.Node.FilePermissions
+                        Test.Cardano.Node.Gen
+                        Test.Cardano.Node.Json
+                        Test.Cardano.Node.POM
+                        Test.Cardano.Tracing.NewTracing.Consistency
+                        Test.Cardano.Tracing.OrphanInstances.HardFork
+
+  ghc-options:          -threaded -rtsopts "-with-rtsopts=-N -T"


### PR DESCRIPTION
## Summary

Adds a cabal revision for `cardano-node-10.6.1` to cap its `optparse-applicative-fork` dependency at `< 0.19`.

Without this bound, cabal resolves to `optparse-applicative-fork-0.19.0.0` (which has breaking API changes), causing Nix plan evaluation to fail when that version is present in CHaP.

## Context

- `optparse-applicative-fork-0.19.0.0` removes `parserOptionGroup`/`OptGroup`/`propGroup` and colour stubs — breaking changes that `cardano-node-10.6.1` is not updated for.
- `cardano-node-10.6.1` declared `optparse-applicative-fork >= 0.18.1` with no upper bound, so cabal greedily selected the new version.
- This revision pins it to `>= 0.18.1 && < 0.19`.