### PR TITLE
Improve shellcheck CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   NIX_CONFIG: accept-flake-config = true
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,11 +15,14 @@ env:
 
 jobs:
   shellcheck:
-    runs-on: nixos
+    runs-on: ubuntu-latest
     steps:
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-23.05
       - uses: actions/checkout@v7
       - name: Run shellcheck on scripts/*.sh
-        run: nix-shell -I nixpkgs=https://github.com/nixos/nixpkgs/archive/release-23.05.tar.gz -p shellcheck --run 'shellcheck scripts/*.sh'
+        run: nix-shell -p shellcheck --run 'shellcheck scripts/*.sh'
 
   check:
     runs-on: nixos

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: cachix/install-nix-action@v31
         with:
-          nix_path: nixpkgs=channel:nixos-23.05
+          nix_path: nixpkgs=channel:nixos-26.05
       - uses: actions/checkout@v7
       - name: Run shellcheck on scripts/*.sh
         run: nix-shell -p shellcheck --run 'shellcheck scripts/*.sh'


### PR DESCRIPTION
* Stop using a custom runner for `shellcheck`
* Update `shellcheck` to the one from `nixos-26.05` (`0.9.0` to `0.11.0`)
