### PR TITLE
Added ouroboros-consensus-4.2.0.1

### DIFF
--- a/_sources/ouroboros-consensus/4.2.0.1/meta.toml
+++ b/_sources/ouroboros-consensus/4.2.0.1/meta.toml
@@ -1,0 +1,2 @@
+timestamp = 2026-08-28T11:10:12Z
+github = { repo = "IntersectMBO/ouroboros-consensus", rev = "27396eb4fc8c2afbc0ead45eb951593a7ac4bcc6" }


### PR DESCRIPTION
From https://github.com/IntersectMBO/ouroboros-consensus at 27396eb4fc8c2afbc0ead45eb951593a7ac4bcc6

<!--
If you are adding a new package, consider adding yourself or an appropriate
GitHub team to CODEOWNERS for the new package. See the README for more details.
-->
