### PR TITLE
Commit an update to the CHaP flake input when the repo is deployed

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -282,6 +282,25 @@ jobs:
           git update-ref "refs/heads/repo" "$commitId"
           git push origin repo
 
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
+        with:
+          extra-conf: |
+            accept-flake-config = true
+
+      - name: Update CHaP flake input
+        run: |
+          # Restore the original checkout but leave the untracked _repo untouched
+          git restore --staged --worktree .
+          nix flake update CHaP
+          if git diff --quiet -- flake.lock; then
+           echo "flake.lock unchanged; skipping commit"
+           exit 0
+          fi
+          git add flake.lock
+          git commit -m 'Update CHaP flake input'
+          git push origin HEAD:${{ github.ref_name }}
+
       - name: Setup Pages
         uses: actions/configure-pages@v6
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -338,6 +338,25 @@ jobs:
           git update-ref "refs/heads/index-only" "$indexCommitId"
           git push origin index-only
 
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
+        with:
+          extra-conf: |
+            accept-flake-config = true
+
+      - name: Update CHaP flake input
+        run: |
+          # Restore the original checkout but leave the untracked _repo untouched
+          git restore --staged --worktree .
+          nix flake update CHaP
+          if git diff --quiet -- flake.lock; then
+           echo "flake.lock unchanged; skipping commit"
+           exit 0
+          fi
+          git add flake.lock
+          git commit -m 'Update CHaP flake input'
+          git push origin HEAD:${{ github.ref_name }}
+
       - name: Setup Pages
         uses: actions/configure-pages@v6
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ cabalProject {
 To build some of the pacakges from CHaP, some C libraries will need to be installed. If you don't have those libraries installed cabal may pick an older library version that might not compile. An easy way to add those libraries is using the overlays provided by [iohk-nix](https://github.com/input-output-hk/iohk-nix). For example `plutus-core==1.21.0.0` depends on `libblst`, `haskell-nix-crypto` and `crypto` are the two overlays that would make it available during the build.
 
 When you want to update the state of CHaP, you can simply update the flake input
-(in the example above you would run `nix flake lock --update-input CHaP`).
+(in the example above you would run `nix flake update CHaP`).
 
 If you have CHaP configured correctly, then when you run `cabal build` from inside a `haskell.nix`
 shell, you should not see any of the packages in CHaP being built by cabal.
@@ -280,7 +280,7 @@ Ideally, include the conditions under which we can deprecate it, e.g. "can depre
 
 ### How to update Hackage index used by CHaP
 
-If one of your packages requires a newer version of a package published on Hackage, you will need to run: `nix flake lock --update-input hackage-nix`.
+If one of your packages requires a newer version of a package published on Hackage, you will need to run: `nix flake update hackage-nix`.
 [`hackage.nix`] is automatically updated from Hackage once per day.
 If things still don't work because the version of the package is not available you'll need either wait for the automatic update or make a PR to [`hackage.nix`] first and then rerun the above command.
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ cabalProject {
 To build some of the pacakges from CHaP, some C libraries will need to be installed. If you don't have those libraries installed cabal may pick an older library version that might not compile. An easy way to add those libraries is using the overlays provided by [iohk-nix](https://github.com/input-output-hk/iohk-nix). For example `plutus-core==1.21.0.0` depends on `libblst`, `haskell-nix-crypto` and `crypto` are the two overlays that would make it available during the build.
 
 When you want to update the state of CHaP, you can simply update the flake input
-(in the example above you would run `nix flake lock --update-input CHaP`).
+(in the example above you would run `nix flake update CHaP`).
 
 If you have CHaP configured correctly, then when you run `cabal build` from inside a `haskell.nix`
 shell, you should not see any of the packages in CHaP being built by cabal.
@@ -303,7 +303,7 @@ Ideally, include the conditions under which we can deprecate it, e.g. "can depre
 
 ### How to update Hackage index used by CHaP
 
-If one of your packages requires a newer version of a package published on Hackage, you will need to run: `nix flake lock --update-input hackage-nix`.
+If one of your packages requires a newer version of a package published on Hackage, you will need to run: `nix flake update hackage-nix`.
 [`hackage.nix`] is automatically updated from Hackage once per day.
 If things still don't work because the version of the package is not available you'll need either wait for the automatic update or make a PR to [`hackage.nix`] first and then rerun the above command.
 


### PR DESCRIPTION
The lock of the `CHaP` flake input should be updated whenever the `repo` branch is updated, which happens in the `deploy` GitHub workflow step.

This would avoid the need for manual interventions like #1396 to unbreak the Hydra build.