### PR TITLE
Add trace-dispatcher-2.13.0

### DIFF
--- a/_sources/trace-dispatcher/2.13.0/meta.toml
+++ b/_sources/trace-dispatcher/2.13.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-02T10:10:00Z
+github = { repo = "intersectmbo/hermod-tracing", rev = "3d7aeb85d9ef01df48a44c751e45609b4c6dea00" }
+subdir = 'trace-dispatcher'


### PR DESCRIPTION
From: https://github.com/IntersectMBO/hermod-tracing
at: `3d7aeb85d9ef01df48a44c751e45609b4c6dea00`
