### PR TITLE
Added cardano-api-11.4.0.0

### DIFF
--- a/_sources/cardano-api/11.4.0.0/meta.toml
+++ b/_sources/cardano-api/11.4.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-08-06T18:32:54Z
+github = { repo = "IntersectMBO/cardano-api", rev = "1c81d28a1b37941081bfb2283ae1119345a47bec" }
+subdir = 'cardano-api'


### PR DESCRIPTION
From https://github.com/IntersectMBO/cardano-api at 1c81d28a1b37941081bfb2283ae1119345a47bec

Corresponding PR in `cardano-api` repo: https://github.com/IntersectMBO/cardano-api/pull/1281
