### PR TITLE
cardano-ledger release for node 11.1

### DIFF
--- a/_sources/byron-spec-chain/1.0.1.2/meta.toml
+++ b/_sources/byron-spec-chain/1.0.1.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-29T17:00:01Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "f649f9751074d2ab3de033fc3912f29c9862c1f5" }
+subdir = 'eras/byron/chain/executable-spec'

--- a/_sources/byron-spec-ledger/1.1.0.2/meta.toml
+++ b/_sources/byron-spec-ledger/1.1.0.2/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-29T17:00:01Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "f649f9751074d2ab3de033fc3912f29c9862c1f5" }
+subdir = 'eras/byron/ledger/executable-spec'

--- a/_sources/cardano-crypto-wrapper/1.3.0/meta.toml
+++ b/_sources/cardano-crypto-wrapper/1.3.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'eras/byron/crypto'
 [[revisions]]
 number = 1
 timestamp = 2023-03-21T14:44:35Z
+
+[[revisions]]
+number = 2
+timestamp = 2026-07-29T17:12:40Z

--- a/_sources/cardano-crypto-wrapper/1.3.0/revisions/2.cabal
+++ b/_sources/cardano-crypto-wrapper/1.3.0/revisions/2.cabal
@@ -1,0 +1,120 @@
+cabal-version: 2.2
+
+name:                cardano-crypto-wrapper
+version:             1.3.0
+synopsis:            Cryptographic primitives used in the Cardano project
+description:         Cryptographic primitives used in the Cardano project
+license:             Apache-2.0
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2019 IOHK
+category:            Currency
+build-type:          Simple
+extra-source-files:  README.md
+
+common base
+  build-depends:      base >= 4.12 && < 4.15
+
+common project-config
+  default-language:   Haskell2010
+  default-extensions: NoImplicitPrelude
+
+  ghc-options:        -Weverything
+                      -Wno-all-missed-specialisations
+                      -Wno-missing-deriving-strategies
+                      -Wno-missing-import-lists
+                      -Wno-missing-safe-haskell-mode
+                      -Wno-prepositive-qualified-module
+                      -Wno-safe
+                      -Wno-unsafe
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+
+  hs-source-dirs:      src
+  exposed-modules:
+                       Cardano.Crypto
+
+                       Cardano.Crypto.Hashing
+                       Cardano.Crypto.Orphans
+                       Cardano.Crypto.ProtocolMagic
+                       Cardano.Crypto.Random
+                       Cardano.Crypto.Signing
+                       Cardano.Crypto.Signing.Redeem
+                       Cardano.Crypto.Signing.Safe
+
+  other-modules:
+                       Cardano.Crypto.Signing.Tag
+
+                       Cardano.Crypto.Signing.KeyGen
+                       Cardano.Crypto.Signing.VerificationKey
+                       Cardano.Crypto.Signing.SigningKey
+                       Cardano.Crypto.Signing.Signature
+
+                       Cardano.Crypto.Signing.Redeem.Compact
+                       Cardano.Crypto.Signing.Redeem.KeyGen
+                       Cardano.Crypto.Signing.Redeem.SigningKey
+                       Cardano.Crypto.Signing.Redeem.Signature
+                       Cardano.Crypto.Signing.Redeem.VerificationKey
+
+                       Cardano.Crypto.Signing.Safe.KeyGen
+                       Cardano.Crypto.Signing.Safe.PassPhrase
+                       Cardano.Crypto.Signing.Safe.SafeSigner
+
+  build-depends:       aeson
+                     , base16-bytestring >= 1
+                     , base64-bytestring
+                     , base64-bytestring-type
+                     , binary 
+                     , bytestring
+                     , canonical-json
+                     , cardano-binary <= 1.5.0.0
+                     , cardano-crypto < 1.4
+                     , cardano-prelude < 0.1.0.1
+                     , cryptonite
+                     , data-default
+                     , formatting
+                     , memory
+                     , mtl
+                     , nothunks
+                     , text
+
+test-suite test
+  import:             base, project-config
+
+  hs-source-dirs:      test
+  main-is:             test.hs
+  type:                exitcode-stdio-1.0
+
+  other-modules:
+                       Test.Cardano.Crypto.CBOR
+                       Test.Cardano.Crypto.Dummy
+                       Test.Cardano.Crypto.Example
+                       Test.Cardano.Crypto.Gen
+                       Test.Cardano.Crypto.Hashing
+                       Test.Cardano.Crypto.Json
+                       Test.Cardano.Crypto.Keys
+                       Test.Cardano.Crypto.Limits
+                       Test.Cardano.Crypto.Orphans
+                       Test.Cardano.Crypto.Random
+                       Test.Cardano.Crypto.Signing.Redeem
+                       Test.Cardano.Crypto.Signing.Redeem.Compact
+                       Test.Cardano.Crypto.Signing.Safe
+                       Test.Cardano.Crypto.Signing.Signing
+
+  build-depends:       bytestring
+                     , cardano-binary
+                     , cardano-binary-test
+                     , cardano-crypto < 1.4
+                     , cardano-crypto-wrapper
+                     , cardano-prelude
+                     , cardano-prelude-test
+                     , cryptonite
+                     , formatting
+                     , hedgehog >= 1.0.4
+                     , memory
+                     , text
+
+  ghc-options:         -threaded
+                       -rtsopts

--- a/_sources/cardano-crypto-wrapper/1.4.1/meta.toml
+++ b/_sources/cardano-crypto-wrapper/1.4.1/meta.toml
@@ -9,3 +9,7 @@ timestamp = 2023-03-21T14:33:01Z
 [[revisions]]
 number = 2
 timestamp = 2024-09-02T21:57:21Z
+
+[[revisions]]
+number = 3
+timestamp = 2026-07-29T17:12:40Z

--- a/_sources/cardano-crypto-wrapper/1.4.1/revisions/3.cabal
+++ b/_sources/cardano-crypto-wrapper/1.4.1/revisions/3.cabal
@@ -1,0 +1,141 @@
+cabal-version: 2.2
+
+name:                cardano-crypto-wrapper
+version:             1.4.1
+synopsis:            Cryptographic primitives used in the Cardano project
+description:         Cryptographic primitives used in the Cardano project
+license:             Apache-2.0
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2019 IOHK
+category:            Currency
+build-type:          Simple
+extra-source-files:  README.md
+data-files:          test/golden/AbstractHash
+                     test/golden/DecShare
+                     test/golden/EncShare
+                     test/golden/PassPhrase
+                     test/golden/RedeemSignature
+                     test/golden/RedeemSigningKey
+                     test/golden/RedeemVerificationKey
+                     test/golden/Secret
+                     test/golden/SecretProof
+                     test/golden/Signature
+                     test/golden/SigningKey
+                     test/golden/VerificationKey
+                     test/golden/VssPublicKey
+                     test/golden/json/ProtocolMagic0_Legacy_HasNetworkMagic
+                     test/golden/json/ProtocolMagic1_Legacy_HasNetworkMagic
+                     test/golden/json/ProtocolMagic2_Legacy_HasNetworkMagic
+                     test/golden/json/ProtocolMagic_Legacy_NMMustBeJust
+                     test/golden/json/ProtocolMagic_Legacy_NMMustBeNothing
+
+common base
+  build-depends:      base >= 4.12 && < 4.15
+
+common project-config
+  default-language:   Haskell2010
+  default-extensions: NoImplicitPrelude
+
+  ghc-options:        -Weverything
+                      -Wno-all-missed-specialisations
+                      -Wno-missing-deriving-strategies
+                      -Wno-missing-import-lists
+                      -Wno-missing-safe-haskell-mode
+                      -Wno-prepositive-qualified-module
+                      -Wno-safe
+                      -Wno-unsafe
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+
+  hs-source-dirs:      src
+  exposed-modules:
+                       Cardano.Crypto
+
+                       Cardano.Crypto.Hashing
+                       Cardano.Crypto.Orphans
+                       Cardano.Crypto.ProtocolMagic
+                       Cardano.Crypto.Random
+                       Cardano.Crypto.Signing
+                       Cardano.Crypto.Signing.Redeem
+                       Cardano.Crypto.Signing.Safe
+
+  other-modules:
+                       Cardano.Crypto.Signing.Tag
+
+                       Cardano.Crypto.Signing.KeyGen
+                       Cardano.Crypto.Signing.VerificationKey
+                       Cardano.Crypto.Signing.SigningKey
+                       Cardano.Crypto.Signing.Signature
+
+                       Cardano.Crypto.Signing.Redeem.Compact
+                       Cardano.Crypto.Signing.Redeem.KeyGen
+                       Cardano.Crypto.Signing.Redeem.SigningKey
+                       Cardano.Crypto.Signing.Redeem.Signature
+                       Cardano.Crypto.Signing.Redeem.VerificationKey
+
+                       Cardano.Crypto.Signing.Safe.KeyGen
+                       Cardano.Crypto.Signing.Safe.PassPhrase
+                       Cardano.Crypto.Signing.Safe.SafeSigner
+
+  build-depends:       aeson
+                     , base16-bytestring >= 1
+                     , base64-bytestring
+                     , base64-bytestring-type
+                     , binary
+                     , bytestring
+                     , canonical-json
+                     , cardano-binary < 1.7
+                     , cardano-crypto < 1.4
+                     , cardano-prelude >= 0.1.0.1
+                     , cryptonite
+                     , data-default
+                     , formatting
+                     , heapwords
+                     , memory
+                     , mtl
+                     , nothunks
+                     , text
+
+test-suite test
+  import:             base, project-config
+
+  hs-source-dirs:      test
+  main-is:             test.hs
+  type:                exitcode-stdio-1.0
+
+  other-modules:
+                       Test.Cardano.Crypto.CBOR
+                       Test.Cardano.Crypto.Dummy
+                       Test.Cardano.Crypto.Example
+                       Test.Cardano.Crypto.Gen
+                       Test.Cardano.Crypto.Hashing
+                       Test.Cardano.Crypto.Json
+                       Test.Cardano.Crypto.Keys
+                       Test.Cardano.Crypto.Limits
+                       Test.Cardano.Crypto.Orphans
+                       Test.Cardano.Crypto.Random
+                       Test.Cardano.Crypto.Signing.Redeem
+                       Test.Cardano.Crypto.Signing.Redeem.Compact
+                       Test.Cardano.Crypto.Signing.Safe
+                       Test.Cardano.Crypto.Signing.Signing
+                       Paths_cardano_crypto_wrapper
+                       GetDataFileName
+  build-depends:       bytestring
+                     , cardano-binary < 1.7
+                     , cardano-binary-test
+                     , cardano-crypto < 1.4
+                     , cardano-crypto-wrapper
+                     , cardano-prelude
+                     , cardano-prelude-test
+                     , cryptonite
+                     , formatting
+                     , filepath
+                     , hedgehog >= 1.0.4
+                     , memory
+                     , text
+
+  ghc-options:         -threaded
+                       -rtsopts

--- a/_sources/cardano-crypto-wrapper/1.4.2/meta.toml
+++ b/_sources/cardano-crypto-wrapper/1.4.2/meta.toml
@@ -9,3 +9,7 @@ timestamp = 2023-03-21T14:32:34Z
 [[revisions]]
 number = 2
 timestamp = 2023-05-15T03:47:48Z
+
+[[revisions]]
+number = 3
+timestamp = 2026-07-29T17:12:40Z

--- a/_sources/cardano-crypto-wrapper/1.4.2/revisions/3.cabal
+++ b/_sources/cardano-crypto-wrapper/1.4.2/revisions/3.cabal
@@ -1,0 +1,139 @@
+cabal-version: 2.2
+
+name:                cardano-crypto-wrapper
+version:             1.4.2
+synopsis:            Cryptographic primitives used in the Cardano project
+description:         Cryptographic primitives used in the Cardano project
+license:             Apache-2.0
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           2019 IOHK
+category:            Currency
+build-type:          Simple
+extra-source-files:  README.md
+data-files:          test/golden/AbstractHash
+                     test/golden/DecShare
+                     test/golden/EncShare
+                     test/golden/PassPhrase
+                     test/golden/RedeemSignature
+                     test/golden/RedeemSigningKey
+                     test/golden/RedeemVerificationKey
+                     test/golden/Secret
+                     test/golden/SecretProof
+                     test/golden/Signature
+                     test/golden/SigningKey
+                     test/golden/VerificationKey
+                     test/golden/VssPublicKey
+                     test/golden/json/ProtocolMagic0_Legacy_HasNetworkMagic
+                     test/golden/json/ProtocolMagic1_Legacy_HasNetworkMagic
+                     test/golden/json/ProtocolMagic2_Legacy_HasNetworkMagic
+                     test/golden/json/ProtocolMagic_Legacy_NMMustBeJust
+                     test/golden/json/ProtocolMagic_Legacy_NMMustBeNothing
+
+common base
+  build-depends:      base >= 4.12 && < 4.17
+
+common project-config
+  default-language:   Haskell2010
+  default-extensions: NoImplicitPrelude
+
+  ghc-options:        -Weverything
+                      -Wno-all-missed-specialisations
+                      -Wno-missing-deriving-strategies
+                      -Wno-missing-import-lists
+                      -Wno-missing-safe-haskell-mode
+                      -Wno-prepositive-qualified-module
+                      -Wno-safe
+                      -Wno-unsafe
+                      -Wunused-packages
+
+library
+  import:             base, project-config
+
+  hs-source-dirs:      src
+  exposed-modules:
+                       Cardano.Crypto
+
+                       Cardano.Crypto.Hashing
+                       Cardano.Crypto.Orphans
+                       Cardano.Crypto.ProtocolMagic
+                       Cardano.Crypto.Random
+                       Cardano.Crypto.Signing
+                       Cardano.Crypto.Signing.Redeem
+                       Cardano.Crypto.Signing.Safe
+
+  other-modules:
+                       Cardano.Crypto.Signing.Tag
+
+                       Cardano.Crypto.Signing.KeyGen
+                       Cardano.Crypto.Signing.VerificationKey
+                       Cardano.Crypto.Signing.SigningKey
+                       Cardano.Crypto.Signing.Signature
+
+                       Cardano.Crypto.Signing.Redeem.Compact
+                       Cardano.Crypto.Signing.Redeem.KeyGen
+                       Cardano.Crypto.Signing.Redeem.SigningKey
+                       Cardano.Crypto.Signing.Redeem.Signature
+                       Cardano.Crypto.Signing.Redeem.VerificationKey
+
+                       Cardano.Crypto.Signing.Safe.KeyGen
+                       Cardano.Crypto.Signing.Safe.PassPhrase
+                       Cardano.Crypto.Signing.Safe.SafeSigner
+
+  build-depends:       aeson
+                     , base16-bytestring >= 1
+                     , base64-bytestring
+                     , base64-bytestring-type
+                     , binary
+                     , bytestring
+                     , canonical-json
+                     , cardano-binary < 1.5.0.1
+                     , cardano-crypto < 1.4
+                     , cardano-prelude >= 0.1.0.1
+                     , cryptonite
+                     , data-default
+                     , formatting
+                     , heapwords
+                     , memory
+                     , nothunks
+                     , text
+
+test-suite test
+  import:             base, project-config
+
+  hs-source-dirs:      test
+  main-is:             test.hs
+  type:                exitcode-stdio-1.0
+
+  other-modules:
+                       Test.Cardano.Crypto.CBOR
+                       Test.Cardano.Crypto.Dummy
+                       Test.Cardano.Crypto.Example
+                       Test.Cardano.Crypto.Gen
+                       Test.Cardano.Crypto.Hashing
+                       Test.Cardano.Crypto.Json
+                       Test.Cardano.Crypto.Keys
+                       Test.Cardano.Crypto.Limits
+                       Test.Cardano.Crypto.Orphans
+                       Test.Cardano.Crypto.Random
+                       Test.Cardano.Crypto.Signing.Redeem
+                       Test.Cardano.Crypto.Signing.Redeem.Compact
+                       Test.Cardano.Crypto.Signing.Safe
+                       Test.Cardano.Crypto.Signing.Signing
+                       Paths_cardano_crypto_wrapper
+                       GetDataFileName
+  build-depends:       bytestring
+                     , cardano-binary
+                     , cardano-binary-test
+                     , cardano-crypto < 1.4
+                     , cardano-crypto-wrapper
+                     , cardano-prelude
+                     , cardano-prelude-test
+                     , cryptonite
+                     , formatting
+                     , filepath
+                     , hedgehog >= 1.0.4
+                     , memory
+
+  ghc-options:         -threaded
+                       -rtsopts

--- a/_sources/cardano-crypto-wrapper/1.5.0.0/meta.toml
+++ b/_sources/cardano-crypto-wrapper/1.5.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2023-02-23T15:33:46Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "2f5956038233e4df0a065d96db32398605603f9b" }
 subdir = 'eras/byron/crypto'
+
+[[revisions]]
+number = 1
+timestamp = 2026-07-29T17:12:40Z

--- a/_sources/cardano-crypto-wrapper/1.5.0.0/revisions/1.cabal
+++ b/_sources/cardano-crypto-wrapper/1.5.0.0/revisions/1.cabal
@@ -1,0 +1,139 @@
+cabal-version:      3.0
+name:               cardano-crypto-wrapper
+version:            1.5.0.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+synopsis:
+    Cryptographic primitives used in Byron era of the Cardano project
+
+description:
+    Cryptographic primitives used in Byron era of the Cardano project
+
+category:           Currency
+build-type:         Simple
+data-files:
+    test/golden/AbstractHash
+    test/golden/DecShare
+    test/golden/EncShare
+    test/golden/PassPhrase
+    test/golden/RedeemSignature
+    test/golden/RedeemSigningKey
+    test/golden/RedeemVerificationKey
+    test/golden/Secret
+    test/golden/SecretProof
+    test/golden/Signature
+    test/golden/SigningKey
+    test/golden/VerificationKey
+    test/golden/VssPublicKey
+    test/golden/json/ProtocolMagic0_Legacy_HasNetworkMagic
+    test/golden/json/ProtocolMagic1_Legacy_HasNetworkMagic
+    test/golden/json/ProtocolMagic2_Legacy_HasNetworkMagic
+    test/golden/json/ProtocolMagic_Legacy_NMMustBeJust
+    test/golden/json/ProtocolMagic_Legacy_NMMustBeNothing
+
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:
+        Cardano.Crypto
+        Cardano.Crypto.Hashing
+        Cardano.Crypto.Orphans
+        Cardano.Crypto.ProtocolMagic
+        Cardano.Crypto.Random
+        Cardano.Crypto.Raw
+        Cardano.Crypto.Signing
+        Cardano.Crypto.Signing.Redeem
+        Cardano.Crypto.Signing.Safe
+
+    hs-source-dirs:     src
+    other-modules:
+        Cardano.Crypto.Signing.Tag
+        Cardano.Crypto.Signing.KeyGen
+        Cardano.Crypto.Signing.VerificationKey
+        Cardano.Crypto.Signing.SigningKey
+        Cardano.Crypto.Signing.Signature
+        Cardano.Crypto.Signing.Redeem.Compact
+        Cardano.Crypto.Signing.Redeem.KeyGen
+        Cardano.Crypto.Signing.Redeem.SigningKey
+        Cardano.Crypto.Signing.Redeem.Signature
+        Cardano.Crypto.Signing.Redeem.VerificationKey
+        Cardano.Crypto.Signing.Safe.KeyGen
+        Cardano.Crypto.Signing.Safe.PassPhrase
+        Cardano.Crypto.Signing.Safe.SafeSigner
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+
+    build-depends:
+        base >=4.12 && <4.17,
+        aeson,
+        base16-bytestring >=1,
+        base64-bytestring,
+        base64-bytestring-type,
+        binary,
+        bytestring,
+        canonical-json,
+        cardano-ledger-binary,
+        cardano-crypto < 1.4,
+        cardano-prelude,
+        heapwords,
+        cryptonite,
+        data-default,
+        deepseq,
+        formatting,
+        memory,
+        nothunks,
+        text
+
+test-suite test
+    type:               exitcode-stdio-1.0
+    main-is:            test.hs
+    hs-source-dirs:     test
+    other-modules:
+        Test.Cardano.Crypto.CBOR
+        Test.Cardano.Crypto.Dummy
+        Test.Cardano.Crypto.Example
+        Test.Cardano.Crypto.Gen
+        Test.Cardano.Crypto.Hashing
+        Test.Cardano.Crypto.Json
+        Test.Cardano.Crypto.Keys
+        Test.Cardano.Crypto.Limits
+        Test.Cardano.Crypto.Orphans
+        Test.Cardano.Crypto.Random
+        Test.Cardano.Crypto.Signing.Redeem
+        Test.Cardano.Crypto.Signing.Redeem.Compact
+        Test.Cardano.Crypto.Signing.Safe
+        Test.Cardano.Crypto.Signing.Signing
+        Paths_cardano_crypto_wrapper
+        GetDataFileName
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages -threaded -rtsopts
+
+    build-depends:
+        base >=4.12 && <4.17,
+        bytestring,
+        cardano-ledger-binary,
+        cardano-ledger-binary:testlib,
+        cardano-crypto < 1.4,
+        cardano-crypto-wrapper,
+        cardano-prelude,
+        cardano-prelude-test,
+        cryptonite,
+        formatting,
+        filepath,
+        hedgehog >=1.0.4,
+        memory

--- a/_sources/cardano-crypto-wrapper/1.5.1.0/meta.toml
+++ b/_sources/cardano-crypto-wrapper/1.5.1.0/meta.toml
@@ -5,3 +5,7 @@ subdir = 'eras/byron/crypto'
 [[revisions]]
 number = 1
 timestamp = 2023-08-02T11:20:00Z
+
+[[revisions]]
+number = 2
+timestamp = 2026-07-29T17:12:40Z

--- a/_sources/cardano-crypto-wrapper/1.5.1.0/revisions/2.cabal
+++ b/_sources/cardano-crypto-wrapper/1.5.1.0/revisions/2.cabal
@@ -1,0 +1,138 @@
+cabal-version:      3.0
+name:               cardano-crypto-wrapper
+version:            1.5.1.0
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+synopsis:
+    Cryptographic primitives used in Byron era of the Cardano project
+
+description:
+    Cryptographic primitives used in Byron era of the Cardano project
+
+category:           Currency
+build-type:         Simple
+data-files:
+    test/golden/AbstractHash
+    test/golden/DecShare
+    test/golden/EncShare
+    test/golden/PassPhrase
+    test/golden/RedeemSignature
+    test/golden/RedeemSigningKey
+    test/golden/RedeemVerificationKey
+    test/golden/Secret
+    test/golden/SecretProof
+    test/golden/Signature
+    test/golden/SigningKey
+    test/golden/VerificationKey
+    test/golden/VssPublicKey
+    test/golden/json/ProtocolMagic0_Legacy_HasNetworkMagic
+    test/golden/json/ProtocolMagic1_Legacy_HasNetworkMagic
+    test/golden/json/ProtocolMagic2_Legacy_HasNetworkMagic
+    test/golden/json/ProtocolMagic_Legacy_NMMustBeJust
+    test/golden/json/ProtocolMagic_Legacy_NMMustBeNothing
+
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:
+        Cardano.Crypto
+        Cardano.Crypto.Hashing
+        Cardano.Crypto.Orphans
+        Cardano.Crypto.ProtocolMagic
+        Cardano.Crypto.Random
+        Cardano.Crypto.Raw
+        Cardano.Crypto.Signing
+        Cardano.Crypto.Signing.Redeem
+        Cardano.Crypto.Signing.Safe
+
+    hs-source-dirs:     src
+    other-modules:
+        Cardano.Crypto.Signing.Tag
+        Cardano.Crypto.Signing.KeyGen
+        Cardano.Crypto.Signing.VerificationKey
+        Cardano.Crypto.Signing.SigningKey
+        Cardano.Crypto.Signing.Signature
+        Cardano.Crypto.Signing.Redeem.Compact
+        Cardano.Crypto.Signing.Redeem.KeyGen
+        Cardano.Crypto.Signing.Redeem.SigningKey
+        Cardano.Crypto.Signing.Redeem.Signature
+        Cardano.Crypto.Signing.Redeem.VerificationKey
+        Cardano.Crypto.Signing.Safe.KeyGen
+        Cardano.Crypto.Signing.Safe.PassPhrase
+        Cardano.Crypto.Signing.Safe.SafeSigner
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <4.19,
+        aeson,
+        base16-bytestring >=1,
+        base64-bytestring,
+        base64-bytestring-type,
+        binary,
+        bytestring,
+        canonical-json,
+        cardano-ledger-binary >=1.0,
+        cardano-crypto < 1.4,
+        cardano-prelude >=0.1.0.1,
+        heapwords,
+        cryptonite,
+        data-default,
+        deepseq,
+        formatting,
+        memory,
+        nothunks,
+        text
+
+test-suite test
+    type:               exitcode-stdio-1.0
+    main-is:            test.hs
+    hs-source-dirs:     test
+    other-modules:
+        Test.Cardano.Crypto.CBOR
+        Test.Cardano.Crypto.Dummy
+        Test.Cardano.Crypto.Example
+        Test.Cardano.Crypto.Gen
+        Test.Cardano.Crypto.Hashing
+        Test.Cardano.Crypto.Json
+        Test.Cardano.Crypto.Keys
+        Test.Cardano.Crypto.Limits
+        Test.Cardano.Crypto.Orphans
+        Test.Cardano.Crypto.Random
+        Test.Cardano.Crypto.Signing.Redeem
+        Test.Cardano.Crypto.Signing.Redeem.Compact
+        Test.Cardano.Crypto.Signing.Safe
+        Test.Cardano.Crypto.Signing.Signing
+        Paths_cardano_crypto_wrapper
+        GetDataFileName
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages -threaded -rtsopts
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-crypto < 1.4,
+        cardano-crypto-wrapper,
+        cardano-prelude,
+        cardano-prelude-test,
+        cryptonite,
+        formatting,
+        filepath,
+        hedgehog >=1.0.4,
+        memory

--- a/_sources/cardano-crypto-wrapper/1.5.1.1/meta.toml
+++ b/_sources/cardano-crypto-wrapper/1.5.1.1/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-01-26T10:34:07Z
 github = { repo = "IntersectMBO/cardano-ledger", rev = "6e2d37cc0f47bd02e89b4ce9f78b59c35c958e96" }
 subdir = 'eras/byron/crypto'
+
+[[revisions]]
+number = 1
+timestamp = 2026-07-29T17:12:40Z

--- a/_sources/cardano-crypto-wrapper/1.5.1.1/revisions/1.cabal
+++ b/_sources/cardano-crypto-wrapper/1.5.1.1/revisions/1.cabal
@@ -1,0 +1,138 @@
+cabal-version:      3.0
+name:               cardano-crypto-wrapper
+version:            1.5.1.1
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+synopsis:
+    Cryptographic primitives used in Byron era of the Cardano project
+
+description:
+    Cryptographic primitives used in Byron era of the Cardano project
+
+category:           Currency
+build-type:         Simple
+data-files:
+    test/golden/AbstractHash
+    test/golden/DecShare
+    test/golden/EncShare
+    test/golden/PassPhrase
+    test/golden/RedeemSignature
+    test/golden/RedeemSigningKey
+    test/golden/RedeemVerificationKey
+    test/golden/Secret
+    test/golden/SecretProof
+    test/golden/Signature
+    test/golden/SigningKey
+    test/golden/VerificationKey
+    test/golden/VssPublicKey
+    test/golden/json/ProtocolMagic0_Legacy_HasNetworkMagic
+    test/golden/json/ProtocolMagic1_Legacy_HasNetworkMagic
+    test/golden/json/ProtocolMagic2_Legacy_HasNetworkMagic
+    test/golden/json/ProtocolMagic_Legacy_NMMustBeJust
+    test/golden/json/ProtocolMagic_Legacy_NMMustBeNothing
+
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:
+        Cardano.Crypto
+        Cardano.Crypto.Hashing
+        Cardano.Crypto.Orphans
+        Cardano.Crypto.ProtocolMagic
+        Cardano.Crypto.Random
+        Cardano.Crypto.Raw
+        Cardano.Crypto.Signing
+        Cardano.Crypto.Signing.Redeem
+        Cardano.Crypto.Signing.Safe
+
+    hs-source-dirs:     src
+    other-modules:
+        Cardano.Crypto.Signing.Tag
+        Cardano.Crypto.Signing.KeyGen
+        Cardano.Crypto.Signing.VerificationKey
+        Cardano.Crypto.Signing.SigningKey
+        Cardano.Crypto.Signing.Signature
+        Cardano.Crypto.Signing.Redeem.Compact
+        Cardano.Crypto.Signing.Redeem.KeyGen
+        Cardano.Crypto.Signing.Redeem.SigningKey
+        Cardano.Crypto.Signing.Redeem.Signature
+        Cardano.Crypto.Signing.Redeem.VerificationKey
+        Cardano.Crypto.Signing.Safe.KeyGen
+        Cardano.Crypto.Signing.Safe.PassPhrase
+        Cardano.Crypto.Signing.Safe.SafeSigner
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson,
+        base16-bytestring >=1,
+        base64-bytestring,
+        base64-bytestring-type,
+        binary,
+        bytestring,
+        canonical-json,
+        cardano-ledger-binary >=1.0,
+        cardano-crypto < 1.4,
+        cardano-prelude >=0.1.0.1,
+        heapwords,
+        cryptonite,
+        data-default,
+        deepseq,
+        formatting,
+        memory,
+        nothunks,
+        text
+
+test-suite test
+    type:               exitcode-stdio-1.0
+    main-is:            test.hs
+    hs-source-dirs:     test
+    other-modules:
+        Test.Cardano.Crypto.CBOR
+        Test.Cardano.Crypto.Dummy
+        Test.Cardano.Crypto.Example
+        Test.Cardano.Crypto.Gen
+        Test.Cardano.Crypto.Hashing
+        Test.Cardano.Crypto.Json
+        Test.Cardano.Crypto.Keys
+        Test.Cardano.Crypto.Limits
+        Test.Cardano.Crypto.Orphans
+        Test.Cardano.Crypto.Random
+        Test.Cardano.Crypto.Signing.Redeem
+        Test.Cardano.Crypto.Signing.Redeem.Compact
+        Test.Cardano.Crypto.Signing.Safe
+        Test.Cardano.Crypto.Signing.Signing
+        Paths_cardano_crypto_wrapper
+        GetDataFileName
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages -threaded -rtsopts
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-crypto < 1.4,
+        cardano-crypto-wrapper,
+        cardano-prelude,
+        cardano-prelude-test,
+        cryptonite,
+        formatting,
+        filepath,
+        hedgehog >=1.0.4,
+        memory

--- a/_sources/cardano-crypto-wrapper/1.5.1.2/meta.toml
+++ b/_sources/cardano-crypto-wrapper/1.5.1.2/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-03-29T00:54:16Z
 github = { repo = "input-output-hk/cardano-ledger", rev = "ed6d38b0bf0a54504c781b3c274745846476ca3c" }
 subdir = 'eras/byron/crypto'
+
+[[revisions]]
+number = 1
+timestamp = 2026-07-29T17:12:40Z

--- a/_sources/cardano-crypto-wrapper/1.5.1.2/revisions/1.cabal
+++ b/_sources/cardano-crypto-wrapper/1.5.1.2/revisions/1.cabal
@@ -1,0 +1,138 @@
+cabal-version:      3.0
+name:               cardano-crypto-wrapper
+version:            1.5.1.2
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+synopsis:
+    Cryptographic primitives used in Byron era of the Cardano project
+
+description:
+    Cryptographic primitives used in Byron era of the Cardano project
+
+category:           Currency
+build-type:         Simple
+data-files:
+    test/golden/AbstractHash
+    test/golden/DecShare
+    test/golden/EncShare
+    test/golden/PassPhrase
+    test/golden/RedeemSignature
+    test/golden/RedeemSigningKey
+    test/golden/RedeemVerificationKey
+    test/golden/Secret
+    test/golden/SecretProof
+    test/golden/Signature
+    test/golden/SigningKey
+    test/golden/VerificationKey
+    test/golden/VssPublicKey
+    test/golden/json/ProtocolMagic0_Legacy_HasNetworkMagic
+    test/golden/json/ProtocolMagic1_Legacy_HasNetworkMagic
+    test/golden/json/ProtocolMagic2_Legacy_HasNetworkMagic
+    test/golden/json/ProtocolMagic_Legacy_NMMustBeJust
+    test/golden/json/ProtocolMagic_Legacy_NMMustBeNothing
+
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:
+        Cardano.Crypto
+        Cardano.Crypto.Hashing
+        Cardano.Crypto.Orphans
+        Cardano.Crypto.ProtocolMagic
+        Cardano.Crypto.Random
+        Cardano.Crypto.Raw
+        Cardano.Crypto.Signing
+        Cardano.Crypto.Signing.Redeem
+        Cardano.Crypto.Signing.Safe
+
+    hs-source-dirs:     src
+    other-modules:
+        Cardano.Crypto.Signing.Tag
+        Cardano.Crypto.Signing.KeyGen
+        Cardano.Crypto.Signing.VerificationKey
+        Cardano.Crypto.Signing.SigningKey
+        Cardano.Crypto.Signing.Signature
+        Cardano.Crypto.Signing.Redeem.Compact
+        Cardano.Crypto.Signing.Redeem.KeyGen
+        Cardano.Crypto.Signing.Redeem.SigningKey
+        Cardano.Crypto.Signing.Redeem.Signature
+        Cardano.Crypto.Signing.Redeem.VerificationKey
+        Cardano.Crypto.Signing.Safe.KeyGen
+        Cardano.Crypto.Signing.Safe.PassPhrase
+        Cardano.Crypto.Signing.Safe.SafeSigner
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson,
+        base16-bytestring >=1,
+        base64-bytestring,
+        base64-bytestring-type,
+        binary,
+        bytestring,
+        canonical-json,
+        cardano-ledger-binary >=1.3.1,
+        cardano-crypto < 1.4,
+        cardano-prelude >=0.1.0.1,
+        heapwords,
+        cryptonite,
+        data-default,
+        deepseq,
+        formatting,
+        memory,
+        nothunks,
+        text
+
+test-suite test
+    type:               exitcode-stdio-1.0
+    main-is:            test.hs
+    hs-source-dirs:     test
+    other-modules:
+        Test.Cardano.Crypto.CBOR
+        Test.Cardano.Crypto.Dummy
+        Test.Cardano.Crypto.Example
+        Test.Cardano.Crypto.Gen
+        Test.Cardano.Crypto.Hashing
+        Test.Cardano.Crypto.Json
+        Test.Cardano.Crypto.Keys
+        Test.Cardano.Crypto.Limits
+        Test.Cardano.Crypto.Orphans
+        Test.Cardano.Crypto.Random
+        Test.Cardano.Crypto.Signing.Redeem
+        Test.Cardano.Crypto.Signing.Redeem.Compact
+        Test.Cardano.Crypto.Signing.Safe
+        Test.Cardano.Crypto.Signing.Signing
+        Paths_cardano_crypto_wrapper
+        GetDataFileName
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages -threaded -rtsopts
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-crypto < 1.4,
+        cardano-crypto-wrapper,
+        cardano-prelude,
+        cardano-prelude-test,
+        cryptonite,
+        formatting,
+        filepath,
+        hedgehog >=1.0.4,
+        memory

--- a/_sources/cardano-crypto-wrapper/1.5.1.3/meta.toml
+++ b/_sources/cardano-crypto-wrapper/1.5.1.3/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2024-08-25T15:05:06Z
 github = { repo = "IntersectMBO/cardano-ledger", rev = "d82ac6915424df5e151d5fa12ff6346ce814e7c3" }
 subdir = 'eras/byron/crypto'
+
+[[revisions]]
+number = 1
+timestamp = 2026-07-29T17:12:40Z

--- a/_sources/cardano-crypto-wrapper/1.5.1.3/revisions/1.cabal
+++ b/_sources/cardano-crypto-wrapper/1.5.1.3/revisions/1.cabal
@@ -1,0 +1,138 @@
+cabal-version:      3.0
+name:               cardano-crypto-wrapper
+version:            1.5.1.3
+license:            Apache-2.0
+maintainer:         operations@iohk.io
+author:             IOHK
+synopsis:
+    Cryptographic primitives used in Byron era of the Cardano project
+
+description:
+    Cryptographic primitives used in Byron era of the Cardano project
+
+category:           Currency
+build-type:         Simple
+data-files:
+    test/golden/AbstractHash
+    test/golden/DecShare
+    test/golden/EncShare
+    test/golden/PassPhrase
+    test/golden/RedeemSignature
+    test/golden/RedeemSigningKey
+    test/golden/RedeemVerificationKey
+    test/golden/Secret
+    test/golden/SecretProof
+    test/golden/Signature
+    test/golden/SigningKey
+    test/golden/VerificationKey
+    test/golden/VssPublicKey
+    test/golden/json/ProtocolMagic0_Legacy_HasNetworkMagic
+    test/golden/json/ProtocolMagic1_Legacy_HasNetworkMagic
+    test/golden/json/ProtocolMagic2_Legacy_HasNetworkMagic
+    test/golden/json/ProtocolMagic_Legacy_NMMustBeJust
+    test/golden/json/ProtocolMagic_Legacy_NMMustBeNothing
+
+extra-source-files:
+    README.md
+    CHANGELOG.md
+
+library
+    exposed-modules:
+        Cardano.Crypto
+        Cardano.Crypto.Hashing
+        Cardano.Crypto.Orphans
+        Cardano.Crypto.ProtocolMagic
+        Cardano.Crypto.Random
+        Cardano.Crypto.Raw
+        Cardano.Crypto.Signing
+        Cardano.Crypto.Signing.Redeem
+        Cardano.Crypto.Signing.Safe
+
+    hs-source-dirs:     src
+    other-modules:
+        Cardano.Crypto.Signing.Tag
+        Cardano.Crypto.Signing.KeyGen
+        Cardano.Crypto.Signing.VerificationKey
+        Cardano.Crypto.Signing.SigningKey
+        Cardano.Crypto.Signing.Signature
+        Cardano.Crypto.Signing.Redeem.Compact
+        Cardano.Crypto.Signing.Redeem.KeyGen
+        Cardano.Crypto.Signing.Redeem.SigningKey
+        Cardano.Crypto.Signing.Redeem.Signature
+        Cardano.Crypto.Signing.Redeem.VerificationKey
+        Cardano.Crypto.Signing.Safe.KeyGen
+        Cardano.Crypto.Signing.Safe.PassPhrase
+        Cardano.Crypto.Signing.Safe.SafeSigner
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages
+
+    build-depends:
+        base >=4.14 && <5,
+        aeson,
+        base16-bytestring >=1,
+        base64-bytestring,
+        base64-bytestring-type,
+        binary,
+        bytestring,
+        canonical-json,
+        cardano-ledger-binary >=1.3.1,
+        cardano-crypto < 1.4,
+        cardano-prelude >=0.2.0.0,
+        heapwords,
+        cryptonite,
+        data-default,
+        deepseq,
+        formatting,
+        memory,
+        nothunks,
+        text
+
+test-suite test
+    type:               exitcode-stdio-1.0
+    main-is:            test.hs
+    hs-source-dirs:     test
+    other-modules:
+        Test.Cardano.Crypto.CBOR
+        Test.Cardano.Crypto.Dummy
+        Test.Cardano.Crypto.Example
+        Test.Cardano.Crypto.Gen
+        Test.Cardano.Crypto.Hashing
+        Test.Cardano.Crypto.Json
+        Test.Cardano.Crypto.Keys
+        Test.Cardano.Crypto.Limits
+        Test.Cardano.Crypto.Orphans
+        Test.Cardano.Crypto.Random
+        Test.Cardano.Crypto.Signing.Redeem
+        Test.Cardano.Crypto.Signing.Redeem.Compact
+        Test.Cardano.Crypto.Signing.Safe
+        Test.Cardano.Crypto.Signing.Signing
+        Paths_cardano_crypto_wrapper
+        GetDataFileName
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    ghc-options:
+        -Wall -Wno-all-missed-specialisations
+        -Wno-missing-deriving-strategies -Wno-missing-import-lists
+        -Wno-missing-safe-haskell-mode -Wno-prepositive-qualified-module
+        -Wno-safe -Wno-unsafe -Wunused-packages -threaded -rtsopts
+
+    build-depends:
+        base,
+        bytestring,
+        cardano-ledger-binary:{cardano-ledger-binary, testlib},
+        cardano-crypto < 1.4,
+        cardano-crypto-wrapper,
+        cardano-prelude,
+        cardano-prelude-test,
+        cryptonite,
+        formatting,
+        filepath,
+        hedgehog >=1.0.4,
+        memory

--- a/_sources/cardano-crypto-wrapper/1.6.0.0/meta.toml
+++ b/_sources/cardano-crypto-wrapper/1.6.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2025-03-21T09:06:59Z
 github = { repo = "intersectmbo/cardano-ledger", rev = "a9e78ae63cf8870f0ce6ce76bd7029b82ddb47e1" }
 subdir = 'eras/byron/crypto'
+
+[[revisions]]
+number = 1
+timestamp = 2026-07-29T17:12:40Z

--- a/_sources/cardano-crypto-wrapper/1.6.0.0/revisions/1.cabal
+++ b/_sources/cardano-crypto-wrapper/1.6.0.0/revisions/1.cabal
@@ -1,0 +1,150 @@
+cabal-version: 3.0
+name: cardano-crypto-wrapper
+version: 1.6.0.0
+license: Apache-2.0
+maintainer: operations@iohk.io
+author: IOHK
+synopsis:
+  Cryptographic primitives used in Byron era of the Cardano project
+
+description:
+  Cryptographic primitives used in Byron era of the Cardano project
+
+category: Currency
+build-type: Simple
+data-files:
+  test/golden/AbstractHash
+  test/golden/DecShare
+  test/golden/EncShare
+  test/golden/PassPhrase
+  test/golden/RedeemSignature
+  test/golden/RedeemSigningKey
+  test/golden/RedeemVerificationKey
+  test/golden/Secret
+  test/golden/SecretProof
+  test/golden/Signature
+  test/golden/SigningKey
+  test/golden/VerificationKey
+  test/golden/VssPublicKey
+  test/golden/json/ProtocolMagic0_Legacy_HasNetworkMagic
+  test/golden/json/ProtocolMagic1_Legacy_HasNetworkMagic
+  test/golden/json/ProtocolMagic2_Legacy_HasNetworkMagic
+  test/golden/json/ProtocolMagic_Legacy_NMMustBeJust
+  test/golden/json/ProtocolMagic_Legacy_NMMustBeNothing
+
+extra-source-files:
+  CHANGELOG.md
+  README.md
+
+library
+  exposed-modules:
+    Cardano.Crypto
+    Cardano.Crypto.Hashing
+    Cardano.Crypto.Orphans
+    Cardano.Crypto.ProtocolMagic
+    Cardano.Crypto.Random
+    Cardano.Crypto.Raw
+    Cardano.Crypto.Signing
+    Cardano.Crypto.Signing.Redeem
+    Cardano.Crypto.Signing.Safe
+
+  hs-source-dirs: src
+  other-modules:
+    Cardano.Crypto.Signing.KeyGen
+    Cardano.Crypto.Signing.Redeem.Compact
+    Cardano.Crypto.Signing.Redeem.KeyGen
+    Cardano.Crypto.Signing.Redeem.Signature
+    Cardano.Crypto.Signing.Redeem.SigningKey
+    Cardano.Crypto.Signing.Redeem.VerificationKey
+    Cardano.Crypto.Signing.Safe.KeyGen
+    Cardano.Crypto.Signing.Safe.PassPhrase
+    Cardano.Crypto.Signing.Safe.SafeSigner
+    Cardano.Crypto.Signing.Signature
+    Cardano.Crypto.Signing.SigningKey
+    Cardano.Crypto.Signing.Tag
+    Cardano.Crypto.Signing.VerificationKey
+
+  default-language: Haskell2010
+  default-extensions: NoImplicitPrelude
+  ghc-options:
+    -Wall
+    -Wno-all-missed-specialisations
+    -Wno-missing-deriving-strategies
+    -Wno-missing-import-lists
+    -Wno-missing-safe-haskell-mode
+    -Wno-prepositive-qualified-module
+    -Wno-safe
+    -Wno-unsafe
+    -Wunused-packages
+
+  build-depends:
+    aeson,
+    base >=4.14 && <5,
+    base16-bytestring >=1,
+    base64-bytestring,
+    base64-bytestring-type,
+    binary,
+    bytestring,
+    canonical-json,
+    cardano-crypto < 1.4,
+    cardano-ledger-binary >=1.3.1,
+    cardano-prelude >=0.2.0.0,
+    crypton,
+    data-default,
+    deepseq,
+    formatting,
+    heapwords,
+    memory,
+    nothunks,
+    text,
+
+test-suite test
+  type: exitcode-stdio-1.0
+  main-is: test.hs
+  hs-source-dirs: test
+  other-modules:
+    GetDataFileName
+    Paths_cardano_crypto_wrapper
+    Test.Cardano.Crypto.CBOR
+    Test.Cardano.Crypto.Dummy
+    Test.Cardano.Crypto.Example
+    Test.Cardano.Crypto.Gen
+    Test.Cardano.Crypto.Hashing
+    Test.Cardano.Crypto.Json
+    Test.Cardano.Crypto.Keys
+    Test.Cardano.Crypto.Limits
+    Test.Cardano.Crypto.Orphans
+    Test.Cardano.Crypto.Random
+    Test.Cardano.Crypto.Signing.Redeem
+    Test.Cardano.Crypto.Signing.Redeem.Compact
+    Test.Cardano.Crypto.Signing.Safe
+    Test.Cardano.Crypto.Signing.Signing
+
+  default-language: Haskell2010
+  default-extensions: NoImplicitPrelude
+  ghc-options:
+    -Wall
+    -Wno-all-missed-specialisations
+    -Wno-missing-deriving-strategies
+    -Wno-missing-import-lists
+    -Wno-missing-safe-haskell-mode
+    -Wno-prepositive-qualified-module
+    -Wno-safe
+    -Wno-unsafe
+    -Wunused-packages
+    -threaded
+    -rtsopts
+
+  build-depends:
+    base,
+    bytestring,
+    cardano-crypto < 1.4,
+    cardano-crypto-wrapper,
+    cardano-ledger-binary:{cardano-ledger-binary, testlib},
+    cardano-prelude,
+    cardano-prelude-test,
+    crypton,
+    filepath,
+    formatting,
+    hedgehog >=1.0.4,
+    memory,

--- a/_sources/cardano-crypto-wrapper/1.6.1.0/meta.toml
+++ b/_sources/cardano-crypto-wrapper/1.6.1.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2025-09-10T02:05:10Z
 github = { repo = "IntersectMBO/cardano-ledger", rev = "faa7a9dc347697b11d4da5b7818b1731e11aeeef" }
 subdir = 'eras/byron/crypto'
+
+[[revisions]]
+number = 1
+timestamp = 2026-07-29T17:12:40Z

--- a/_sources/cardano-crypto-wrapper/1.6.1.0/revisions/1.cabal
+++ b/_sources/cardano-crypto-wrapper/1.6.1.0/revisions/1.cabal
@@ -1,0 +1,181 @@
+cabal-version: 3.0
+name: cardano-crypto-wrapper
+version: 1.6.1.0
+license: Apache-2.0
+maintainer: operations@iohk.io
+author: IOHK
+synopsis:
+  Cryptographic primitives used in Byron era of the Cardano project
+
+description:
+  Cryptographic primitives used in Byron era of the Cardano project
+
+category: Currency
+build-type: Simple
+data-files:
+  golden/AbstractHash
+  golden/DecShare
+  golden/EncShare
+  golden/PassPhrase
+  golden/RedeemSignature
+  golden/RedeemSigningKey
+  golden/RedeemVerificationKey
+  golden/Secret
+  golden/SecretProof
+  golden/Signature
+  golden/SigningKey
+  golden/VerificationKey
+  golden/VssPublicKey
+  golden/json/ProtocolMagic0_Legacy_HasNetworkMagic
+  golden/json/ProtocolMagic1_Legacy_HasNetworkMagic
+  golden/json/ProtocolMagic2_Legacy_HasNetworkMagic
+  golden/json/ProtocolMagic_Legacy_NMMustBeJust
+  golden/json/ProtocolMagic_Legacy_NMMustBeNothing
+
+extra-source-files:
+  CHANGELOG.md
+  README.md
+
+library
+  exposed-modules:
+    Cardano.Crypto
+    Cardano.Crypto.Hashing
+    Cardano.Crypto.Orphans
+    Cardano.Crypto.ProtocolMagic
+    Cardano.Crypto.Random
+    Cardano.Crypto.Raw
+    Cardano.Crypto.Signing
+    Cardano.Crypto.Signing.Redeem
+    Cardano.Crypto.Signing.Safe
+
+  hs-source-dirs: src
+  other-modules:
+    Cardano.Crypto.Signing.KeyGen
+    Cardano.Crypto.Signing.Redeem.Compact
+    Cardano.Crypto.Signing.Redeem.KeyGen
+    Cardano.Crypto.Signing.Redeem.Signature
+    Cardano.Crypto.Signing.Redeem.SigningKey
+    Cardano.Crypto.Signing.Redeem.VerificationKey
+    Cardano.Crypto.Signing.Safe.KeyGen
+    Cardano.Crypto.Signing.Safe.PassPhrase
+    Cardano.Crypto.Signing.Safe.SafeSigner
+    Cardano.Crypto.Signing.Signature
+    Cardano.Crypto.Signing.SigningKey
+    Cardano.Crypto.Signing.Tag
+    Cardano.Crypto.Signing.VerificationKey
+
+  default-language: Haskell2010
+  default-extensions: NoImplicitPrelude
+  ghc-options:
+    -Wall
+    -Wno-all-missed-specialisations
+    -Wno-missing-deriving-strategies
+    -Wno-missing-import-lists
+    -Wno-missing-safe-haskell-mode
+    -Wno-prepositive-qualified-module
+    -Wno-safe
+    -Wno-unsafe
+    -Wunused-packages
+
+  build-depends:
+    aeson,
+    base >=4.18 && <5,
+    base16-bytestring >=1,
+    base64-bytestring,
+    base64-bytestring-type,
+    binary,
+    bytestring,
+    canonical-json,
+    cardano-crypto < 1.4,
+    cardano-ledger-binary >=1.3.1,
+    cardano-prelude >=0.2.0.0,
+    crypton,
+    data-default,
+    deepseq,
+    formatting,
+    heapwords,
+    memory,
+    nothunks,
+    text,
+
+library testlib
+  exposed-modules:
+    Test.Cardano.Crypto.CBOR
+    Test.Cardano.Crypto.Dummy
+    Test.Cardano.Crypto.Example
+    Test.Cardano.Crypto.Gen
+    Test.Cardano.Crypto.Json
+    Test.Cardano.Crypto.Orphans
+
+  visibility: public
+  hs-source-dirs: testlib
+  other-modules:
+    Paths_cardano_crypto_wrapper
+
+  default-language: Haskell2010
+  default-extensions: NoImplicitPrelude
+  ghc-options:
+    -Weverything
+    -Wno-all-missed-specialisations
+    -Wno-missing-deriving-strategies
+    -Wno-missing-import-lists
+    -Wno-missing-safe-haskell-mode
+    -Wno-prepositive-qualified-module
+    -Wno-safe
+    -Wno-unsafe
+    -Wunused-packages
+
+  build-depends:
+    base,
+    bytestring,
+    cardano-crypto < 1.4,
+    cardano-crypto-wrapper,
+    cardano-ledger-binary:{cardano-ledger-binary, testlib},
+    cardano-prelude,
+    cardano-prelude-test,
+    crypton,
+    hedgehog >=1.0.4,
+    memory,
+
+test-suite test
+  type: exitcode-stdio-1.0
+  main-is: test.hs
+  hs-source-dirs: test
+  other-modules:
+    Paths_cardano_crypto_wrapper
+    Test.Cardano.Crypto.Hashing
+    Test.Cardano.Crypto.Keys
+    Test.Cardano.Crypto.Limits
+    Test.Cardano.Crypto.Random
+    Test.Cardano.Crypto.Signing.Redeem
+    Test.Cardano.Crypto.Signing.Redeem.Compact
+    Test.Cardano.Crypto.Signing.Safe
+    Test.Cardano.Crypto.Signing.Signing
+
+  default-language: Haskell2010
+  default-extensions: NoImplicitPrelude
+  ghc-options:
+    -Wall
+    -Wno-all-missed-specialisations
+    -Wno-missing-deriving-strategies
+    -Wno-missing-import-lists
+    -Wno-missing-safe-haskell-mode
+    -Wno-prepositive-qualified-module
+    -Wno-safe
+    -Wno-unsafe
+    -Wunused-packages
+    -threaded
+    -rtsopts
+
+  build-depends:
+    base,
+    bytestring,
+    cardano-crypto < 1.4,
+    cardano-crypto-wrapper,
+    cardano-ledger-binary,
+    cardano-prelude,
+    cardano-prelude-test,
+    crypton,
+    formatting,
+    hedgehog >=1.0.4,
+    testlib,

--- a/_sources/cardano-crypto-wrapper/1.7.0.0/meta.toml
+++ b/_sources/cardano-crypto-wrapper/1.7.0.0/meta.toml
@@ -1,3 +1,7 @@
 timestamp = 2026-03-10T14:34:17Z
 github = { repo = "IntersectMBO/cardano-ledger", rev = "30a3e666b84f9d056f464b3a00c56ab0c5bccacd" }
 subdir = 'eras/byron/crypto'
+
+[[revisions]]
+number = 1
+timestamp = 2026-07-29T17:12:40Z

--- a/_sources/cardano-crypto-wrapper/1.7.0.0/revisions/1.cabal
+++ b/_sources/cardano-crypto-wrapper/1.7.0.0/revisions/1.cabal
@@ -1,0 +1,182 @@
+cabal-version: 3.0
+name: cardano-crypto-wrapper
+version: 1.7.0.0
+license: Apache-2.0
+maintainer: operations@iohk.io
+author: IOHK
+synopsis:
+  Cryptographic primitives used in Byron era of the Cardano project
+
+description:
+  Cryptographic primitives used in Byron era of the Cardano project
+
+category: Currency
+build-type: Simple
+data-files:
+  golden/AbstractHash
+  golden/DecShare
+  golden/EncShare
+  golden/PassPhrase
+  golden/RedeemSignature
+  golden/RedeemSigningKey
+  golden/RedeemVerificationKey
+  golden/Secret
+  golden/SecretProof
+  golden/Signature
+  golden/SigningKey
+  golden/VerificationKey
+  golden/VssPublicKey
+  golden/json/ProtocolMagic0_Legacy_HasNetworkMagic
+  golden/json/ProtocolMagic1_Legacy_HasNetworkMagic
+  golden/json/ProtocolMagic2_Legacy_HasNetworkMagic
+  golden/json/ProtocolMagic_Legacy_NMMustBeJust
+  golden/json/ProtocolMagic_Legacy_NMMustBeNothing
+
+extra-source-files:
+  CHANGELOG.md
+  README.md
+
+library
+  exposed-modules:
+    Cardano.Crypto
+    Cardano.Crypto.Hashing
+    Cardano.Crypto.Orphans
+    Cardano.Crypto.ProtocolMagic
+    Cardano.Crypto.Random
+    Cardano.Crypto.Raw
+    Cardano.Crypto.Signing
+    Cardano.Crypto.Signing.Redeem
+    Cardano.Crypto.Signing.Safe
+
+  hs-source-dirs: src
+  other-modules:
+    Cardano.Crypto.Signing.KeyGen
+    Cardano.Crypto.Signing.Redeem.Compact
+    Cardano.Crypto.Signing.Redeem.KeyGen
+    Cardano.Crypto.Signing.Redeem.Signature
+    Cardano.Crypto.Signing.Redeem.SigningKey
+    Cardano.Crypto.Signing.Redeem.VerificationKey
+    Cardano.Crypto.Signing.Safe.KeyGen
+    Cardano.Crypto.Signing.Safe.PassPhrase
+    Cardano.Crypto.Signing.Safe.SafeSigner
+    Cardano.Crypto.Signing.Signature
+    Cardano.Crypto.Signing.SigningKey
+    Cardano.Crypto.Signing.Tag
+    Cardano.Crypto.Signing.VerificationKey
+
+  default-language: Haskell2010
+  default-extensions: NoImplicitPrelude
+  ghc-options:
+    -Wall
+    -Wno-all-missed-specialisations
+    -Wno-missing-deriving-strategies
+    -Wno-missing-import-lists
+    -Wno-missing-safe-haskell-mode
+    -Wno-prepositive-qualified-module
+    -Wno-safe
+    -Wno-unsafe
+    -Wunused-packages
+
+  build-depends:
+    aeson,
+    base >=4.18 && <5,
+    base16-bytestring >=1,
+    base64-bytestring,
+    base64-bytestring-type,
+    binary,
+    bytestring,
+    canonical-json,
+    cardano-crypto < 1.4,
+    cardano-ledger-binary >=1.3.1,
+    cardano-prelude >=0.2.0.0,
+    crypton,
+    data-default,
+    deepseq,
+    formatting,
+    heapwords,
+    memory,
+    nothunks,
+    text,
+
+library testlib
+  exposed-modules:
+    Test.Cardano.Crypto.CBOR
+    Test.Cardano.Crypto.Dummy
+    Test.Cardano.Crypto.Example
+    Test.Cardano.Crypto.Gen
+    Test.Cardano.Crypto.Json
+    Test.Cardano.Crypto.Orphans
+
+  visibility: public
+  hs-source-dirs: testlib
+  other-modules:
+    Paths_cardano_crypto_wrapper
+
+  default-language: Haskell2010
+  default-extensions: NoImplicitPrelude
+  ghc-options:
+    -Weverything
+    -Wno-all-missed-specialisations
+    -Wno-missing-deriving-strategies
+    -Wno-missing-import-lists
+    -Wno-missing-safe-haskell-mode
+    -Wno-prepositive-qualified-module
+    -Wno-safe
+    -Wno-unsafe
+    -Wunused-packages
+
+  build-depends:
+    base,
+    bytestring,
+    cardano-binary:testlib,
+    cardano-crypto < 1.4,
+    cardano-crypto-wrapper,
+    cardano-ledger-binary:{cardano-ledger-binary, testlib},
+    cardano-prelude,
+    cardano-prelude-test,
+    crypton,
+    hedgehog >=1.0.4,
+    memory,
+
+test-suite test
+  type: exitcode-stdio-1.0
+  main-is: test.hs
+  hs-source-dirs: test
+  other-modules:
+    Paths_cardano_crypto_wrapper
+    Test.Cardano.Crypto.Hashing
+    Test.Cardano.Crypto.Keys
+    Test.Cardano.Crypto.Limits
+    Test.Cardano.Crypto.Random
+    Test.Cardano.Crypto.Signing.Redeem
+    Test.Cardano.Crypto.Signing.Redeem.Compact
+    Test.Cardano.Crypto.Signing.Safe
+    Test.Cardano.Crypto.Signing.Signing
+
+  default-language: Haskell2010
+  default-extensions: NoImplicitPrelude
+  ghc-options:
+    -Wall
+    -Wno-all-missed-specialisations
+    -Wno-missing-deriving-strategies
+    -Wno-missing-import-lists
+    -Wno-missing-safe-haskell-mode
+    -Wno-prepositive-qualified-module
+    -Wno-safe
+    -Wno-unsafe
+    -Wunused-packages
+    -threaded
+    -rtsopts
+
+  build-depends:
+    base,
+    bytestring,
+    cardano-crypto < 1.4,
+    cardano-crypto-wrapper,
+    cardano-ledger-binary,
+    cardano-prelude,
+    cardano-prelude-test,
+    crypton,
+    formatting,
+    hedgehog >=1.0.4,
+    testlib,

--- a/_sources/cardano-ledger-allegra/1.10.0.0/meta.toml
+++ b/_sources/cardano-ledger-allegra/1.10.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-29T17:00:01Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "f649f9751074d2ab3de033fc3912f29c9862c1f5" }
+subdir = 'eras/allegra/impl'

--- a/_sources/cardano-ledger-alonzo/1.16.0.0/meta.toml
+++ b/_sources/cardano-ledger-alonzo/1.16.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-29T17:00:01Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "f649f9751074d2ab3de033fc3912f29c9862c1f5" }
+subdir = 'eras/alonzo/impl'

--- a/_sources/cardano-ledger-api/1.14.0.0/meta.toml
+++ b/_sources/cardano-ledger-api/1.14.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-29T17:00:01Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "f649f9751074d2ab3de033fc3912f29c9862c1f5" }
+subdir = 'libs/cardano-ledger-api'

--- a/_sources/cardano-ledger-babbage/1.14.0.0/meta.toml
+++ b/_sources/cardano-ledger-babbage/1.14.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-29T17:00:01Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "f649f9751074d2ab3de033fc3912f29c9862c1f5" }
+subdir = 'eras/babbage/impl'

--- a/_sources/cardano-ledger-binary/1.9.0.0/meta.toml
+++ b/_sources/cardano-ledger-binary/1.9.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-29T17:00:01Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "f649f9751074d2ab3de033fc3912f29c9862c1f5" }
+subdir = 'libs/cardano-ledger-binary'

--- a/_sources/cardano-ledger-conway/1.23.0.0/meta.toml
+++ b/_sources/cardano-ledger-conway/1.23.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-29T17:00:01Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "f649f9751074d2ab3de033fc3912f29c9862c1f5" }
+subdir = 'eras/conway/impl'

--- a/_sources/cardano-ledger-core/1.21.0.0/meta.toml
+++ b/_sources/cardano-ledger-core/1.21.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-29T17:00:01Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "f649f9751074d2ab3de033fc3912f29c9862c1f5" }
+subdir = 'libs/cardano-ledger-core'

--- a/_sources/cardano-ledger-dijkstra/0.3.0.0/meta.toml
+++ b/_sources/cardano-ledger-dijkstra/0.3.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-29T17:00:01Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "f649f9751074d2ab3de033fc3912f29c9862c1f5" }
+subdir = 'eras/dijkstra/impl'

--- a/_sources/cardano-ledger-mary/1.11.0.0/meta.toml
+++ b/_sources/cardano-ledger-mary/1.11.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-29T17:00:01Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "f649f9751074d2ab3de033fc3912f29c9862c1f5" }
+subdir = 'eras/mary/impl'

--- a/_sources/cardano-ledger-shelley-test/1.9.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley-test/1.9.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-29T17:00:01Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "f649f9751074d2ab3de033fc3912f29c9862c1f5" }
+subdir = 'eras/shelley/test-suite'

--- a/_sources/cardano-ledger-shelley/1.19.0.0/meta.toml
+++ b/_sources/cardano-ledger-shelley/1.19.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-29T17:00:01Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "f649f9751074d2ab3de033fc3912f29c9862c1f5" }
+subdir = 'eras/shelley/impl'

--- a/_sources/cardano-protocol-tpraos/1.6.0.0/meta.toml
+++ b/_sources/cardano-protocol-tpraos/1.6.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-29T17:00:01Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "f649f9751074d2ab3de033fc3912f29c9862c1f5" }
+subdir = 'libs/cardano-protocol-tpraos'

--- a/_sources/cardano-protocol/0.1.0.0/meta.toml
+++ b/_sources/cardano-protocol/0.1.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-29T17:00:01Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "f649f9751074d2ab3de033fc3912f29c9862c1f5" }
+subdir = 'libs/cardano-protocol'

--- a/_sources/small-steps/1.1.4.0/meta.toml
+++ b/_sources/small-steps/1.1.4.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-29T17:00:01Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "f649f9751074d2ab3de033fc3912f29c9862c1f5" }
+subdir = 'libs/small-steps'

--- a/_sources/vector-map/1.2.1.0/meta.toml
+++ b/_sources/vector-map/1.2.1.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-07-29T17:00:01Z
+github = { repo = "IntersectMBO/cardano-ledger", rev = "f649f9751074d2ab3de033fc3912f29c9862c1f5" }
+subdir = 'libs/vector-map'

--- a/hackage-candidates/cardano-protocol/cardano-protocol.cabal
+++ b/hackage-candidates/cardano-protocol/cardano-protocol.cabal
@@ -1,0 +1,23 @@
+cabal-version: 3.0
+name: cardano-protocol
+version: 0.0.0.0
+license: Apache-2.0
+maintainer: operations@iohk.io
+author: IOHK
+homepage: https://github.com/intersectmbo/cardano-haskell-packages/
+synopsis: Candidate package that prevents unauthorized release of cardano-protocol
+category: Control
+build-type: Simple
+
+source-repository head
+  type: git
+  location: https://github.com/intersectmbo/cardano-haskell-packages
+  subdir: hackage-candidates/cardano-protocol
+
+library
+  build-depends:
+    base >=1 && <100,
+  default-language: Haskell2010
+
+  buildable:
+    False


### PR DESCRIPTION
* byron-spec-chain-1.0.1.2
* byron-spec-ledger-1.1.0.2
* cardano-ledger-allegra-1.10.0.0
* cardano-ledger-alonzo-1.16.0.0
* cardano-ledger-api-1.14.0.0
* cardano-ledger-babbage-1.14.0.0
* cardano-ledger-binary-1.9.0.0
* cardano-ledger-conway-1.23.0.0
* cardano-ledger-core-1.21.0.0
* cardano-ledger-dijkstra-0.3.0.0
* cardano-ledger-mary-1.11.0.0
* cardano-ledger-shelley-1.19.0.0
* cardano-ledger-shelley-test-1.9.0.0
* cardano-protocol-0.1.0.0
* cardano-protocol-tpraos-1.6.0.0
* small-steps-1.1.4.0
* vector-map-1.2.1.0

From https://github.com/IntersectMBO/cardano-ledger at f649f9751074d2ab3de033fc3912f29c9862c1f5

