### PR TITLE
Added cardano-crypto-class-2.6.0.0

### DIFF
--- a/_sources/cardano-crypto-class/2.6.0.0/meta.toml
+++ b/_sources/cardano-crypto-class/2.6.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-27T12:46:11Z
+github = { repo = "IntersectMBO/cardano-base", rev = "12168e4b32b44d30dd401010ccd969accaf2add7" }
+subdir = 'cardano-crypto-class'


### PR DESCRIPTION
From https://github.com/IntersectMBO/cardano-base at 12168e4b32b44d30dd401010ccd969accaf2add7

