### PR TITLE
Add ouroboros-consensus 4.2.1.0

### DIFF
--- a/_sources/ouroboros-consensus/4.2.1.0/meta.toml
+++ b/_sources/ouroboros-consensus/4.2.1.0/meta.toml
@@ -1,0 +1,2 @@
+timestamp = 2026-08-31T18:21:54Z
+github = { repo = "IntersectMBO/ouroboros-consensus", rev = "8fca655fa95f13ba33a98d19ebb3565405aacf82" }

--- a/_sources/ouroboros-consensus/4.2.1.0/meta.toml
+++ b/_sources/ouroboros-consensus/4.2.1.0/meta.toml
@@ -1,2 +1,2 @@
 timestamp = 2026-08-31T18:21:54Z
-github = { repo = "IntersectMBO/ouroboros-consensus", rev = "8fca655fa95f13ba33a98d19ebb3565405aacf82" }
+github = { repo = "IntersectMBO/ouroboros-consensus", rev = "500772db1b59d944a86aeaf86fa2368b2bf76273" }

--- a/_sources/ouroboros-consensus/4.2.1.0/meta.toml
+++ b/_sources/ouroboros-consensus/4.2.1.0/meta.toml
@@ -1,2 +1,2 @@
 timestamp = 2026-08-31T18:21:54Z
-github = { repo = "IntersectMBO/ouroboros-consensus", rev = "500772db1b59d944a86aeaf86fa2368b2bf76273" }
+github = { repo = "IntersectMBO/ouroboros-consensus", rev = "82ecba329d7d054340bf707d44fe6e9ac27cec40" }


### PR DESCRIPTION
`ouroboros-consensus 4.2.1.0`, pointing at commit `82ecba329` on `ouroboros-consensus-4.x-backports` (the merge commit of IntersectMBO/ouroboros-consensus#2257).

Contents: backport of IntersectMBO/ouroboros-consensus#2251 and its follow-up fix IntersectMBO/ouroboros-consensus#2258, which restores the 15-field `ShelleyGenesis` CBOR encoding for the `GetGenesisConfig` node-to-client query.