### PR TITLE
cardano-ledger release for node 11.1

### DIFF
--- a/_sources/byron-spec-chain/1.0.1.2/meta.toml
+++ b/_sources/byron-spec-chain/1.0.1.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-27T14:57:26Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "a88b60bdcf3248dfe5a2f9372c188c399233f479" }
+subdir = 'eras/byron/chain/executable-spec'

--- a/_sources/byron-spec-ledger/1.1.0.2/meta.toml
+++ b/_sources/byron-spec-ledger/1.1.0.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-27T14:57:26Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "a88b60bdcf3248dfe5a2f9372c188c399233f479" }
+subdir = 'eras/byron/ledger/executable-spec'

--- a/_sources/cardano-ledger-allegra/1.10.0.0/meta.toml
+++ b/_sources/cardano-ledger-allegra/1.10.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-27T14:57:26Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "a88b60bdcf3248dfe5a2f9372c188c399233f479" }
+subdir = 'eras/allegra/impl'

--- a/_sources/cardano-ledger-alonzo/1.16.0.0/meta.toml
+++ b/_sources/cardano-ledger-alonzo/1.16.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-27T14:57:26Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "a88b60bdcf3248dfe5a2f9372c188c399233f479" }
+subdir = 'eras/alonzo/impl'

--- a/_sources/cardano-ledger-api/1.14.0.0/meta.toml
+++ b/_sources/cardano-ledger-api/1.14.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-27T14:57:26Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "a88b60bdcf3248dfe5a2f9372c188c399233f479" }
+subdir = 'libs/cardano-ledger-api'

--- a/_sources/cardano-ledger-babbage/1.14.0.0/meta.toml
+++ b/_sources/cardano-ledger-babbage/1.14.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-27T14:57:26Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "a88b60bdcf3248dfe5a2f9372c188c399233f479" }
+subdir = 'eras/babbage/impl'

--- a/_sources/cardano-ledger-binary/1.9.0.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.9.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-27T14:57:26Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "a88b60bdcf3248dfe5a2f9372c188c399233f479" }
+subdir = 'libs/cardano-ledger-binary'

--- a/_sources/cardano-ledger-conway/1.23.0.0/meta.toml
+++ b/_sources/cardano-ledger-conway/1.23.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-27T14:57:26Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "a88b60bdcf3248dfe5a2f9372c188c399233f479" }
+subdir = 'eras/conway/impl'

--- a/_sources/cardano-ledger-core/1.21.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.21.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-27T14:57:26Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "a88b60bdcf3248dfe5a2f9372c188c399233f479" }
+subdir = 'libs/cardano-ledger-core'

--- a/_sources/cardano-ledger-dijkstra/0.3.0.0/meta.toml
+++ b/_sources/cardano-ledger-dijkstra/0.3.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-27T14:57:26Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "a88b60bdcf3248dfe5a2f9372c188c399233f479" }
+subdir = 'eras/dijkstra/impl'

--- a/_sources/cardano-ledger-mary/1.11.0.0/meta.toml
+++ b/_sources/cardano-ledger-mary/1.11.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-27T14:57:26Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "a88b60bdcf3248dfe5a2f9372c188c399233f479" }
+subdir = 'eras/mary/impl'

--- a/_sources/cardano-ledger-shelley-test/1.9.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley-test/1.9.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-27T14:57:26Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "a88b60bdcf3248dfe5a2f9372c188c399233f479" }
+subdir = 'eras/shelley/test-suite'

--- a/_sources/cardano-ledger-shelley/1.19.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley/1.19.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-27T14:57:26Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "a88b60bdcf3248dfe5a2f9372c188c399233f479" }
+subdir = 'eras/shelley/impl'

--- a/_sources/cardano-protocol-tpraos/1.6.0.0/meta.toml
+++ b/_sources/cardano-protocol-tpraos/1.6.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-27T14:57:26Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "a88b60bdcf3248dfe5a2f9372c188c399233f479" }
+subdir = 'libs/cardano-protocol-tpraos'

--- a/_sources/cardano-protocol/0.1.0.0/meta.toml
+++ b/_sources/cardano-protocol/0.1.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-27T14:57:26Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "a88b60bdcf3248dfe5a2f9372c188c399233f479" }
+subdir = 'libs/cardano-protocol'

--- a/_sources/small-steps/1.1.4.0/meta.toml
+++ b/_sources/small-steps/1.1.4.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-27T14:57:26Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "a88b60bdcf3248dfe5a2f9372c188c399233f479" }
+subdir = 'libs/small-steps'

--- a/_sources/vector-map/1.2.1.0/meta.toml
+++ b/_sources/vector-map/1.2.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-27T14:57:26Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "a88b60bdcf3248dfe5a2f9372c188c399233f479" }
+subdir = 'libs/vector-map'

--- a/hackage-candidates/cardano-protocol/cardano-protocol.cabal
+++ b/hackage-candidates/cardano-protocol/cardano-protocol.cabal
@@ -1,0 +1,23 @@
+cabal-version: 3.0
+name: cardano-protocol
+version: 0.0.0.0
+license: Apache-2.0
+maintainer: operations@iohk.io
+author: IOHK
+homepage: https://github.com/intersectmbo/cardano-haskell-packages/
+synopsis: Candidate package that prevents unauthorized release of cardano-protocol
+category: Control
+build-type: Simple
+
+source-repository head
+  type: git
+  location: https://github.com/intersectmbo/cardano-haskell-packages
+  subdir: hackage-candidates/cardano-protocol
+
+library
+  build-depends:
+    base >=1 && <100,
+  default-language: Haskell2010
+
+  buildable:
+    False


### PR DESCRIPTION
* byron-spec-chain-1.0.1.2
* byron-spec-ledger-1.1.0.2
* cardano-ledger-allegra-1.10.0.0
* cardano-ledger-alonzo-1.16.0.0
* cardano-ledger-api-1.14.0.0
* cardano-ledger-babbage-1.14.0.0
* cardano-ledger-binary-1.9.0.0
* cardano-ledger-conway-1.23.0.0
* cardano-ledger-core-1.21.0.0
* cardano-ledger-dijkstra-0.3.0.0
* cardano-ledger-mary-1.11.0.0
* cardano-ledger-shelley-1.19.0.0
* cardano-ledger-shelley-test-1.9.0.0
* cardano-protocol-0.1.0.0
* cardano-protocol-tpraos-1.6.0.0
* small-steps-1.1.4.0
* vector-map-1.2.1.0

From https://github.com/IntersectMBO/cardano-ledger at a88b60bdcf3248dfe5a2f9372c188c399233f479