### PR TITLE
Added cardano-cli-11.2.0.0

### DIFF
--- a/_sources/cardano-cli/11.2.0.0/meta.toml
+++ b/_sources/cardano-cli/11.2.0.0/meta.toml
@@ -1,0 +1,3 @@
+timestamp = 2026-08-13T17:13:21Z
+github = { repo = "IntersectMBO/cardano-cli", rev = "4aa8f5b33ff4a7b54025680b12df59a838b8dcf5" }
+subdir = 'cardano-cli'


### PR DESCRIPTION
From https://github.com/IntersectMBO/cardano-cli at 4aa8f5b33ff4a7b54025680b12df59a838b8dcf5 (tag `cardano-cli-11.2.0.0`)

Release PR: https://github.com/IntersectMBO/cardano-cli/pull/1416