### PR TITLE
Add a script and CI check that new packages already exist on Hackage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -184,6 +184,37 @@ jobs:
           --override-input CHaP path:_repo
           --show-trace
 
+  check-existence:
+    runs-on: ubuntu-latest
+    needs:
+      - build-repo
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download package metadata
+        uses: actions/download-artifact@v8
+        with:
+          name: package-metadata
+          path: .
+
+      - name: Check that new package names also exist on Hackage
+        run: |
+          pkg-names() { jq -r 'map(."pkg-name") | unique | .[]' "$@"; }
+
+          MISSING=$(mktemp); trap 'rm -f "$MISSING"' EXIT
+          LANG=C join -v2 <(pkg-names packages-old.json) <(pkg-names packages-new.json) |
+            xargs -r scripts/not-on-hackage.sh >"$MISSING"
+          [ -s "$MISSING" ] || exit 0
+
+          # Output a multi-line annotation
+          sed '1s/^/::error::/;$!s/$/%0A/' <<EOF | tr -d '\n'; echo
+          The following packages do not exist on Hackage:
+          $(sed 's/^/* /' "$MISSING")
+          Please ensure they are published or are candidates before adding them to CHaP
+          EOF
+
+          false # Fail
+
   deploy-check:
     runs-on: nixos
 

--- a/scripts/not-on-hackage.sh
+++ b/scripts/not-on-hackage.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Output any package names given on the command line that do not exist on Hackage,
+# either as published packages or as unpublished candidates
+
+# Unfortunately, the /package/$PACKAGE/candidates/ API endpoint doesn't exist if $PACKAGE
+# has never been published, so we have to download the list of all candidates and
+# check whether $PACKAGE appears in it
+
+CANDIDATES=$(mktemp)
+trap 'rm -f "$CANDIDATES"' EXIT
+
+curl -fsSH 'Accept: application/json' "https://hackage.haskell.org/packages/candidates/" |
+  jq -r 'map(.name) | unique | .[]' >"$CANDIDATES"
+
+for PACKAGE
+do
+  # Skip if a candidate
+  ! grep -qFxe "$PACKAGE" "$CANDIDATES" || continue
+
+  # Skip if published
+  ! curl -fsIH 'Accept: application/json' "https://hackage.haskell.org/package/$PACKAGE" -o /dev/null || continue
+
+  echo "$PACKAGE"
+done


### PR DESCRIPTION
If a package with the same name as one on CHaP is later added to Hackage, it prevents us from eventually migrating the CHaP package to Hackage. Our policy is to create an unpublished package candidate on Hackage for every package on CHaP that isn't already published to Hackage. This check ensures the invariant is maintained.