### PR TITLE
Fixed add-from-github.sh script

### DIFF
--- a/scripts/add-from-github.sh
+++ b/scripts/add-from-github.sh
@@ -184,7 +184,7 @@ rm -rf "$WORKDIR"
 
 git log -1 --name-status
 
-NEW_CANDIDATES=$(git log -1 --name-only --format= | grep ^hackage-candidates/ | xargs sed -n '/^name: */Is///p')
+NEW_CANDIDATES=$(git log --name-only --format= main.. | { grep ^hackage-candidates/ || true; } | xargs sed -n '/^name: */Is///p')
 
 if [[ -n $NEW_CANDIDATES ]]
 then


### PR DESCRIPTION
This PR fixes two problems:
* the script failed with exit code `-1`, when there is no hackage candidate.
* `NEW_CANDIDATES` is empty, if the script `./hackage-candidates/create-placeholders.sh` is run without `--no-commit` flag, which results in a missing warning message.
